### PR TITLE
Add vernemq pipeline and use cobaltcore-dev/vernemq image

### DIFF
--- a/.github/workflows/vernemq.yaml
+++ b/.github/workflows/vernemq.yaml
@@ -1,0 +1,87 @@
+# Copyright 2025 SAP SE
+# SPDX-License-Identifier: Apache-2.0
+
+# Vernemq EULA requires us to build the image ourselves and not use the official image.
+# This workflow clones the official docker-vernemq repository and builds the image.
+# The image is then pushed to the GitHub Container Registry.
+name: Build and Push VerneMQ Docker Image
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: cobaltcore-dev/vernemq
+
+jobs:
+  docker:
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      # Only run this workflow when the vernemq workflow file is changed.
+      # In this way, we can configure the tag below that should be pushed.
+      - uses: actions/checkout@v4
+        with:
+          repository: cobaltcore-dev/cortex
+          path: cortex
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          path: cortex
+          files: |
+            .github/workflows/vernemq.yaml
+
+      # Configure the vernemq repository and its tag that should be pushed.
+      - uses: actions/checkout@v4
+        if: steps.changed-files.outputs.files != ''
+        with:
+          repository: vernemq/docker-vernemq
+          ref: 2.0.1
+
+      # Build and push the VerneMQ image.
+      - name: Set up QEMU
+        if: steps.changed-files.outputs.files != ''
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        if: steps.changed-files.outputs.files != ''
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Registry
+        if: steps.changed-files.outputs.files != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Meta
+        if: steps.changed-files.outputs.files != ''
+        id: meta_vernemq
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+      - name: Build and Push VerneMQ
+        if: steps.changed-files.outputs.files != ''
+        id: push_vernemq
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta_vernemq.outputs.tags }}
+          labels: ${{ steps.meta_vernemq.outputs.labels }}
+      - name: Generate Artifact Attestation
+        if: steps.changed-files.outputs.files != ''
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push_vernemq.outputs.digest }}
+          push-to-registry: true

--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -66,6 +66,9 @@ owner-info:
   enabled: true
 
 vernemq:
+  image:
+    repository: ghcr.io/cobaltcore-dev/vernemq
+    tag: "sha-8c964a2"
   # Whether a vernemq instance should be spawned and mqtt sent.
   enabled: true
   # The username and password to use for the mqtt connection.


### PR DESCRIPTION
Adds build pipeline for: https://github.com/orgs/cobaltcore-dev/packages/container/package/vernemq
Also sets the vernemq docker image to ghcr.io/cobaltcore-dev/vernemq.
Needed to conform to the VerneMQ EULA.