### PR TITLE
Fallback to original hosts if all are filtered out

### DIFF
--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -145,6 +145,14 @@ func (p *Pipeline) Run(request api.Request, novaWeights map[string]float64) ([]s
 		outWeights = p.ActivationFunction.Apply(outWeights, stepActivations)
 	}
 
+	// For now, the scheduler should not filter out all hosts.
+	// If it does, we should fall back to the original host list.
+	// This will prevent Cortex from blocking all scheduling requests.
+	if len(outWeights) == 0 {
+		slog.Warn("scheduler: all hosts filtered out, falling back to original host list")
+		outWeights = inWeights
+	}
+
 	if p.monitor.hostNumberOutObserver != nil {
 		p.monitor.hostNumberOutObserver.Observe(float64(len(outWeights)))
 	}

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -118,7 +118,7 @@ func TestPipeline_FallbackToOriginalHosts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := pipeline.Run(
 				tt.request,
-				map[string]float64{"host1": 0.0, "host2": 0.0, "host3": 0.0},
+				map[string]float64{"host1": 1.0, "host2": 0.5, "host3": 0.0},
 			)
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)


### PR DESCRIPTION
See also: https://github.com/sapcc/nova/pull/535

This adds more safety, in case some scheduler step decides to filter out all hosts from the Nova request. For now we consider this case a bug, and if we are confident enough, we can remove this check and let the scheduling fail on purpose.