### PR TITLE
Fix migration on clean service startup

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -72,7 +72,7 @@ func (d *DB) CreateTable(table ...*gorp.TableMap) error {
 		return tx.Rollback()
 	}
 	for _, t := range table {
-		slog.Info("creating table", "table", t.TableName)
+		slog.Info("creating table if exists", "table", t.TableName)
 		sql := t.SqlForCreate(true) // true means to add IF NOT EXISTS
 		if _, err := tx.Exec(sql); err != nil {
 			return tx.Rollback()

--- a/internal/db/migrations/001_add_openstack_servers_flavorid.sql
+++ b/internal/db/migrations/001_add_openstack_servers_flavorid.sql
@@ -4,12 +4,3 @@
 -- Add the new column with a default value.
 ALTER TABLE IF EXISTS openstack_servers
 ADD COLUMN IF NOT EXISTS flavor_id VARCHAR(255) DEFAULT 'flavor';
-
--- Update existing rows to have a non-null value
-UPDATE openstack_servers
-SET flavor_id = 'flavor'
-WHERE flavor_id IS NULL;
-
--- Alter the column to set it as NOT NULL
-ALTER TABLE openstack_servers
-ALTER COLUMN flavor_id SET NOT NULL;


### PR DESCRIPTION
Before, starting with a clean DB would result in a crash.
Now the service properly tracks which migrations were
executed and if the database is fresh.