### PR TITLE
Validate same host number in and out for weighers

### DIFF
--- a/internal/conf/yaml.go
+++ b/internal/conf/yaml.go
@@ -143,6 +143,16 @@ type SchedulerStepConfig struct {
 	Options RawOpts `yaml:"options,omitempty"`
 	// The dependencies this step needs.
 	DependencyConfig `yaml:"dependencies,omitempty"`
+	// The validations to use for this step.
+	DisabledValidations SchedulerStepDisabledValidationsConfig `yaml:"disabledValidations,omitempty"`
+}
+
+// Config for which validations to disable for a scheduler step.
+type SchedulerStepDisabledValidationsConfig struct {
+	// Whether to validate that no hosts are removed or added from the scheduler
+	// step. This should only be disabled for scheduler steps that remove hosts.
+	// Thus, if no value is provided, the default is false.
+	SameHostNumberInOut bool `yaml:"sameHostNumberInOut,omitempty"`
 }
 
 // Configuration for the scheduler module.

--- a/internal/scheduler/monitor.go
+++ b/internal/scheduler/monitor.go
@@ -124,9 +124,6 @@ func monitorStep[S plugins.Step](step S, m Monitor) *StepMonitor[S] {
 func (s *StepMonitor[S]) Run(request api.Request) (map[string]float64, error) {
 	stepName := s.GetName()
 
-	slog.Info("scheduler: running step", "name", stepName)
-	defer slog.Info("scheduler: finished step", "name", stepName)
-
 	if s.runTimer != nil {
 		timer := prometheus.NewTimer(s.runTimer)
 		defer timer.ObserveDuration()

--- a/internal/scheduler/validation.go
+++ b/internal/scheduler/validation.go
@@ -19,21 +19,21 @@ import (
 type disabledValidations = conf.SchedulerStepDisabledValidationsConfig
 
 // Wrapper for scheduler steps that validates them before/after execution.
-type StepValidator[S plugins.Step] struct {
+type StepValidator struct {
 	// The wrapped step to validate.
-	Step S
+	Step plugins.Step
 	// By default, we execute all validations. However, through the config,
 	// we can also disable some validations if necessary.
 	DisabledValidations disabledValidations
 }
 
 // Get the name of the wrapped step.
-func (s *StepValidator[S]) GetName() string {
+func (s *StepValidator) GetName() string {
 	return s.Step.GetName()
 }
 
 // Initialize the wrapped step with the database and options.
-func (s *StepValidator[S]) Init(db db.DB, opts conf.RawOpts) error {
+func (s *StepValidator) Init(db db.DB, opts conf.RawOpts) error {
 	slog.Info(
 		"scheduler: init validation for step", "name", s.GetName(),
 		"disabled", s.DisabledValidations,
@@ -42,15 +42,15 @@ func (s *StepValidator[S]) Init(db db.DB, opts conf.RawOpts) error {
 }
 
 // Validate the wrapped step with the database and options.
-func validateStep[S plugins.Step](step S, disabledValidations disabledValidations) *StepValidator[S] {
-	return &StepValidator[S]{
+func validateStep[S plugins.Step](step S, disabledValidations disabledValidations) *StepValidator {
+	return &StepValidator{
 		Step:                step,
 		DisabledValidations: disabledValidations,
 	}
 }
 
 // Run the step and validate what happens.
-func (s *StepValidator[S]) Run(request api.Request) (map[string]float64, error) {
+func (s *StepValidator) Run(request api.Request) (map[string]float64, error) {
 	weights, err := s.Step.Run(request)
 	if err != nil {
 		return nil, err

--- a/internal/scheduler/validation.go
+++ b/internal/scheduler/validation.go
@@ -1,0 +1,65 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package scheduler
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	"github.com/cobaltcore-dev/cortex/internal/scheduler/api"
+	"github.com/cobaltcore-dev/cortex/internal/scheduler/plugins"
+)
+
+// The config type has a long name, so we use a shorter alias here.
+// The name is intentionally long to make it explicit that we disable
+// validations for the scheduler step instead of enabling them.
+type disabledValidations = conf.SchedulerStepDisabledValidationsConfig
+
+// Wrapper for scheduler steps that validates them before/after execution.
+type StepValidator[S plugins.Step] struct {
+	// The wrapped step to validate.
+	Step S
+	// By default, we execute all validations. However, through the config,
+	// we can also disable some validations if necessary.
+	DisabledValidations disabledValidations
+}
+
+// Get the name of the wrapped step.
+func (s *StepValidator[S]) GetName() string {
+	return s.Step.GetName()
+}
+
+// Initialize the wrapped step with the database and options.
+func (s *StepValidator[S]) Init(db db.DB, opts conf.RawOpts) error {
+	slog.Info(
+		"scheduler: init validation for step", "name", s.GetName(),
+		"disabled", s.DisabledValidations,
+	)
+	return s.Step.Init(db, opts)
+}
+
+// Validate the wrapped step with the database and options.
+func validateStep[S plugins.Step](step S, disabledValidations disabledValidations) *StepValidator[S] {
+	return &StepValidator[S]{
+		Step:                step,
+		DisabledValidations: disabledValidations,
+	}
+}
+
+// Run the step and validate what happens.
+func (s *StepValidator[S]) Run(request api.Request) (map[string]float64, error) {
+	weights, err := s.Step.Run(request)
+	if err != nil {
+		return nil, err
+	}
+	// If not disabled, validate that the number of hosts stayed the same.
+	if !s.DisabledValidations.SameHostNumberInOut {
+		if len(weights) != len(request.Hosts) {
+			return nil, errors.New("number of hosts changed during step execution")
+		}
+	}
+	return weights, nil
+}

--- a/internal/scheduler/validation_test.go
+++ b/internal/scheduler/validation_test.go
@@ -1,0 +1,184 @@
+package scheduler
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	"github.com/cobaltcore-dev/cortex/internal/scheduler/api"
+	"github.com/cobaltcore-dev/cortex/internal/scheduler/plugins"
+)
+
+// MockStep is a manual mock implementation of the plugins.Step interface.
+type MockStep struct {
+	Name     string
+	InitFunc func(db db.DB, opts conf.RawOpts) error
+	RunFunc  func(request api.Request) (map[string]float64, error)
+}
+
+func (m *MockStep) GetName() string {
+	return m.Name
+}
+
+func (m *MockStep) Init(db db.DB, opts conf.RawOpts) error {
+	return m.InitFunc(db, opts)
+}
+
+func (m *MockStep) Run(request api.Request) (map[string]float64, error) {
+	return m.RunFunc(request)
+}
+
+func TestStepValidator_GetName(t *testing.T) {
+	mockStep := &MockStep{
+		Name: "mock-step",
+	}
+
+	validator := StepValidator[plugins.Step]{
+		Step: mockStep,
+	}
+
+	if got := validator.GetName(); got != "mock-step" {
+		t.Errorf("GetName() = %v, want %v", got, "mock-step")
+	}
+}
+
+func TestStepValidator_Init(t *testing.T) {
+	mockStep := &MockStep{
+		InitFunc: func(db db.DB, opts conf.RawOpts) error {
+			return nil
+		},
+	}
+
+	testDB := db.DB{}
+	mockOpts := conf.RawOpts{}
+
+	validator := StepValidator[plugins.Step]{
+		Step: mockStep,
+	}
+
+	if err := validator.Init(testDB, mockOpts); err != nil {
+		t.Errorf("Init() error = %v, want nil", err)
+	}
+}
+
+func TestStepValidator_Run_ValidHosts(t *testing.T) {
+	mockStep := &MockStep{
+		RunFunc: func(request api.Request) (map[string]float64, error) {
+			return map[string]float64{
+				"host1": 1.0,
+				"host2": 1.0,
+			}, nil
+		},
+	}
+
+	request := api.Request{
+		Hosts: []api.Host{{ComputeHost: "host1"}, {ComputeHost: "host2"}},
+	}
+
+	validator := StepValidator[plugins.Step]{
+		Step: mockStep,
+		DisabledValidations: conf.SchedulerStepDisabledValidationsConfig{
+			SameHostNumberInOut: false,
+		},
+	}
+
+	weights, err := validator.Run(request)
+	if err != nil {
+		t.Errorf("Run() error = %v, want nil", err)
+	}
+
+	expectedWeights := map[string]float64{
+		"host1": 1.0,
+		"host2": 1.0,
+	}
+
+	if !reflect.DeepEqual(weights, expectedWeights) {
+		t.Errorf("Run() weights = %v, want %v", weights, expectedWeights)
+	}
+}
+
+func TestStepValidator_Run_HostNumberMismatch(t *testing.T) {
+	mockStep := &MockStep{
+		RunFunc: func(request api.Request) (map[string]float64, error) {
+			return map[string]float64{
+				"host1": 1.0,
+			}, nil
+		},
+	}
+
+	request := api.Request{
+		Hosts: []api.Host{{ComputeHost: "host1"}, {ComputeHost: "host2"}},
+	}
+
+	validator := StepValidator[plugins.Step]{
+		Step: mockStep,
+		DisabledValidations: conf.SchedulerStepDisabledValidationsConfig{
+			SameHostNumberInOut: false,
+		},
+	}
+
+	weights, err := validator.Run(request)
+	if err == nil {
+		t.Errorf("Run() error = nil, want error")
+	}
+
+	if weights != nil {
+		t.Errorf("Run() weights = %v, want nil", weights)
+	}
+
+	expectedError := "number of hosts changed during step execution"
+	if err.Error() != expectedError {
+		t.Errorf("Run() error = %v, want %v", err.Error(), expectedError)
+	}
+}
+
+func TestStepValidator_Run_DisabledValidation(t *testing.T) {
+	mockStep := &MockStep{
+		RunFunc: func(request api.Request) (map[string]float64, error) {
+			return map[string]float64{
+				"host1": 1.0,
+			}, nil
+		},
+	}
+
+	request := api.Request{
+		Hosts: []api.Host{{ComputeHost: "host1"}},
+	}
+
+	validator := StepValidator[plugins.Step]{
+		Step: mockStep,
+		DisabledValidations: conf.SchedulerStepDisabledValidationsConfig{
+			SameHostNumberInOut: true, // Validation is disabled
+		},
+	}
+
+	weights, err := validator.Run(request)
+	if err != nil {
+		t.Errorf("Run() error = %v, want nil", err)
+	}
+
+	expectedWeights := map[string]float64{
+		"host1": 1.0,
+	}
+
+	if !reflect.DeepEqual(weights, expectedWeights) {
+		t.Errorf("Run() weights = %v, want %v", weights, expectedWeights)
+	}
+}
+
+func TestValidateStep(t *testing.T) {
+	mockStep := &MockStep{}
+	disabledValidations := conf.SchedulerStepDisabledValidationsConfig{
+		SameHostNumberInOut: true,
+	}
+
+	validator := validateStep(mockStep, disabledValidations)
+	if validator.Step != mockStep {
+		t.Errorf("validateStep() Step = %v, want %v", validator.Step, mockStep)
+	}
+
+	if !reflect.DeepEqual(validator.DisabledValidations, disabledValidations) {
+		t.Errorf("validateStep() DisabledValidations = %v, want %v", validator.DisabledValidations, disabledValidations)
+	}
+}

--- a/internal/scheduler/validation_test.go
+++ b/internal/scheduler/validation_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
 package scheduler
 
 import (

--- a/internal/scheduler/validation_test.go
+++ b/internal/scheduler/validation_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/conf"
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/scheduler/api"
-	"github.com/cobaltcore-dev/cortex/internal/scheduler/plugins"
 )
 
 // MockStep is a manual mock implementation of the plugins.Step interface.
@@ -37,7 +36,7 @@ func TestStepValidator_GetName(t *testing.T) {
 		Name: "mock-step",
 	}
 
-	validator := StepValidator[plugins.Step]{
+	validator := StepValidator{
 		Step: mockStep,
 	}
 
@@ -56,7 +55,7 @@ func TestStepValidator_Init(t *testing.T) {
 	testDB := db.DB{}
 	mockOpts := conf.RawOpts{}
 
-	validator := StepValidator[plugins.Step]{
+	validator := StepValidator{
 		Step: mockStep,
 	}
 
@@ -79,7 +78,7 @@ func TestStepValidator_Run_ValidHosts(t *testing.T) {
 		Hosts: []api.Host{{ComputeHost: "host1"}, {ComputeHost: "host2"}},
 	}
 
-	validator := StepValidator[plugins.Step]{
+	validator := StepValidator{
 		Step: mockStep,
 		DisabledValidations: conf.SchedulerStepDisabledValidationsConfig{
 			SameHostNumberInOut: false,
@@ -114,7 +113,7 @@ func TestStepValidator_Run_HostNumberMismatch(t *testing.T) {
 		Hosts: []api.Host{{ComputeHost: "host1"}, {ComputeHost: "host2"}},
 	}
 
-	validator := StepValidator[plugins.Step]{
+	validator := StepValidator{
 		Step: mockStep,
 		DisabledValidations: conf.SchedulerStepDisabledValidationsConfig{
 			SameHostNumberInOut: false,
@@ -149,7 +148,7 @@ func TestStepValidator_Run_DisabledValidation(t *testing.T) {
 		Hosts: []api.Host{{ComputeHost: "host1"}},
 	}
 
-	validator := StepValidator[plugins.Step]{
+	validator := StepValidator{
 		Step: mockStep,
 		DisabledValidations: conf.SchedulerStepDisabledValidationsConfig{
 			SameHostNumberInOut: true, // Validation is disabled


### PR DESCRIPTION
- Add step validator as wrapper, similar to step monitor
- Move general logging out of step monitor
- Enable all validations by default, but can be disabled through config
- No generics in step monitor