### PR TITLE
Simplify feature extractor logic

### DIFF
--- a/internal/features/plugins/base.go
+++ b/internal/features/plugins/base.go
@@ -4,6 +4,8 @@
 package plugins
 
 import (
+	"log/slog"
+
 	"github.com/cobaltcore-dev/cortex/internal/conf"
 	"github.com/cobaltcore-dev/cortex/internal/db"
 )
@@ -25,4 +27,19 @@ func (e *BaseExtractor[Opts, Feature]) Init(db db.DB, opts conf.RawOpts) error {
 	e.DB = db
 	var f Feature
 	return db.CreateTable(db.AddTable(f))
+}
+
+// Replace all features of the given model in the database and
+// return them as a slice of generic features for counting.
+func (e *BaseExtractor[Opts, F]) Extracted(fs []F) ([]Feature, error) {
+	if err := db.ReplaceAll(e.DB, fs...); err != nil {
+		return nil, err
+	}
+	output := make([]Feature, len(fs))
+	for i, f := range fs {
+		output[i] = f
+	}
+	var model F
+	slog.Info("features: extracted", model.TableName(), len(output))
+	return output, nil
 }

--- a/internal/features/plugins/vmware/vrops_hostsystem_resolver.go
+++ b/internal/features/plugins/vmware/vrops_hostsystem_resolver.go
@@ -4,8 +4,6 @@
 package vmware
 
 import (
-	"log/slog"
-
 	"github.com/cobaltcore-dev/cortex/internal/features/plugins"
 )
 
@@ -38,38 +36,17 @@ func (e *VROpsHostsystemResolver) GetName() string {
 
 // Resolve vROps hostsystems to Nova compute hosts.
 func (e *VROpsHostsystemResolver) Extract() ([]plugins.Feature, error) {
-	// Delete the old data in the same transaction.
-	tx, err := e.DB.Begin()
-	if err != nil {
-		return nil, err
-	}
-	if _, err := tx.Exec("DELETE FROM feature_vrops_resolved_hostsystem"); err != nil {
-		return nil, tx.Rollback()
-	}
-	if _, err := tx.Exec(`
-		INSERT INTO feature_vrops_resolved_hostsystem (vrops_hostsystem, nova_compute_host)
+	var features []ResolvedVROpsHostsystem
+	if _, err := e.DB.Select(&features, `
 		SELECT
-			m.hostsystem AS hostsystem,
-			h.service_host AS service_host
+			m.hostsystem AS vrops_hostsystem,
+			h.service_host AS nova_compute_host
 		FROM vrops_vm_metrics m
 		JOIN openstack_servers s ON m.instance_uuid = s.id
 		JOIN openstack_hypervisors h ON s.os_ext_srv_attr_hypervisor_hostname = h.hostname
 		GROUP BY m.hostsystem, h.service_host;
     `); err != nil {
-		return nil, tx.Rollback()
-	}
-	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	// Load the extracted features from the database and return them.
-	var features []ResolvedVROpsHostsystem
-	if _, err := e.DB.Select(&features, "SELECT * FROM feature_vrops_resolved_hostsystem"); err != nil {
-		return nil, err
-	}
-	output := make([]plugins.Feature, len(features))
-	for i, f := range features {
-		output[i] = f
-	}
-	slog.Info("features: extracted", "feature_vrops_resolved_hostsystem", len(output))
-	return output, nil
+	return e.Extracted(features)
 }


### PR DESCRIPTION
Provides a common `Extracted` function to feature extractors which replaces all existing features in the db in one transaction + logs the extraction and returns generic features.