### PR TITLE
Event-based feature extraction (MQTT)

### DIFF
--- a/docs/adrs/001-event-based-feature-extraction.md
+++ b/docs/adrs/001-event-based-feature-extraction.md
@@ -1,0 +1,129 @@
+Architecture Decision Record 001
+
+---
+
+# Event-Based Feature Extraction
+
+## Background
+
+```mermaid
+graph TB
+subgraph Syncer[Syncer Service]
+direction TB
+SP1[OpenStack Objects]
+SP2[Prometheus Metrics]
+SP3[Other Data Sources]
+end
+DBS[(Synced Data in Database)]
+SP1 --> DBS
+SP2 --> DBS
+SP3 --> DBS
+subgraph FeatureExtractor[Feature Extractor Service]
+direction TB
+FE1[Contended Hostsystems]
+FE2[Best Placement for Flavors]
+FE3[Other Knowledge]
+end
+DBS --> FE1
+DBS --> FE2
+DBS --> FE3
+DBF[(Extracted Features in Database)]
+FE1 --> DBF
+FE2 --> DBF
+FE3 --> DBF
+Scheduler[Scheduler]
+DBF --> Scheduler
+```
+
+Currently we have an architecture as given in the diagram above:
+
+- The syncer service fetches data from remote sources (prometheus, openstack, in the future maybe kubernetes, ...) and inserts it into the database. Note that the synced data may be raw and unprocessed, such as prometheus timeline data.
+- The feature extractor reads this unprocessed data from the database and extracts features from it. Features provide a condensed, optimized knowledge for scheduling. For example, they can combine information from multiple data sources so that this information is not recalculated on each scheduler execution.
+- The scheduler uses this knowledge to make weighing/filtering decisions. Ideally, only the features relevant for this request (e.g. best placement for this flavor) are queried from the database, providing rapid scheduling decisions.
+
+Now, the more recent the provided features are, the better the scheduling decision can be made. For example, if a large vm flavor is placed on one of the hosts, this influences directly how future vms should be placed. In this case, the "best placement for flavors" feature (see above) needs to be recalculated as soon as possible.
+
+However, currently the feature extraction and syncing are run completely without knowledge of each other, in a 1-minute cycle. Thus, information that was synced may only propagate to the features after this cycle was restarted again. This may lead to inconsistencies i.e. to bad scheduling, and in the worst case, failed scheduling.
+
+## Proposed Solution
+
+Instead of executing the feature extraction periodically, the proposed solution would be to extract the features as soon as the underlying data has changed. This means that the syncer needs to communicate data changes to the feature extractor. Furthermore, the feature extractor needs to know which part of the dataset has changed, to not re-calculate all features. Furthermore, the update should propagate if [a feature depends on another feature](https://github.com/cobaltcore-dev/cortex/blob/d1698cfa7a07a1eafacfc56dd2545ee1e28da40b/helm/cortex/values.yaml#L269).
+
+Cons:
+- Added complexity to the syncer and the feature extractor
+- Syncer + feature extractor are no longer completely isolated except shared db usage
+- Need to consider mqtt triggers when implementing new extractors/syncers
+
+Pros:
+- Features that rarily change are not unnecessarily recalculated
+- Quicker response to changes in the underlying data, potentially less inconsistencies
+- Concept can be extended in the future, e.g. notifying the syncer when to fetch new data
+
+The following implementation options are available.
+
+### Implementation Option 1: Use Message Broker
+
+Add an message broker into the architecture and connect the syncer + feature extractor with it. Updates to data can be published on topics. Topics are defined in a consistent way, e.g. `triggers/sync/openstack/nova/types/hypervisors` when hypervisors change. All new syncer plugins and feature extractor plugins follow this schema.
+
+E.g., VerneMQT (MQTT) is a message broker that could be used.
+
+Cons:
+- Need to add mqtt broker and maintain that (operational overhead)
+
+Pros:
+- Existing service separation can stay for now, no refactoring of the structure needed
+- Decoupling & loose coupling, communicate via well-defined mqtt topics
+- Lightweight implementation
+
+### Implementation Option 2: Merge Syncer and Feature Extractor
+
+Merge the syncer and feature extractor service to one service (e.g. "", "")
+
+Cons:
+- Loss of service separation, we make it much harder to separate the services later on
+- Needs refactoring of the go modules, since they are separated by scheduler/syncer/features currently
+
+Pros:
+- The feature extraction can be directly called, avoiding mapping layer to topics between.
+- Simpler to maintain since no mqtt broker is required
+
+### Implementation Option 3: Replace the Syncer and Feature Extractors with a Generic Distribution Task Pipeline
+
+Let's replace the syncer and feature extractor and replace with distributed task scheduling. Syncers would be periodic tasks (that can then also run with different frequencies). Feature extractors are executed once their precondition tasks are completed. This could be implemented, for example, with something like https://github.com/celery/celery.
+
+High level design:
+* We have a controller managing a task queue
+* We have n worker that execute the tasks
+
+Cons:
+- Highest complexity, at least initially
+- Need some kind of task dependency declaration similar to option 1
+- Added task queue and controller logic or use additional framework that needs to be maintained
+- Need to consider execution waiting times (delays) and priorities
+- If implemented with golang also needs a shared kv-storage or message queue, similar to option 1
+- Highest change effort, requires the most rebuilding
+
+Pros:
+- Task handling automated by queue, tasks are spawned on the fly as needed
+- Generic task configuration, e.g. execute task A every 30 sec while task B every 10 min
+- Separation between periodic task and triggered tasks
+
+### Implementation Option 4: Keep As-Is
+
+We accept that we are somewhat outdated as the syncer runs "only" once every 1 minute. This option needs to be considered, as it is unclear if the optimization is needed at the moment.
+
+Cons:
+- No potential performance improvement, risk of inconsistencies with features that need to be timely
+- No support for future logic like "scheduler spawned VM" --> "monitor VM in OpenStack" --> "spawned" --> "resync"
+
+Pros:
+- No change effort
+- No additional services introduced into the architecture that need to be maintained
+- Current service isolation persists
+
+## Decision and Consequences
+
+Among the available options, **Option 1: Message Broker** was chosen as the immediate solution. This approach allows us to move forward with minimal disruption to the current architecture while addressing the need for event-driven design. MQTT will be used as the message broker, making it a mandatory component of the system.
+
+However, **Option 3: Generic Distribution Task Pipeline** is recognized as a more robust and scalable long-term solution. While it offers significant flexibility and automation, it is currently considered overkill due to its high complexity and the substantial effort required for implementation.
+As the system evolves and the demand for more advanced task handling grows, we will re-evaluate the design (e.g., **Option 3**) when it becomes necessary.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,10 @@
 
 This guide provides an overview of the Cortex architecture, its components, and how they interact.
 
+## Architecture Decision Records (ADRs)
+
+See the [Architecture Decision Records](./adrs) for more detailed information on specific architectural decisions.
+
 ## Integration
 
 Cortex is integrated with Nova, OpenStack's compute service. When new VMs are created or existing ones moved, Nova selects the right compute host as follows:

--- a/helm/cortex/Chart.yaml
+++ b/helm/cortex/Chart.yaml
@@ -37,4 +37,3 @@ dependencies:
   - name: vernemq
     repository: https://vernemq.github.io/docker-vernemq
     version: 2.0.1
-    condition: vernemq.enabled

--- a/helm/cortex/templates/mqtt.yaml
+++ b/helm/cortex/templates/mqtt.yaml
@@ -1,7 +1,6 @@
 # Copyright 2025 SAP SE
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if index .Values "vernemq" "enabled" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,4 +17,3 @@ data:
   DOCKER_VERNEMQ_USER_{{ .Values.vernemq.username }}: "{{ .Values.vernemq.password }}"
   DOCKER_VERNEMQ_LISTENER__TCP__LOCALHOST: "127.0.0.1:1883"
   DOCKER_VERNEMQ_LISTENER__WS__LOCALHOST: "127.0.0.1:8080"
-{{- end }}

--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -69,8 +69,6 @@ vernemq:
   image:
     repository: ghcr.io/cobaltcore-dev/cortex-vernemq
     tag: "latest"
-  # Whether a vernemq instance should be spawned and mqtt sent.
-  enabled: true
   # The username and password to use for the mqtt connection.
   username: cortex
   password: cortex
@@ -142,7 +140,6 @@ conf:
 
   # Configure here if we should connect to an mqtt broker.
   mqtt:
-    enabled: true
     # Must match vernemq.fullnameOverride, vernemq.username and vernemq.password.
     url: "tcp://cortex-mqtt:1883"
     username: "cortex"
@@ -248,7 +245,7 @@ conf:
             prometheus:
               metrics:
                 # Any vrops vm metric suffices.
-                - vrops_virtualmachine_cpu_demand_ratio
+                - type: vrops_vm_metric
             openstack:
               nova:
                 types:
@@ -259,7 +256,7 @@ conf:
           sync:
             prometheus:
               metrics:
-                - vrops_virtualmachine_cpu_demand_ratio
+                - alias: vrops_virtualmachine_cpu_demand_ratio
             openstack:
               nova:
                 types:
@@ -273,7 +270,7 @@ conf:
           sync:
             prometheus:
               metrics:
-                - vrops_hostsystem_cpu_contention_percentage
+                - alias: vrops_hostsystem_cpu_contention_percentage
 
       # KVM-specific extractors.
       - name: node_exporter_host_cpu_usage_extractor
@@ -281,13 +278,13 @@ conf:
           sync:
             prometheus:
               metrics:
-                - node_exporter_cpu_usage_pct
+                - alias: node_exporter_cpu_usage_pct
       - name: node_exporter_host_memory_active_extractor
         dependencies:
           sync:
             prometheus:
               metrics:
-                - node_exporter_memory_active_pct
+                - alias: node_exporter_memory_active_pct
 
       # Shared extractors.
       - name: flavor_host_space_extractor

--- a/internal/conf/graph.go
+++ b/internal/conf/graph.go
@@ -52,3 +52,90 @@ func (g *DependencyGraph[K]) Resolve() [][]K {
 	slices.Reverse(result)
 	return result
 }
+
+// Get distinct subgraphs from the dependency graph where a condition is met.
+//
+// Example: consider the following graph:
+//   - A -> B (condition: true) -> C, D (condition: true) -> E
+//   - F (condition: true) -> G, H -> I
+//
+// The result would be two subgraphs: B -> C, D -> E and F -> G, H -> I.
+// The subgraph after node D is part of B's subgraph, therefore we don't get
+// three results.
+func (g *DependencyGraph[K]) DistinctSubgraphs(condition func(K) bool) []DependencyGraph[K] {
+	// Build the children mapping: for each dependency edge:
+	// for node, and each prereq in Dependencies[node],
+	// add an edge prereq -> node.
+	children := make(map[K][]K)
+	for node, deps := range g.Dependencies {
+		for _, prereq := range deps {
+			children[prereq] = append(children[prereq], node)
+		}
+	}
+
+	// visited records nodes that have already been assigned to a subgraph.
+	visited := make(map[K]bool)
+	var distinct []DependencyGraph[K]
+
+	// Iterate over all nodes in the original order.
+	for _, node := range g.Nodes {
+		if !condition(node) {
+			continue
+		}
+		if visited[node] {
+			// This condition node is already part of some earlier subgraph.
+			continue
+		}
+
+		// Start a BFS from the current condition node over the children mapping
+		// to collect all nodes transitively reachable (including this node).
+		subNodesSet := make(map[K]bool)
+		queue := []K{node}
+		subNodesSet[node] = true
+
+		for len(queue) > 0 {
+			curr := queue[0]
+			queue = queue[1:]
+			for _, child := range children[curr] {
+				if !subNodesSet[child] {
+					subNodesSet[child] = true
+					queue = append(queue, child)
+				}
+			}
+		}
+
+		// Build subNodes by filtering g.Nodes according to subNodesSet to
+		// respect the original ordering.
+		var subNodes []K
+		for _, n := range g.Nodes {
+			if subNodesSet[n] {
+				subNodes = append(subNodes, n)
+			}
+		}
+
+		// Build the dependencies for the subgraph.
+		subDeps := make(map[K][]K)
+		for _, n := range subNodes {
+			if deps, ok := g.Dependencies[n]; ok {
+				for _, prereq := range deps {
+					if subNodesSet[prereq] {
+						subDeps[n] = append(subDeps[n], prereq)
+					}
+				}
+			}
+		}
+
+		// Create the subgraph and add it to distinct.
+		subGraph := DependencyGraph[K]{
+			Dependencies: subDeps,
+			Nodes:        subNodes,
+		}
+		distinct = append(distinct, subGraph)
+
+		// Mark all nodes in this subgraph as visited.
+		for n := range subNodesSet {
+			visited[n] = true
+		}
+	}
+	return distinct
+}

--- a/internal/conf/validation_test.go
+++ b/internal/conf/validation_test.go
@@ -28,11 +28,17 @@ features:
         sync:
           prometheus:
             metrics:
-              - metric_1
+              - alias: metric_1
           openstack:
             nova:
               types:
                 - servers
+    - name: extractor_2
+      dependencies:
+        sync:
+          prometheus:
+            metrics:
+              - type: metric_type_1
 scheduler:
   steps:
     - name: scheduler_1
@@ -63,7 +69,7 @@ features:
         sync:
           prometheus:
             metrics:
-              - metric_1
+              - alias: metric_1
           openstack:
             nova:
               types:

--- a/internal/conf/yaml.go
+++ b/internal/conf/yaml.go
@@ -174,7 +174,6 @@ type MonitoringConfig struct {
 
 // Configuration for the mqtt client.
 type MQTTConfig struct {
-	Enabled bool `yaml:"enabled"`
 	// The URL of the MQTT broker to use for mqtt.
 	URL string `yaml:"url"`
 	// Credentials for the MQTT broker.

--- a/internal/features/monitor.go
+++ b/internal/features/monitor.go
@@ -68,6 +68,12 @@ func (m FeatureExtractorMonitor[F]) GetName() string {
 	return m.FeatureExtractor.GetName()
 }
 
+// Get the message topics that trigger a re-execution of the wrapped feature extractor.
+func (m FeatureExtractorMonitor[F]) Triggers() []string {
+	// Return the triggers of the wrapped feature extractor.
+	return m.FeatureExtractor.Triggers()
+}
+
 // Initialize the wrapped feature extractor with the database and options.
 func (m FeatureExtractorMonitor[F]) Init(db db.DB, opts conf.RawOpts) error {
 	// Configure the wrapped feature extractor.

--- a/internal/features/pipeline.go
+++ b/internal/features/pipeline.go
@@ -56,6 +56,7 @@ type FeatureExtractorPipeline struct {
 // Create a new feature extractor pipeline with extractors contained in the configuration.
 func NewPipeline(config conf.FeaturesConfig, database db.DB, m Monitor) FeatureExtractorPipeline {
 	return FeatureExtractorPipeline{
+		db:      database,
 		config:  config,
 		monitor: m,
 	}

--- a/internal/features/pipeline.go
+++ b/internal/features/pipeline.go
@@ -5,6 +5,7 @@ package features
 
 import (
 	"log/slog"
+	"slices"
 	"sync"
 
 	"github.com/cobaltcore-dev/cortex/internal/conf"
@@ -13,12 +14,13 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/features/plugins/kvm"
 	"github.com/cobaltcore-dev/cortex/internal/features/plugins/shared"
 	"github.com/cobaltcore-dev/cortex/internal/features/plugins/vmware"
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/cobaltcore-dev/cortex/internal/mqtt"
+
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
 // Configuration of feature extractors supported by the scheduler.
-// The actual features to extract are defined in the configuration file.
-var supportedExtractors = []plugins.FeatureExtractor{
+var SupportedExtractors = []plugins.FeatureExtractor{
 	// VMware-specific extractors
 	&vmware.VROpsHostsystemResolver{},
 	&vmware.VROpsProjectNoisinessExtractor{},
@@ -32,18 +34,41 @@ var supportedExtractors = []plugins.FeatureExtractor{
 
 // Pipeline that contains multiple feature extractors and executes them.
 type FeatureExtractorPipeline struct {
-	// The order in which feature extractors are executed.
+	// The dependency graph of the feature extractors, which is used to
+	// determine the execution order of the feature extractors.
+	//
 	// For example, [[f1], [f2, f3], [f4]] means that f1 is executed first
 	// followed by f2 and f3 in parallel, and finally f4.
-	executionOrder [][]plugins.FeatureExtractor
+	dependencyGraph conf.DependencyGraph[plugins.FeatureExtractor]
+	// The resolved order in which feature extractors are executed when triggered
+	// by a message on a topic (key).
+	//
+	// Dimensions: distinct subgraph depending on the topic -> step -> extractor.
+	triggerExecutionOrder map[string][][][]plugins.FeatureExtractor
+	// Database to store the extracted features.
+	db db.DB
+	// Config to use for the feature extractors.
+	config conf.FeaturesConfig
 	// Monitor to use for tracking the pipeline.
 	monitor Monitor
 }
 
-// Create a new feature extractor pipeline with extractors contained in
-// the configuration. This function automatically resolves an execution
-// graph to automate parallel execution of the individual feature extractors.
+// Create a new feature extractor pipeline with extractors contained in the configuration.
 func NewPipeline(config conf.FeaturesConfig, database db.DB, m Monitor) FeatureExtractorPipeline {
+	return FeatureExtractorPipeline{
+		config:  config,
+		monitor: m,
+	}
+}
+
+// Initialize the feature extractors in the pipeline.
+func (p *FeatureExtractorPipeline) Init(supportedExtractors []plugins.FeatureExtractor) {
+	p.initDependencyGraph(supportedExtractors)
+	p.initTriggerExecutionOrder()
+}
+
+// Initialize the execution order of the feature extractors.
+func (p *FeatureExtractorPipeline) initDependencyGraph(supportedExtractors []plugins.FeatureExtractor) {
 	supportedExtractorsByName := make(map[string]plugins.FeatureExtractor)
 	for _, extractor := range supportedExtractors {
 		supportedExtractorsByName[extractor.GetName()] = extractor
@@ -51,13 +76,13 @@ func NewPipeline(config conf.FeaturesConfig, database db.DB, m Monitor) FeatureE
 
 	// Load all extractors from the configuration.
 	extractorsByName := make(map[string]plugins.FeatureExtractor)
-	for _, extractorConfig := range config.Extractors {
+	for _, extractorConfig := range p.config.Extractors {
 		extractorFunc, ok := supportedExtractorsByName[extractorConfig.Name]
 		if !ok {
 			panic("unknown feature extractor: " + extractorConfig.Name)
 		}
-		wrappedExtractor := monitorFeatureExtractor(extractorFunc, m)
-		if err := wrappedExtractor.Init(database, extractorConfig.Options); err != nil {
+		wrappedExtractor := monitorFeatureExtractor(extractorFunc, p.monitor)
+		if err := wrappedExtractor.Init(p.db, extractorConfig.Options); err != nil {
 			panic("failed to initialize feature extractor: " + err.Error())
 		}
 		extractorsByName[extractorConfig.Name] = wrappedExtractor
@@ -71,7 +96,7 @@ func NewPipeline(config conf.FeaturesConfig, database db.DB, m Monitor) FeatureE
 	// Build the dependency graph and resolve the execution order.
 	extractors := []plugins.FeatureExtractor{}
 	extractorDependencies := make(map[plugins.FeatureExtractor][]plugins.FeatureExtractor)
-	for _, extractorConfig := range config.Extractors {
+	for _, extractorConfig := range p.config.Extractors {
 		extractor := extractorsByName[extractorConfig.Name]
 		extractors = append(extractors, extractor)
 		dependencies := []plugins.FeatureExtractor{}
@@ -84,36 +109,63 @@ func NewPipeline(config conf.FeaturesConfig, database db.DB, m Monitor) FeatureE
 		}
 		extractorDependencies[extractor] = dependencies
 	}
-	dependencyGraph := conf.DependencyGraph[plugins.FeatureExtractor]{
+	p.dependencyGraph = conf.DependencyGraph[plugins.FeatureExtractor]{
 		Dependencies: extractorDependencies,
 		Nodes:        extractors,
 	}
-	executionOrder := dependencyGraph.Resolve()
-
-	// Print out the execution order to the log.
-	slog.Info("feature extractor: dependency graph resolved")
-	for i, extractors := range executionOrder {
-		for _, extractor := range extractors {
-			slog.Info(
-				"feature extractor: execution order",
-				"group", i, "name", extractor.GetName(),
-			)
-		}
-	}
-
-	return FeatureExtractorPipeline{executionOrder: executionOrder, monitor: m}
 }
 
-// Extract features from the data sources, in the sequence given by
-// the automatically calculated execution order.
-func (p *FeatureExtractorPipeline) Extract() {
-	if p.monitor.pipelineRunTimer != nil {
-		timer := prometheus.NewTimer(p.monitor.pipelineRunTimer)
-		defer timer.ObserveDuration()
+// Initialize the trigger execution order of the feature extractors.
+func (p *FeatureExtractorPipeline) initTriggerExecutionOrder() {
+	// Resolve which feature extractors to execute when triggers are received.
+	// First collect all triggers we are listening for.
+	triggers := make(map[string]struct{})
+	for _, extractor := range p.dependencyGraph.Nodes {
+		for _, topic := range extractor.Triggers() {
+			triggers[topic] = struct{}{}
+		}
 	}
+	// Then, for each topic, get the highest node in the dependency graph
+	// that has a trigger for this topic and resolve its subgraph.
+	triggerExecutionOrder := make(map[string][][][]plugins.FeatureExtractor)
+	for topic := range triggers {
+		condition := func(extractor plugins.FeatureExtractor) bool {
+			return slices.Contains(extractor.Triggers(), topic)
+		}
+		subgraphs := p.dependencyGraph.DistinctSubgraphs(condition)
+		triggerExecutionOrder[topic] = make([][][]plugins.FeatureExtractor, len(subgraphs))
+		for i, subgraph := range subgraphs {
+			triggerExecutionOrder[topic][i] = subgraph.Resolve()
+		}
+	}
+	p.triggerExecutionOrder = triggerExecutionOrder
+	slog.Info(
+		"feature extractor: resolved execution order",
+		"order", triggerExecutionOrder, "trigger", triggerExecutionOrder,
+	)
+}
 
+// Extract features from the data sources when triggered by MQTT messages.
+// If mqtt is disabled, this function does nothing.
+func (p *FeatureExtractorPipeline) ExtractOnTrigger() {
+	// Subscribe to the MQTT topics that trigger the feature extraction.
+	mqttClient := mqtt.NewClient()
+	for topic, subgraphs := range p.triggerExecutionOrder {
+		if err := mqttClient.Subscribe(topic, func(_ pahomqtt.Client, _ pahomqtt.Message) {
+			for _, order := range subgraphs {
+				slog.Info("triggered feature extractors by mqtt message", "topic", topic)
+				p.extract(order)
+			}
+		}); err != nil {
+			panic("failed to subscribe to topic: " + topic)
+		}
+	}
+}
+
+// Extract features in the sequence given by the execution order.
+func (p *FeatureExtractorPipeline) extract(order [][]plugins.FeatureExtractor) {
 	// Execute the extractors in groups of the execution order.
-	for _, extractors := range p.executionOrder {
+	for _, extractors := range order {
 		var wg sync.WaitGroup
 		for _, extractor := range extractors {
 			wg.Add(1)

--- a/internal/features/pipeline.go
+++ b/internal/features/pipeline.go
@@ -135,7 +135,11 @@ func (p *FeatureExtractorPipeline) initTriggerExecutionOrder() {
 		subgraphs := p.dependencyGraph.DistinctSubgraphs(condition)
 		triggerExecutionOrder[topic] = make([][][]plugins.FeatureExtractor, len(subgraphs))
 		for i, subgraph := range subgraphs {
-			triggerExecutionOrder[topic][i] = subgraph.Resolve()
+			order, err := subgraph.Resolve()
+			if err != nil {
+				panic("failed to resolve dependency graph: " + err.Error())
+			}
+			triggerExecutionOrder[topic][i] = order
 		}
 	}
 	p.triggerExecutionOrder = triggerExecutionOrder

--- a/internal/features/pipeline_test.go
+++ b/internal/features/pipeline_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 type mockFeatureExtractor struct {
+	name       string
+	triggers   []string
 	initErr    error
 	extractErr error
 }
@@ -26,33 +28,148 @@ func (m *mockFeatureExtractor) Extract() ([]plugins.Feature, error) {
 }
 
 func (m *mockFeatureExtractor) GetName() string {
-	return "mock_feature_extractor"
+	return m.name
+}
+
+func (m *mockFeatureExtractor) Triggers() []string {
+	return m.triggers
 }
 
 func TestFeatureExtractorPipeline_Extract(t *testing.T) {
 	// Test case: All extractors extract successfully
-	pipeline := &FeatureExtractorPipeline{
-		executionOrder: [][]plugins.FeatureExtractor{
-			{&mockFeatureExtractor{}},
-			{&mockFeatureExtractor{}},
-		},
-	}
-
-	pipeline.Extract()
+	pipeline := &FeatureExtractorPipeline{}
+	pipeline.extract([][]plugins.FeatureExtractor{
+		{&mockFeatureExtractor{}},
+		{&mockFeatureExtractor{}},
+	})
 
 	// No errors means the test passed
 }
 
 func TestFeatureExtractorPipeline_Extract_Failure(t *testing.T) {
 	// Test case: One extractor fails to extract
-	pipeline := &FeatureExtractorPipeline{
-		executionOrder: [][]plugins.FeatureExtractor{
-			{&mockFeatureExtractor{}},
-			{&mockFeatureExtractor{extractErr: errors.New("extract error")}},
+	pipeline := &FeatureExtractorPipeline{}
+	pipeline.extract([][]plugins.FeatureExtractor{
+		{&mockFeatureExtractor{}},
+		{&mockFeatureExtractor{extractErr: errors.New("extract error")}},
+	})
+
+	// No panic means the test passed
+}
+
+func TestFeatureExtractorPipeline_InitDependencyGraph(t *testing.T) {
+	// Mock configuration with two extractors and a dependency
+	config := conf.FeaturesConfig{
+		Extractors: []conf.FeatureExtractorConfig{
+			{
+				Name:    "extractor1",
+				Options: conf.RawOpts{},
+				DependencyConfig: conf.DependencyConfig{
+					Features: conf.FeaturesDependency{
+						// Extractor 1 depends on Extractor 2
+						ExtractorNames: []string{"extractor2"},
+					},
+				},
+			},
+			{
+				Name:    "extractor2",
+				Options: conf.RawOpts{},
+			},
+			{
+				Name:    "extractor3",
+				Options: conf.RawOpts{},
+				DependencyConfig: conf.DependencyConfig{
+					Features: conf.FeaturesDependency{
+						// Extractor 1 depends on Extractor 2
+						ExtractorNames: []string{"extractor2"},
+					},
+				},
+			},
 		},
 	}
 
-	pipeline.Extract()
+	// Mock supported extractors
+	supportedExtractors := []plugins.FeatureExtractor{
+		&mockFeatureExtractor{name: "extractor1"},
+		&mockFeatureExtractor{name: "extractor2"},
+		&mockFeatureExtractor{name: "extractor3"},
+	}
 
-	// No panic means the test passed
+	pipeline := FeatureExtractorPipeline{
+		config: config,
+	}
+
+	// Call the function
+	pipeline.initDependencyGraph(supportedExtractors)
+	t.Logf("%v", pipeline.dependencyGraph.Resolve())
+
+	// Assertions
+	if len(pipeline.dependencyGraph.Nodes) != 3 {
+		t.Fatalf("expected 3 nodes in the dependency graph, got %d", len(pipeline.dependencyGraph.Nodes))
+	}
+
+	if len(pipeline.dependencyGraph.Dependencies) != 3 {
+		t.Fatalf("expected 3 dependencies in the dependency graph, got %d", len(pipeline.dependencyGraph.Dependencies))
+	}
+
+	// Need to compare the values like this since the map keys are pointers.
+	getDeps := func(name string) []plugins.FeatureExtractor {
+		for _, node := range pipeline.dependencyGraph.Nodes {
+			if node.GetName() == name {
+				return pipeline.dependencyGraph.Dependencies[node]
+			}
+		}
+		return nil
+	}
+
+	if len(getDeps("extractor1")) != 1 {
+		t.Fatalf("expected 1 dependency for extractor1, got %d", len(getDeps("extractor1")))
+	}
+	if len(getDeps("extractor2")) != 0 {
+		t.Fatalf("expected 0 dependencies for extractor2, got %d", len(getDeps("extractor2")))
+	}
+	if len(getDeps("extractor3")) != 1 {
+		t.Fatalf("expected 1 dependency for extractor3, got %d", len(getDeps("extractor3")))
+	}
+}
+
+func TestFeatureExtractorPipeline_InitTriggerExecutionOrder(t *testing.T) {
+	// Mock configuration with two extractors and triggers
+	config := conf.FeaturesConfig{
+		Extractors: []conf.FeatureExtractorConfig{
+			{
+				Name:    "extractor1",
+				Options: conf.RawOpts{},
+			},
+			{
+				Name:    "extractor2",
+				Options: conf.RawOpts{},
+			},
+		},
+	}
+
+	// Mock supported extractors
+	supportedExtractors := []plugins.FeatureExtractor{
+		&mockFeatureExtractor{name: "extractor1", triggers: []string{"topic1"}},
+		&mockFeatureExtractor{name: "extractor2", triggers: []string{"topic2"}},
+	}
+
+	pipeline := FeatureExtractorPipeline{
+		config: config,
+	}
+	pipeline.initDependencyGraph(supportedExtractors)
+	pipeline.initTriggerExecutionOrder()
+
+	// Assertions
+	if len(pipeline.triggerExecutionOrder) != 2 {
+		t.Fatalf("expected 2 triggers in the trigger execution order, got %d", len(pipeline.triggerExecutionOrder))
+	}
+
+	if _, ok := pipeline.triggerExecutionOrder["topic1"]; !ok {
+		t.Fatalf("expected triggerExecutionOrder to contain topic1")
+	}
+
+	if _, ok := pipeline.triggerExecutionOrder["topic2"]; !ok {
+		t.Fatalf("expected triggerExecutionOrder to contain topic2")
+	}
 }

--- a/internal/features/pipeline_test.go
+++ b/internal/features/pipeline_test.go
@@ -101,7 +101,6 @@ func TestFeatureExtractorPipeline_InitDependencyGraph(t *testing.T) {
 
 	// Call the function
 	pipeline.initDependencyGraph(supportedExtractors)
-	t.Logf("%v", pipeline.dependencyGraph.Resolve())
 
 	// Assertions
 	if len(pipeline.dependencyGraph.Nodes) != 3 {

--- a/internal/features/plugins/interface.go
+++ b/internal/features/plugins/interface.go
@@ -19,6 +19,8 @@ type FeatureExtractor interface {
 	// This name is used to identify the extractor in metrics, config, logs, etc.
 	// Should be something like: "my_cool_feature_extractor".
 	GetName() string
+	// Get message topics that trigger a re-execution of this extractor.
+	Triggers() []string
 }
 
 type Feature interface{}

--- a/internal/features/plugins/kvm/node_exporter_host_cpu_usage.go
+++ b/internal/features/plugins/kvm/node_exporter_host_cpu_usage.go
@@ -5,6 +5,7 @@ package kvm
 
 import (
 	"github.com/cobaltcore-dev/cortex/internal/features/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/sync/prometheus"
 )
 
 // Feature that maps CPU usage of kvm hosts.
@@ -32,6 +33,13 @@ type NodeExporterHostCPUUsageExtractor struct {
 // Name of this feature extractor that is used in the yaml config, for logging etc.
 func (*NodeExporterHostCPUUsageExtractor) GetName() string {
 	return "node_exporter_host_cpu_usage_extractor"
+}
+
+// Get message topics that trigger a re-execution of this extractor.
+func (NodeExporterHostCPUUsageExtractor) Triggers() []string {
+	return []string{
+		prometheus.TriggerMetricAliasSynced("node_exporter_cpu_usage_pct"),
+	}
 }
 
 // Extract CPU usage of kvm hosts.

--- a/internal/features/plugins/kvm/node_exporter_host_memory_active.go
+++ b/internal/features/plugins/kvm/node_exporter_host_memory_active.go
@@ -5,6 +5,7 @@ package kvm
 
 import (
 	"github.com/cobaltcore-dev/cortex/internal/features/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/sync/prometheus"
 )
 
 // Feature that maps memory active percentage of kvm hosts.
@@ -32,6 +33,13 @@ type NodeExporterHostMemoryActiveExtractor struct {
 // Name of this feature extractor that is used in the yaml config, for logging etc.
 func (*NodeExporterHostMemoryActiveExtractor) GetName() string {
 	return "node_exporter_host_memory_active_extractor"
+}
+
+// Get message topics that trigger a re-execution of this extractor.
+func (NodeExporterHostMemoryActiveExtractor) Triggers() []string {
+	return []string{
+		prometheus.TriggerMetricAliasSynced("node_exporter_memory_active_pct"),
+	}
 }
 
 // Extract how much memory of kvm hosts is active.

--- a/internal/features/plugins/shared/flavor_host_space.go
+++ b/internal/features/plugins/shared/flavor_host_space.go
@@ -43,6 +43,14 @@ func (*FlavorHostSpaceExtractor) GetName() string {
 	return "flavor_host_space_extractor"
 }
 
+// Get message topics that trigger a re-execution of this extractor.
+func (FlavorHostSpaceExtractor) Triggers() []string {
+	return []string{
+		openstack.TriggerNovaFlavorsSynced,
+		openstack.TriggerNovaHypervisorsSynced,
+	}
+}
+
 // Extract the space left on a compute host after the placement of a flavor.
 // Depends on the OpenStack flavors and hypervisors to be synced.
 func (e *FlavorHostSpaceExtractor) Extract() ([]plugins.Feature, error) {

--- a/internal/features/plugins/vmware/vrops_hostsystem_contention.go
+++ b/internal/features/plugins/vmware/vrops_hostsystem_contention.go
@@ -5,6 +5,7 @@ package vmware
 
 import (
 	"github.com/cobaltcore-dev/cortex/internal/features/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/sync/prometheus"
 )
 
 // Feature that maps CPU contention of vROps hostsystems.
@@ -32,6 +33,13 @@ type VROpsHostsystemContentionExtractor struct {
 // Name of this feature extractor that is used in the yaml config, for logging etc.
 func (*VROpsHostsystemContentionExtractor) GetName() string {
 	return "vrops_hostsystem_contention_extractor"
+}
+
+// Get message topics that trigger a re-execution of this extractor.
+func (VROpsHostsystemContentionExtractor) Triggers() []string {
+	return []string{
+		prometheus.TriggerMetricAliasSynced("vrops_hostsystem_cpu_contention_percentage"),
+	}
 }
 
 // Extract CPU contention of hostsystems.

--- a/internal/features/plugins/vmware/vrops_hostsystem_resolver.go
+++ b/internal/features/plugins/vmware/vrops_hostsystem_resolver.go
@@ -5,6 +5,8 @@ package vmware
 
 import (
 	"github.com/cobaltcore-dev/cortex/internal/features/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/sync/openstack"
+	"github.com/cobaltcore-dev/cortex/internal/sync/prometheus"
 )
 
 // Feature that resolves the vROps metrics hostsystem label to the
@@ -27,6 +29,15 @@ type VROpsHostsystemResolver struct {
 		struct{},                // No options passed through yaml config
 		ResolvedVROpsHostsystem, // Feature model
 	]
+}
+
+// Get message topics that trigger a re-execution of this extractor.
+func (VROpsHostsystemResolver) Triggers() []string {
+	return []string{
+		openstack.TriggerNovaServersSynced,
+		openstack.TriggerNovaHypervisorsSynced,
+		prometheus.TriggerMetricTypeSynced("vrops_vm_metrics"),
+	}
 }
 
 // Name of this feature extractor that is used in the yaml config, for logging etc.

--- a/internal/features/plugins/vmware/vrops_project_noisiness.go
+++ b/internal/features/plugins/vmware/vrops_project_noisiness.go
@@ -5,6 +5,8 @@ package vmware
 
 import (
 	"github.com/cobaltcore-dev/cortex/internal/features/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/sync/openstack"
+	"github.com/cobaltcore-dev/cortex/internal/sync/prometheus"
 )
 
 // Feature that calculates the noisiness of projects and on which
@@ -33,6 +35,15 @@ type VROpsProjectNoisinessExtractor struct {
 // Name of this feature extractor that is used in the yaml config, for logging etc.
 func (e *VROpsProjectNoisinessExtractor) GetName() string {
 	return "vrops_project_noisiness_extractor"
+}
+
+// Get message topics that trigger a re-execution of this extractor.
+func (VROpsProjectNoisinessExtractor) Triggers() []string {
+	return []string{
+		openstack.TriggerNovaServersSynced,
+		openstack.TriggerNovaHypervisorsSynced,
+		prometheus.TriggerMetricAliasSynced("vrops_virtualmachine_cpu_demand_ratio"),
+	}
 }
 
 // Extract the noisiness for each project in OpenStack with the following steps:

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -47,16 +47,16 @@ func (t *client) Connect() error {
 	opts.SetConnectTimeout(10 * time.Second)
 	opts.SetConnectRetry(true)
 	opts.SetConnectRetryInterval(5 * time.Second)
-	opts.SetAutoReconnect(false) // Handle the reconnect logic ourselves
 	opts.SetKeepAlive(60 * time.Second)
 	opts.SetPingTimeout(10 * time.Second)
 	opts.SetOnConnectHandler(func(client mqtt.Client) {
 		slog.Info("connected to mqtt broker")
 	})
+	opts.SetAutoReconnect(true)
+	opts.SetResumeSubs(true)
+	opts.SetCleanSession(false)
 	opts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
-		// To avoid weird hanging issues, just panic and let the
-		// kubernetes crashloop backoff handle it.
-		panic(fmt.Errorf("connection to mqtt broker lost: %w", err))
+		slog.Error("mqtt connection lost", "err", err)
 	})
 	//nolint:gosec // We don't care if the client id is cryptographically secure.
 	opts.SetClientID(fmt.Sprintf("cortex-scheduler-%d", rand.Intn(1_000_000)))

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -47,14 +47,16 @@ func (t *client) Connect() error {
 	opts.SetConnectTimeout(10 * time.Second)
 	opts.SetConnectRetry(true)
 	opts.SetConnectRetryInterval(5 * time.Second)
-	opts.SetAutoReconnect(true)
+	opts.SetAutoReconnect(false) // Handle the reconnect logic ourselves
 	opts.SetKeepAlive(60 * time.Second)
 	opts.SetPingTimeout(10 * time.Second)
 	opts.SetOnConnectHandler(func(client mqtt.Client) {
 		slog.Info("connected to mqtt broker")
 	})
 	opts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
-		slog.Error("connection to mqtt broker lost", "err", err)
+		// To avoid weird hanging issues, just panic and let the
+		// kubernetes crashloop backoff handle it.
+		panic(fmt.Errorf("connection to mqtt broker lost: %w", err))
 	})
 	//nolint:gosec // We don't care if the client id is cryptographically secure.
 	opts.SetClientID(fmt.Sprintf("cortex-scheduler-%d", rand.Intn(1_000_000)))

--- a/internal/mqtt/mqtt_test.go
+++ b/internal/mqtt/mqtt_test.go
@@ -41,7 +41,7 @@ func TestPublish(t *testing.T) {
 	conf := conf.MQTTConfig{URL: "tcp://localhost:" + container.GetPort()}
 	c := client{conf: conf, lock: &sync.Mutex{}}
 
-	err := c.Publish("test/topic", map[string]string{"key": "value"})
+	err := c.publish("test/topic", map[string]string{"key": "value"})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/scheduler/api"
 	"github.com/cobaltcore-dev/cortex/internal/scheduler/plugins"
+	"github.com/cobaltcore-dev/cortex/testlib/mqtt"
 )
 
 type mockPipelineStep struct {
@@ -40,6 +41,7 @@ func TestPipeline_Run(t *testing.T) {
 		applicationOrder: []string{
 			"mock_pipeline_step",
 		},
+		mqttClient: &mqtt.MockClient{},
 	}
 
 	tests := []struct {

--- a/internal/sync/openstack/nova_sync.go
+++ b/internal/sync/openstack/nova_sync.go
@@ -39,7 +39,6 @@ type novaSyncer struct {
 	// Nova API client to fetch the data.
 	api NovaAPI
 	// MQTT client to publish mqtt data.
-	// Only initialized if mqtt is enabled.
 	mqttClient mqtt.Client
 }
 
@@ -73,23 +72,29 @@ func (s *novaSyncer) Init(ctx context.Context) {
 	}
 }
 
-// Sync the OpenStack nova objects.
+// Sync the OpenStack nova objects and publish triggers.
 func (s *novaSyncer) Sync(ctx context.Context) error {
 	// Only sync the objects that are configured in the yaml conf.
 	if slices.Contains(s.conf.Types, "servers") {
 		if _, err := s.SyncServers(ctx); err != nil {
 			return err
 		}
+		go s.mqttClient.Publish(TriggerNovaServersSynced, "")
 	}
 	if slices.Contains(s.conf.Types, "hypervisors") {
-		if _, err := s.SyncHypervisors(ctx); err != nil {
+		hypervisors, err := s.SyncHypervisors(ctx)
+		if err != nil {
 			return err
 		}
+		go s.mqttClient.Publish(TriggerNovaHypervisorsSynced, "")
+		// Publish additional information required for the visualizer.
+		go s.mqttClient.Publish("cortex/sync/openstack/nova/hypervisors", hypervisors)
 	}
 	if slices.Contains(s.conf.Types, "flavors") {
 		if _, err := s.SyncFlavors(ctx); err != nil {
 			return err
 		}
+		go s.mqttClient.Publish(TriggerNovaFlavorsSynced, "")
 	}
 	return nil
 }
@@ -127,13 +132,6 @@ func (s *novaSyncer) SyncServers(ctx context.Context) ([]Server, error) {
 		counter := s.mon.PipelineRequestProcessedCounter.WithLabelValues(label)
 		counter.Inc()
 	}
-	// Publish information about the servers to an mqtt broker.
-	// In this way, the changes in server placement etc. can be monitored
-	// or visualized by other services.
-	if s.mqttClient != nil {
-		//nolint:errcheck // Don't need to check the error here. It should be logged.
-		go s.mqttClient.Publish("cortex/sync/openstack/nova/servers", servers)
-	}
 	return servers, nil
 }
 
@@ -169,13 +167,6 @@ func (s *novaSyncer) SyncHypervisors(ctx context.Context) ([]Hypervisor, error) 
 	if s.mon.PipelineRequestProcessedCounter != nil {
 		counter := s.mon.PipelineRequestProcessedCounter.WithLabelValues(label)
 		counter.Inc()
-	}
-	// Publish information about the hypervisors to an mqtt broker.
-	// In this way, the changes in hypervisor usage etc. can be monitored
-	// or visualized by other services.
-	if s.mqttClient != nil {
-		//nolint:errcheck // Don't need to check the error here. It should be logged.
-		go s.mqttClient.Publish("cortex/sync/openstack/nova/hypervisors", hypervisors)
 	}
 	return hypervisors, nil
 }

--- a/internal/sync/openstack/nova_sync_test.go
+++ b/internal/sync/openstack/nova_sync_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/sync"
 	testlibDB "github.com/cobaltcore-dev/cortex/testlib/db"
+	"github.com/cobaltcore-dev/cortex/testlib/mqtt"
 )
 
 type mockNovaAPI struct{}
@@ -53,10 +54,11 @@ func TestNovaSyncer_Sync(t *testing.T) {
 
 	mon := sync.Monitor{}
 	syncer := &novaSyncer{
-		db:   testDB,
-		mon:  mon,
-		conf: NovaConf{Types: []string{"servers", "hypervisors"}},
-		api:  &mockNovaAPI{},
+		db:         testDB,
+		mon:        mon,
+		conf:       NovaConf{Types: []string{"servers", "hypervisors"}},
+		api:        &mockNovaAPI{},
+		mqttClient: &mqtt.MockClient{},
 	}
 
 	ctx := context.Background()

--- a/internal/sync/openstack/triggers.go
+++ b/internal/sync/openstack/triggers.go
@@ -1,0 +1,19 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+// Trigger executed when new servers are available.
+const TriggerNovaServersSynced = "triggers/sync/openstack/nova/types/servers"
+
+// Trigger executed when new hypervisors are available.
+const TriggerNovaHypervisorsSynced = "triggers/sync/openstack/nova/types/hypervisors"
+
+// Trigger executed when new flavors are available.
+const TriggerNovaFlavorsSynced = "triggers/sync/openstack/nova/types/flavors"
+
+// Trigger executed when new resource providers are available.
+const TriggerPlacementResourceProvidersSynced = "triggers/sync/openstack/placement/types/resource_providers"
+
+// Trigger executed when new traits are available.
+const TriggerPlacementTraitsSynced = "triggers/sync/openstack/placement/types/traits"

--- a/internal/sync/prometheus/sync_test.go
+++ b/internal/sync/prometheus/sync_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cobaltcore-dev/cortex/internal/conf"
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	testlibDB "github.com/cobaltcore-dev/cortex/testlib/db"
 )
@@ -37,8 +38,10 @@ func TestSyncer_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	syncer := &syncer[VROpsVMMetric]{
-		MetricAlias:   "test_metric",
-		MetricQuery:   "test_query",
+		MetricConf: conf.SyncPrometheusMetricConfig{
+			Alias: "test_metric",
+			Query: "test_query",
+		},
 		PrometheusAPI: &mockPrometheusAPI[VROpsVMMetric]{},
 		DB:            testDB,
 	}
@@ -58,8 +61,10 @@ func TestSyncer_getSyncWindowStart(t *testing.T) {
 
 	// Test case: No metrics in the database
 	syncer := &syncer[VROpsVMMetric]{
-		MetricAlias:   "test_metric",
-		MetricQuery:   "test_query",
+		MetricConf: conf.SyncPrometheusMetricConfig{
+			Alias: "test_metric",
+			Query: "test_query",
+		},
 		PrometheusAPI: &mockPrometheusAPI[VROpsVMMetric]{},
 		DB:            testDB,
 	}
@@ -112,10 +117,12 @@ func TestSyncer_sync(t *testing.T) {
 		SyncTimeRange:         4 * 7 * 24 * time.Hour, // 4 weeks
 		SyncInterval:          24 * time.Hour,
 		SyncResolutionSeconds: 12 * 60 * 60, // 12 hours (2 datapoints per day per metric)
-		MetricAlias:           "test_metric",
-		MetricQuery:           "test_query",
-		PrometheusAPI:         mockPrometheusAPI,
-		DB:                    testDB,
+		MetricConf: conf.SyncPrometheusMetricConfig{
+			Alias: "test_metric",
+			Query: "test_query",
+		},
+		PrometheusAPI: mockPrometheusAPI,
+		DB:            testDB,
 	}
 	syncer.Init(t.Context())
 
@@ -153,10 +160,12 @@ func TestSyncer_sync_Failure(t *testing.T) {
 		SyncTimeRange:         4 * 7 * 24 * time.Hour, // 4 weeks
 		SyncInterval:          24 * time.Hour,
 		SyncResolutionSeconds: 12 * 60 * 60, // 12 hours (2 datapoints per day per metric)
-		MetricAlias:           "test_metric",
-		MetricQuery:           "test_query",
-		PrometheusAPI:         mockPrometheusAPI,
-		DB:                    testDB,
+		MetricConf: conf.SyncPrometheusMetricConfig{
+			Alias: "test_metric",
+			Query: "test_query",
+		},
+		PrometheusAPI: mockPrometheusAPI,
+		DB:            testDB,
 	}
 	syncer.Init(t.Context())
 
@@ -191,10 +200,12 @@ func TestSyncer_DeleteOldMetrics(t *testing.T) {
 		SyncTimeRange:         4 * 7 * 24 * time.Hour, // 4 weeks
 		SyncInterval:          24 * time.Hour,
 		SyncResolutionSeconds: 12 * 60 * 60, // 12 hours (2 datapoints per day per metric)
-		MetricAlias:           "test_metric",
-		MetricQuery:           "test_query",
-		PrometheusAPI:         mockPrometheusAPI,
-		DB:                    testDB,
+		MetricConf: conf.SyncPrometheusMetricConfig{
+			Alias: "test_metric",
+			Query: "test_query",
+		},
+		PrometheusAPI: mockPrometheusAPI,
+		DB:            testDB,
 	}
 	syncer.Init(t.Context())
 

--- a/internal/sync/prometheus/triggers.go
+++ b/internal/sync/prometheus/triggers.go
@@ -1,0 +1,14 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheus
+
+// Trigger executed when the prometheus metric with this alias has finished syncing.
+func TriggerMetricAliasSynced(metricAlias string) string {
+	return "triggers/sync/prometheus/alias/" + metricAlias
+}
+
+// Trigger executed when the prometheus metric with this type has finished syncing.
+func TriggerMetricTypeSynced(metricType string) string {
+	return "triggers/sync/prometheus/type/" + metricType
+}

--- a/testlib/mqtt/mock.go
+++ b/testlib/mqtt/mock.go
@@ -1,0 +1,27 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package mqtt
+
+import (
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+// Mock mqtt client that does nothing and can be used for testing.
+type MockClient struct{}
+
+func (m *MockClient) Publish(topic string, payload any) {
+	// Do nothing
+}
+
+func (m *MockClient) Connect() error {
+	return nil
+}
+
+func (m *MockClient) Disconnect() {
+	// Do nothing
+}
+
+func (m *MockClient) Subscribe(topic string, callback pahomqtt.MessageHandler) error {
+	return nil
+}


### PR DESCRIPTION
Adds event-based feature extraction to Cortex: features are now extracted as soon as the underlying data was updated. 

Closes: #66 

- If mqtt is enabled, the syncer will now publish triggers there.
- Triggers are received by the feature extractor to re-trigger feature extraction on-demand.
- Don't re-calculate all features. Calculate distinct feature extractor subgraphs to determine which features need re-calculation.
- Refactor the config a bit to make it more consistent with the newly introduced triggers.
- Wrap the `Publish` function in the mqtt client to not write `//nolint` everywhere.
- Add architecture decision record
- Make mqtt broker deployment mandatory
- Disable periodic feature extraction

Co-authored-by: mblos <marcel.bloecher@sap.com>