### PR TITLE
Remove archived gopkg.in/yaml.v3 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,6 @@ require (
 	github.com/sapcc/go-api-declarations v1.14.3
 	github.com/sapcc/go-bits v0.0.0-20250410003731-7b4174e5d933
 	go.uber.org/automaxprocs v1.6.0
-	// TODO: We should replace this package, since the author decided to
-	// archive it on 1st of April 2025 (unfortunately no April fools joke).
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -53,7 +50,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 // indirect
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,12 +104,8 @@ github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYW
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
-github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
@@ -173,8 +169,6 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
-github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
-github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sapcc/go-api-declarations v1.14.3 h1:iDmwB8LGO+tkgW4A4nh1pILWIs7w4AM6f7SSMZtltSk=
 github.com/sapcc/go-api-declarations v1.14.3/go.mod h1:KEYQoknn0gSjhmI19b85YUEZkav9SOu2bC21VeDNlnU=
@@ -280,8 +274,6 @@ google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojt
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/helm/cortex/templates/_conf.yaml.tpl
+++ b/helm/cortex/templates/_conf.yaml.tpl
@@ -1,6 +1,0 @@
-# Copyright 2025 SAP SE
-# SPDX-License-Identifier: Apache-2.0
-
-{{- if .Values.conf }}
-{{ toYaml .Values.conf }}
-{{- end }}

--- a/helm/cortex/templates/configmap.yaml
+++ b/helm/cortex/templates/configmap.yaml
@@ -6,5 +6,9 @@ kind: ConfigMap
 metadata:
   name: {{ include "cortex.fullname" . }}-config
 data:
-  conf.yaml: |-
-{{ include "cortex/templates/_conf.yaml.tpl" . | nindent 4 }}
+  conf.json: |-
+    {{- if .Values.conf }}
+    {{ toJson .Values.conf }}
+    {{- else }}
+    {}
+    {{- end }}

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -4,147 +4,146 @@
 package conf
 
 import (
+	"encoding/json"
 	"io"
 	"os"
-
-	"gopkg.in/yaml.v3"
 )
 
 // Configuration for single-sign-on (SSO).
 type SSOConfig struct {
-	Cert    string `yaml:"cert,omitempty"`
-	CertKey string `yaml:"certKey,omitempty"`
+	Cert    string `json:"cert,omitempty"`
+	CertKey string `json:"certKey,omitempty"`
 
 	// If the certificate is self-signed, we need to skip verification.
-	SelfSigned bool `yaml:"selfSigned,omitempty"`
+	SelfSigned bool `json:"selfSigned,omitempty"`
 }
 
 // Configuration for structured logging.
 type LoggingConfig struct {
 	// The log level to use (debug, info, warn, error).
-	LevelStr string `yaml:"level"`
+	LevelStr string `json:"level"`
 	// The log format to use (json, text).
-	Format string `yaml:"format"`
+	Format string `json:"format"`
 }
 
 // Database configuration.
 type DBConfig struct {
-	Host     string `yaml:"host"`
-	Port     string `yaml:"port"`
-	Database string `yaml:"database"`
-	User     string `yaml:"user"`
-	Password string `yaml:"password"`
+	Host     string `json:"host"`
+	Port     string `json:"port"`
+	Database string `json:"database"`
+	User     string `json:"user"`
+	Password string `json:"password"`
 }
 
 // Metric configuration for the sync/prometheus module.
 type SyncPrometheusMetricConfig struct {
 	// The query to use to fetch the metric.
-	Query string `yaml:"query"`
+	Query string `json:"query"`
 	// Especially when a more complex query is used, we need an alias
 	// under which the table will be stored in the database.
 	// Additionally, this alias is used to reference the metric in the
 	// feature extractors as dependency.
-	Alias string `yaml:"alias"`
+	Alias string `json:"alias"`
 	// The type of the metric, mapping directly to a metric model.
-	Type string `yaml:"type"`
+	Type string `json:"type"`
 
-	TimeRangeSeconds  *int `yaml:"timeRangeSeconds,omitempty"`
-	IntervalSeconds   *int `yaml:"intervalSeconds,omitempty"`
-	ResolutionSeconds *int `yaml:"resolutionSeconds,omitempty"`
+	TimeRangeSeconds  *int `json:"timeRangeSeconds,omitempty"`
+	IntervalSeconds   *int `json:"intervalSeconds,omitempty"`
+	ResolutionSeconds *int `json:"resolutionSeconds,omitempty"`
 }
 
 // Configuration for a single prometheus host.
 type SyncPrometheusHostConfig struct {
 	// The name of the prometheus host.
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 	// The URL of the prometheus host.
-	URL string `yaml:"url"`
+	URL string `json:"url"`
 	// The SSO configuration for this host.
-	SSO SSOConfig `yaml:"sso,omitempty"`
+	SSO SSOConfig `json:"sso,omitempty"`
 	// The types of metrics this host provides.
-	ProvidedMetricTypes []string `yaml:"provides"`
+	ProvidedMetricTypes []string `json:"provides"`
 }
 
 // Configuration for the sync/prometheus module containing a list of metrics.
 type SyncPrometheusConfig struct {
-	Hosts   []SyncPrometheusHostConfig   `yaml:"hosts,omitempty"`
-	Metrics []SyncPrometheusMetricConfig `yaml:"metrics,omitempty"`
+	Hosts   []SyncPrometheusHostConfig   `json:"hosts,omitempty"`
+	Metrics []SyncPrometheusMetricConfig `json:"metrics,omitempty"`
 }
 
 // Configuration for the sync/openstack module.
 type SyncOpenStackConfig struct {
 	// Configuration for the keystone service.
-	Keystone SyncOpenStackKeystoneConfig `yaml:"keystone"`
+	Keystone SyncOpenStackKeystoneConfig `json:"keystone"`
 	// Configuration for the nova service.
-	Nova SyncOpenStackNovaConfig `yaml:"nova"`
+	Nova SyncOpenStackNovaConfig `json:"nova"`
 	// Configuration for the placement service.
-	Placement SyncOpenStackPlacementConfig `yaml:"placement"`
+	Placement SyncOpenStackPlacementConfig `json:"placement"`
 }
 
 // Configuration for the keystone authentication.
 type SyncOpenStackKeystoneConfig struct {
 	// The URL of the keystone service.
-	URL string `yaml:"url"`
+	URL string `json:"url"`
 	// The SSO certificate to use. If none is given, we won't
 	// use SSO to connect to the openstack services.
-	SSO SSOConfig `yaml:"sso,omitempty"`
+	SSO SSOConfig `json:"sso,omitempty"`
 	// The OpenStack username (OS_USERNAME in openstack cli).
-	OSUsername string `yaml:"username"`
+	OSUsername string `json:"username"`
 	// The OpenStack password (OS_PASSWORD in openstack cli).
-	OSPassword string `yaml:"password"`
+	OSPassword string `json:"password"`
 	// The OpenStack project name (OS_PROJECT_NAME in openstack cli).
-	OSProjectName string `yaml:"projectName"`
+	OSProjectName string `json:"projectName"`
 	// The OpenStack user domain name (OS_USER_DOMAIN_NAME in openstack cli).
-	OSUserDomainName string `yaml:"userDomainName"`
+	OSUserDomainName string `json:"userDomainName"`
 	// The OpenStack project domain name (OS_PROJECT_DOMAIN_NAME in openstack cli).
-	OSProjectDomainName string `yaml:"projectDomainName"`
+	OSProjectDomainName string `json:"projectDomainName"`
 }
 
 // Configuration for the nova service.
 type SyncOpenStackNovaConfig struct {
 	// Availability of the service, such as "public", "internal", or "admin".
-	Availability string `yaml:"availability"`
+	Availability string `json:"availability"`
 	// The types of resources to sync.
-	Types []string `yaml:"types"`
+	Types []string `json:"types"`
 }
 
 // Configuration for the placement service.
 type SyncOpenStackPlacementConfig struct {
 	// Availability of the service, such as "public", "internal", or "admin".
-	Availability string `yaml:"availability"`
+	Availability string `json:"availability"`
 	// The types of resources to sync.
-	Types []string `yaml:"types"`
+	Types []string `json:"types"`
 }
 
 // Configuration for the sync module.
 type SyncConfig struct {
-	Prometheus SyncPrometheusConfig `yaml:"prometheus"`
-	OpenStack  SyncOpenStackConfig  `yaml:"openstack"`
+	Prometheus SyncPrometheusConfig `json:"prometheus"`
+	OpenStack  SyncOpenStackConfig  `json:"openstack"`
 }
 
 type FeatureExtractorConfig struct {
 	// The name of the extractor.
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 	// Custom options for the extractor, as a raw yaml map.
-	Options RawOpts `yaml:"options,omitempty"`
+	Options RawOpts `json:"options,omitempty"`
 	// The dependencies this extractor needs.
-	DependencyConfig `yaml:"dependencies,omitempty"`
+	DependencyConfig `json:"dependencies,omitempty"`
 }
 
 // Configuration for the features module.
 type FeaturesConfig struct {
-	Extractors []FeatureExtractorConfig `yaml:"extractors"`
+	Extractors []FeatureExtractorConfig `json:"extractors"`
 }
 
 type SchedulerStepConfig struct {
 	// The name of the step.
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 	// Custom options for the step, as a raw yaml map.
-	Options RawOpts `yaml:"options,omitempty"`
+	Options RawOpts `json:"options,omitempty"`
 	// The dependencies this step needs.
-	DependencyConfig `yaml:"dependencies,omitempty"`
+	DependencyConfig `json:"dependencies,omitempty"`
 	// The validations to use for this step.
-	DisabledValidations SchedulerStepDisabledValidationsConfig `yaml:"disabledValidations,omitempty"`
+	DisabledValidations SchedulerStepDisabledValidationsConfig `json:"disabledValidations,omitempty"`
 }
 
 // Config for which validations to disable for a scheduler step.
@@ -152,43 +151,43 @@ type SchedulerStepDisabledValidationsConfig struct {
 	// Whether to validate that no hosts are removed or added from the scheduler
 	// step. This should only be disabled for scheduler steps that remove hosts.
 	// Thus, if no value is provided, the default is false.
-	SameHostNumberInOut bool `yaml:"sameHostNumberInOut,omitempty"`
+	SameHostNumberInOut bool `json:"sameHostNumberInOut,omitempty"`
 }
 
 // Configuration for the scheduler module.
 type SchedulerConfig struct {
 	// Scheduler steps by their name.
-	Steps []SchedulerStepConfig `yaml:"steps"`
+	Steps []SchedulerStepConfig `json:"steps"`
 
-	API SchedulerAPIConfig `yaml:"api"`
+	API SchedulerAPIConfig `json:"api"`
 }
 
 // Configuration for the scheduler API.
 type SchedulerAPIConfig struct {
 	// If request bodies should be logged out.
 	// This feature is intended for debugging purposes only.
-	LogRequestBodies bool `yaml:"logRequestBodies"`
+	LogRequestBodies bool `json:"logRequestBodies"`
 
 	// The port to use for the scheduler API.
-	Port int `yaml:"port"`
+	Port int `json:"port"`
 }
 
 // Configuration for the monitoring module.
 type MonitoringConfig struct {
 	// The labels to add to all metrics.
-	Labels map[string]string `yaml:"labels"`
+	Labels map[string]string `json:"labels"`
 
 	// The port to expose the metrics on.
-	Port int `yaml:"port"`
+	Port int `json:"port"`
 }
 
 // Configuration for the mqtt client.
 type MQTTConfig struct {
 	// The URL of the MQTT broker to use for mqtt.
-	URL string `yaml:"url"`
+	URL string `json:"url"`
 	// Credentials for the MQTT broker.
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 // Configuration for the cortex service.
@@ -205,13 +204,13 @@ type Config interface {
 }
 
 type config struct {
-	LoggingConfig    `yaml:"logging"`
-	DBConfig         `yaml:"db"`
-	SyncConfig       `yaml:"sync"`
-	FeaturesConfig   `yaml:"features"`
-	SchedulerConfig  `yaml:"scheduler"`
-	MonitoringConfig `yaml:"monitoring"`
-	MQTTConfig       `yaml:"mqtt"`
+	LoggingConfig    `json:"logging"`
+	DBConfig         `json:"db"`
+	SyncConfig       `json:"sync"`
+	FeaturesConfig   `json:"features"`
+	SchedulerConfig  `json:"scheduler"`
+	MonitoringConfig `json:"monitoring"`
+	MQTTConfig       `json:"mqtt"`
 }
 
 // Create a new configuration from the default config yaml file.
@@ -236,7 +235,7 @@ func newConfigFromFile(filepath string) Config {
 // Create a new configuration from the given bytes.
 func newConfigFromBytes(bytes []byte) Config {
 	var c config
-	if err := yaml.Unmarshal(bytes, &c); err != nil {
+	if err := json.Unmarshal(bytes, &c); err != nil {
 		panic(err)
 	}
 	return &c

--- a/internal/conf/opts.go
+++ b/internal/conf/opts.go
@@ -3,46 +3,46 @@
 
 package conf
 
-import "gopkg.in/yaml.v3"
+import "encoding/json"
 
-// Raw options that are not directly unmarshalled when loading from yaml.
+// Raw options that are not directly unmarshalled when loading from json.
 // Usage: call Unmarshal to unmarshal the options into a struct.
 type RawOpts struct {
 	// Postponed unmarshal function.
 	unmarshal func(any) error
 }
 
-// Create a new RawOpts instance with the given yaml string.
-func NewRawOpts(rawYaml string) RawOpts {
+// Create a new RawOpts instance with the given json string.
+func NewRawOpts(rawJson string) RawOpts {
 	return RawOpts{unmarshal: func(v any) error {
-		return yaml.Unmarshal([]byte(rawYaml), v)
+		return json.Unmarshal([]byte(rawJson), v)
 	}}
 }
 
 // Call the postponed unmarshal function and unmarshal the options into a struct.
 func (msg *RawOpts) Unmarshal(v any) error {
 	if msg.unmarshal == nil {
-		// No unmarshal function set (e.g. empty yaml), return nil.
+		// No unmarshal function set (e.g. empty json), return nil.
 		return nil
 	}
 	return msg.unmarshal(v)
 }
 
-// Override the default yaml unmarshal behavior to postpone the unmarshal.
-func (msg *RawOpts) UnmarshalYAML(unmarshal func(any) error) error {
+// Override the default json unmarshal behavior to postpone the unmarshal.
+func (msg *RawOpts) UnmarshalJSON(unmarshal func(any) error) error {
 	msg.unmarshal = unmarshal
 	return nil
 }
 
-// Mixin that adds the ability to load options from a yaml map.
-// Usage: type StructUsingOpts struct { conf.YamlOpts[MyOpts] }
-type YamlOpts[Options any] struct {
-	// Options loaded from a yaml config using the Load method.
+// Mixin that adds the ability to load options from a json map.
+// Usage: type StructUsingOpts struct { conf.JsonOpts[MyOpts] }
+type JsonOpts[Options any] struct {
+	// Options loaded from a json config using the Load method.
 	Options Options
 }
 
-// Set the options contained in the opts yaml map.
-func (s *YamlOpts[Options]) Load(opts RawOpts) error {
+// Set the options contained in the opts json map.
+func (s *JsonOpts[Options]) Load(opts RawOpts) error {
 	var o Options
 	if err := opts.Unmarshal(&o); err != nil {
 		return err

--- a/internal/conf/opts_test.go
+++ b/internal/conf/opts_test.go
@@ -8,25 +8,25 @@ import (
 )
 
 type MockOptions struct {
-	Option1 string `yaml:"option1"`
-	Option2 int    `yaml:"option2"`
+	Option1 string `json:"option1"`
+	Option2 int    `json:"option2"`
 }
 
-func TestYamlOpts(t *testing.T) {
-	opts := NewRawOpts(`
-        option1: value1
-        option2: 2
-    `)
+func TestJsonOpts(t *testing.T) {
+	opts := NewRawOpts(`{
+        "option1": "value1",
+        "option2": 2
+    }`)
 
-	yamlOpts := YamlOpts[MockOptions]{}
-	err := yamlOpts.Load(opts)
+	jsonOpts := JsonOpts[MockOptions]{}
+	err := jsonOpts.Load(opts)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if yamlOpts.Options.Option1 != "value1" {
-		t.Errorf("expected option1 to be 'value1', got %v", yamlOpts.Options.Option1)
+	if jsonOpts.Options.Option1 != "value1" {
+		t.Errorf("expected option1 to be 'value1', got %v", jsonOpts.Options.Option1)
 	}
-	if yamlOpts.Options.Option2 != 2 {
-		t.Errorf("expected option2 to be 2, got %v", yamlOpts.Options.Option2)
+	if jsonOpts.Options.Option2 != 2 {
+		t.Errorf("expected option2 to be 2, got %v", jsonOpts.Options.Option2)
 	}
 }

--- a/internal/conf/validation.go
+++ b/internal/conf/validation.go
@@ -16,24 +16,24 @@ type DependencyConfig struct {
 	Sync struct {
 		OpenStack struct {
 			Nova struct {
-				ObjectTypes []string `yaml:"types,omitempty"`
-			} `yaml:"nova,omitempty"`
+				ObjectTypes []string `json:"types,omitempty"`
+			} `json:"nova,omitempty"`
 			Placement struct {
-				ObjectTypes []string `yaml:"types,omitempty"`
-			} `yaml:"placement,omitempty"`
-		} `yaml:"openstack,omitempty"`
+				ObjectTypes []string `json:"types,omitempty"`
+			} `json:"placement,omitempty"`
+		} `json:"openstack,omitempty"`
 		Prometheus struct {
 			Metrics []struct {
-				Alias string `yaml:"alias,omitempty"`
-				Type  string `yaml:"type,omitempty"`
-			} `yaml:"metrics,omitempty"`
-		} `yaml:"prometheus,omitempty"`
+				Alias string `json:"alias,omitempty"`
+				Type  string `json:"type,omitempty"`
+			} `json:"metrics,omitempty"`
+		} `json:"prometheus,omitempty"`
 	}
-	Features FeaturesDependency `yaml:"features,omitempty"`
+	Features FeaturesDependency `json:"features,omitempty"`
 }
 
 type FeaturesDependency struct {
-	ExtractorNames []string `yaml:"extractors,omitempty"`
+	ExtractorNames []string `json:"extractors,omitempty"`
 }
 
 // Validate if the dependencies are satisfied in the given config.

--- a/internal/conf/validation_test.go
+++ b/internal/conf/validation_test.go
@@ -7,46 +7,83 @@ import "testing"
 
 func TestValidConf(t *testing.T) {
 	content := `
-sync:
-  prometheus:
-    hosts:
-      - name: prometheus
-        url: http://prometheus:9090
-        provides: [metric_type_1]
-    metrics:
-      - alias: metric_1
-        query: metric_1
-        type: metric_type_1
-  openstack:
-    nova:
-      types:
-        - servers
-features:
-  extractors:
-    - name: extractor_1
-      dependencies:
-        sync:
-          prometheus:
-            metrics:
-              - alias: metric_1
-          openstack:
-            nova:
-              types:
-                - servers
-    - name: extractor_2
-      dependencies:
-        sync:
-          prometheus:
-            metrics:
-              - type: metric_type_1
-scheduler:
-  steps:
-    - name: scheduler_1
-      dependencies:
-        features:
-          extractors:
-            - extractor_1
-    - name: scheduler_2
+{
+  "sync": {
+    "prometheus": {
+      "hosts": [
+        {
+          "name": "prometheus",
+          "url": "http://prometheus:9090",
+          "provides": ["metric_type_1"]
+        }
+      ],
+      "metrics": [
+        {
+          "alias": "metric_1",
+          "query": "metric_1",
+          "type": "metric_type_1"
+        }
+      ]
+    },
+    "openstack": {
+      "nova": {
+        "types": ["servers"]
+      }
+    }
+  },
+  "features": {
+    "extractors": [
+      {
+        "name": "extractor_1",
+        "dependencies": {
+          "sync": {
+            "prometheus": {
+              "metrics": [
+                {
+                  "alias": "metric_1"
+                }
+              ]
+            },
+            "openstack": {
+              "nova": {
+                "types": ["servers"]
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "extractor_2",
+        "dependencies": {
+          "sync": {
+            "prometheus": {
+              "metrics": [
+                {
+                  "type": "metric_type_1"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "scheduler": {
+    "steps": [
+      {
+        "name": "scheduler_1",
+        "dependencies": {
+          "features": {
+            "extractors": ["extractor_1"]
+          }
+        }
+      },
+      {
+        "name": "scheduler_2"
+      }
+    ]
+  }
+}
 `
 	conf := newConfigFromBytes([]byte(content))
 	if err := conf.Validate(); err != nil {
@@ -56,25 +93,44 @@ scheduler:
 
 func TestInvalidConf_MissingNovaDependency(t *testing.T) {
 	content := `
-sync:
-  prometheus:
-    metrics:
-      - alias: metric_1
-        query: metric_1
-        type: metric_type_1
-features:
-  extractors:
-    - name: extractor_1
-      dependencies:
-        sync:
-          prometheus:
-            metrics:
-              - alias: metric_1
-          openstack:
-            nova:
-              types:
-                # missing dependency
-                - hypervisors
+{
+  "sync": {
+    "prometheus": {
+      "metrics": [
+        {
+          "alias": "metric_1",
+          "query": "metric_1",
+          "type": "metric_type_1"
+        }
+      ]
+    }
+  },
+  "features": {
+    "extractors": [
+      {
+        "name": "extractor_1",
+        "dependencies": {
+          "sync": {
+            "prometheus": {
+              "metrics": [
+                {
+                  "alias": "metric_1"
+                }
+              ]
+            },
+            "openstack": {
+              "nova": {
+                "types": [
+                  "hypervisors"
+                ]
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}
 `
 	conf := newConfigFromBytes([]byte(content))
 	if err := conf.Validate(); err == nil {
@@ -84,12 +140,17 @@ features:
 
 func TestInvalidConf_MissingResourceProviders(t *testing.T) {
 	content := `
-sync:
-  openstack:
-    placement:
-      types:
-        # missing resource_providers
-        - traits
+{
+  "sync": {
+    "openstack": {
+      "placement": {
+        "types": [
+          "traits"
+        ]
+      }
+    }
+  }
+}
 `
 	conf := newConfigFromBytes([]byte(content))
 	if err := conf.Validate(); err == nil {
@@ -99,10 +160,15 @@ sync:
 
 func TestInvalidConf_InvalidServiceAvailability(t *testing.T) {
 	content := `
-sync:
-  openstack:
-    placement:
-      availability: whatever
+{
+  "sync": {
+    "openstack": {
+      "placement": {
+        "availability": "whatever"
+      }
+    }
+  }
+}
 `
 	conf := newConfigFromBytes([]byte(content))
 	if err := conf.Validate(); err == nil {
@@ -112,12 +178,19 @@ sync:
 
 func TestInvalidConf_MissingHost(t *testing.T) {
 	content := `
-sync:
-  prometheus:
-    metrics:
-      - alias: metric_1
-        query: metric_1
-        type: metric_type_1
+{
+  "sync": {
+    "prometheus": {
+      "metrics": [
+        {
+          "alias": "metric_1",
+          "query": "metric_1",
+          "type": "metric_type_1"
+        }
+      ]
+    }
+  }
+}
 `
 	conf := newConfigFromBytes([]byte(content))
 	if err := conf.Validate(); err == nil {

--- a/internal/features/plugins/base.go
+++ b/internal/features/plugins/base.go
@@ -14,7 +14,7 @@ import (
 // that would otherwise be duplicated across all extractors.
 type BaseExtractor[Opts any, Feature db.Table] struct {
 	// Options to pass via yaml to this step.
-	conf.YamlOpts[Opts]
+	conf.JsonOpts[Opts]
 	// Database connection.
 	DB db.DB
 }

--- a/internal/features/plugins/base_test.go
+++ b/internal/features/plugins/base_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 type MockOptions struct {
-	Option1 string `yaml:"option1"`
-	Option2 int    `yaml:"option2"`
+	Option1 string `json:"option1"`
+	Option2 int    `json:"option2"`
 }
 
 type MockFeature struct {
@@ -31,10 +31,10 @@ func TestBaseExtractor_Init(t *testing.T) {
 	defer testDB.Close()
 	defer dbEnv.Close()
 
-	opts := conf.NewRawOpts(`
-        option1: value1
-        option2: 2
-    `)
+	opts := conf.NewRawOpts(`{
+        "option1": "value1",
+        "option2": 2
+    }`)
 
 	extractor := BaseExtractor[MockOptions, MockFeature]{}
 	err := extractor.Init(testDB, opts)

--- a/internal/features/plugins/kvm/node_exporter_host_cpu_usage_test.go
+++ b/internal/features/plugins/kvm/node_exporter_host_cpu_usage_test.go
@@ -19,7 +19,7 @@ func TestNodeExporterHostCPUUsageExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &NodeExporterHostCPUUsageExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -54,7 +54,7 @@ func TestNodeExporterHostCPUUsageExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &NodeExporterHostCPUUsageExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err = extractor.Extract(); err != nil {

--- a/internal/features/plugins/kvm/node_exporter_host_memory_active_test.go
+++ b/internal/features/plugins/kvm/node_exporter_host_memory_active_test.go
@@ -19,7 +19,7 @@ func TestNodeExporterHostMemoryActiveExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &NodeExporterHostMemoryActiveExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -54,7 +54,7 @@ func TestNodeExporterHostMemoryActiveExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &NodeExporterHostMemoryActiveExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err = extractor.Extract(); err != nil {

--- a/internal/features/plugins/shared/flavor_host_space_test.go
+++ b/internal/features/plugins/shared/flavor_host_space_test.go
@@ -19,7 +19,7 @@ func TestFlavorHostSpaceExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &FlavorHostSpaceExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -60,7 +60,7 @@ func TestFlavorHostSpaceExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &FlavorHostSpaceExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err := extractor.Extract(); err != nil {

--- a/internal/features/plugins/vmware/vrops_hostsystem_contention_test.go
+++ b/internal/features/plugins/vmware/vrops_hostsystem_contention_test.go
@@ -19,7 +19,7 @@ func TestVROpsHostsystemContentionExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &VROpsHostsystemContentionExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -66,7 +66,7 @@ func TestVROpsHostsystemContentionExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &VROpsHostsystemContentionExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err = extractor.Extract(); err != nil {

--- a/internal/features/plugins/vmware/vrops_hostsystem_resolver_test.go
+++ b/internal/features/plugins/vmware/vrops_hostsystem_resolver_test.go
@@ -20,7 +20,7 @@ func TestVROpsHostsystemResolver_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &VROpsHostsystemResolver{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -79,7 +79,7 @@ func TestVROpsHostsystemResolver_Extract(t *testing.T) {
 	}
 
 	extractor := &VROpsHostsystemResolver{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err := extractor.Extract(); err != nil {

--- a/internal/features/plugins/vmware/vrops_project_noisiness_test.go
+++ b/internal/features/plugins/vmware/vrops_project_noisiness_test.go
@@ -20,7 +20,7 @@ func TestVROpsProjectNoisinessExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &VROpsProjectNoisinessExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	// Will fail when the table does not exist
@@ -78,7 +78,7 @@ func TestVROpsProjectNoisinessExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &VROpsProjectNoisinessExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("")); err != nil {
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err := extractor.Extract(); err != nil {

--- a/internal/scheduler/plugins/base.go
+++ b/internal/scheduler/plugins/base.go
@@ -24,7 +24,7 @@ func (o EmptyStepOpts) Validate() error { return nil }
 // that would otherwise be duplicated across all steps.
 type BaseStep[Opts StepOpts] struct {
 	// Options to pass via yaml to this step.
-	conf.YamlOpts[Opts]
+	conf.JsonOpts[Opts]
 	// The activation function to use.
 	ActivationFunction
 	// Database connection.

--- a/internal/scheduler/plugins/base_test.go
+++ b/internal/scheduler/plugins/base_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 type MockOptions struct {
-	Option1 string `yaml:"option1"`
-	Option2 int    `yaml:"option2"`
+	Option1 string `json:"option1"`
+	Option2 int    `json:"option2"`
 }
 
 func (o MockOptions) Validate() error {
@@ -26,10 +26,10 @@ func TestBaseStep_Init(t *testing.T) {
 	defer testDB.Close()
 	defer dbEnv.Close()
 
-	opts := conf.NewRawOpts(`
-        option1: value1
-        option2: 2
-    `)
+	opts := conf.NewRawOpts(`{
+        "option1": "value1",
+        "option2": 2
+    }`)
 
 	step := BaseStep[MockOptions]{}
 	err := step.Init(testDB, opts)

--- a/internal/scheduler/plugins/kvm/avoid_overloaded_hosts_cpu.go
+++ b/internal/scheduler/plugins/kvm/avoid_overloaded_hosts_cpu.go
@@ -14,17 +14,17 @@ import (
 // Options for the scheduling step, given through the step config in the service yaml file.
 // Use the options contained in this struct to configure the bounds for min-max scaling.
 type AvoidOverloadedHostsCPUStepOpts struct {
-	AvgCPUUsageLowerBound float64 `yaml:"avgCPUUsageLowerBound"` // -> mapped to ActivationLowerBound
-	AvgCPUUsageUpperBound float64 `yaml:"avgCPUUsageUpperBound"` // -> mapped to ActivationUpperBound
+	AvgCPUUsageLowerBound float64 `json:"avgCPUUsageLowerBound"` // -> mapped to ActivationLowerBound
+	AvgCPUUsageUpperBound float64 `json:"avgCPUUsageUpperBound"` // -> mapped to ActivationUpperBound
 
-	AvgCPUUsageActivationLowerBound float64 `yaml:"avgCPUUsageActivationLowerBound"`
-	AvgCPUUsageActivationUpperBound float64 `yaml:"avgCPUUsageActivationUpperBound"`
+	AvgCPUUsageActivationLowerBound float64 `json:"avgCPUUsageActivationLowerBound"`
+	AvgCPUUsageActivationUpperBound float64 `json:"avgCPUUsageActivationUpperBound"`
 
-	MaxCPUUsageLowerBound float64 `yaml:"maxCPUUsageLowerBound"` // -> mapped to ActivationLowerBound
-	MaxCPUUsageUpperBound float64 `yaml:"maxCPUUsageUpperBound"` // -> mapped to ActivationUpperBound
+	MaxCPUUsageLowerBound float64 `json:"maxCPUUsageLowerBound"` // -> mapped to ActivationLowerBound
+	MaxCPUUsageUpperBound float64 `json:"maxCPUUsageUpperBound"` // -> mapped to ActivationUpperBound
 
-	MaxCPUUsageActivationLowerBound float64 `yaml:"maxCPUUsageActivationLowerBound"`
-	MaxCPUUsageActivationUpperBound float64 `yaml:"maxCPUUsageActivationUpperBound"`
+	MaxCPUUsageActivationLowerBound float64 `json:"maxCPUUsageActivationLowerBound"`
+	MaxCPUUsageActivationUpperBound float64 `json:"maxCPUUsageActivationUpperBound"`
 }
 
 func (o AvoidOverloadedHostsCPUStepOpts) Validate() error {

--- a/internal/scheduler/plugins/kvm/avoid_overloaded_hosts_cpu_test.go
+++ b/internal/scheduler/plugins/kvm/avoid_overloaded_hosts_cpu_test.go
@@ -38,18 +38,16 @@ func TestAvoidOverloadedHostsCPUStep_Run(t *testing.T) {
 	}
 
 	// Create an instance of the step
-	opts := conf.NewRawOpts(`
-        # Min-max scaling for avg CPU usage on the host.
-        avgCPUUsageLowerBound: 10
-        avgCPUUsageUpperBound: 100
-        avgCPUUsageActivationLowerBound: 0.0
-        avgCPUUsageActivationUpperBound: -0.5
-        # Min-max scaling for max CPU usage on the host.
-        maxCPUUsageLowerBound: 20
-        maxCPUUsageUpperBound: 100
-        maxCPUUsageActivationLowerBound: 0.0
-        maxCPUUsageActivationUpperBound: -0.5
-    `)
+	opts := conf.NewRawOpts(`{
+        "avgCPUUsageLowerBound": 10,
+        "avgCPUUsageUpperBound": 100,
+        "avgCPUUsageActivationLowerBound": 0.0,
+        "avgCPUUsageActivationUpperBound": -0.5,
+        "maxCPUUsageLowerBound": 20,
+        "maxCPUUsageUpperBound": 100,
+        "maxCPUUsageActivationLowerBound": 0.0,
+        "maxCPUUsageActivationUpperBound": -0.5
+    }`)
 	step := &AvoidOverloadedHostsCPUStep{}
 	if err := step.Init(testDB, opts); err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/internal/scheduler/plugins/kvm/avoid_overloaded_hosts_memory.go
+++ b/internal/scheduler/plugins/kvm/avoid_overloaded_hosts_memory.go
@@ -14,17 +14,17 @@ import (
 // Options for the scheduling step, given through the step config in the service yaml file.
 // Use the options contained in this struct to configure the bounds for min-max scaling.
 type AvoidOverloadedHostsMemoryStepOpts struct {
-	AvgMemoryUsageLowerBound float64 `yaml:"avgMemoryUsageLowerBound"` // -> mapped to ActivationLowerBound
-	AvgMemoryUsageUpperBound float64 `yaml:"avgMemoryUsageUpperBound"` // -> mapped to ActivationUpperBound
+	AvgMemoryUsageLowerBound float64 `json:"avgMemoryUsageLowerBound"` // -> mapped to ActivationLowerBound
+	AvgMemoryUsageUpperBound float64 `json:"avgMemoryUsageUpperBound"` // -> mapped to ActivationUpperBound
 
-	AvgMemoryUsageActivationLowerBound float64 `yaml:"avgMemoryUsageActivationLowerBound"`
-	AvgMemoryUsageActivationUpperBound float64 `yaml:"avgMemoryUsageActivationUpperBound"`
+	AvgMemoryUsageActivationLowerBound float64 `json:"avgMemoryUsageActivationLowerBound"`
+	AvgMemoryUsageActivationUpperBound float64 `json:"avgMemoryUsageActivationUpperBound"`
 
-	MaxMemoryUsageLowerBound float64 `yaml:"maxMemoryUsageLowerBound"` // -> mapped to ActivationLowerBound
-	MaxMemoryUsageUpperBound float64 `yaml:"maxMemoryUsageUpperBound"` // -> mapped to ActivationUpperBound
+	MaxMemoryUsageLowerBound float64 `json:"maxMemoryUsageLowerBound"` // -> mapped to ActivationLowerBound
+	MaxMemoryUsageUpperBound float64 `json:"maxMemoryUsageUpperBound"` // -> mapped to ActivationUpperBound
 
-	MaxMemoryUsageActivationLowerBound float64 `yaml:"maxMemoryUsageActivationLowerBound"`
-	MaxMemoryUsageActivationUpperBound float64 `yaml:"maxMemoryUsageActivationUpperBound"`
+	MaxMemoryUsageActivationLowerBound float64 `json:"maxMemoryUsageActivationLowerBound"`
+	MaxMemoryUsageActivationUpperBound float64 `json:"maxMemoryUsageActivationUpperBound"`
 }
 
 func (o AvoidOverloadedHostsMemoryStepOpts) Validate() error {

--- a/internal/scheduler/plugins/kvm/avoid_overloaded_hosts_memory_test.go
+++ b/internal/scheduler/plugins/kvm/avoid_overloaded_hosts_memory_test.go
@@ -39,17 +39,16 @@ func TestAvoidOverloadedHostsMemoryStep_Run(t *testing.T) {
 	}
 
 	// Create an instance of the step
-	opts := conf.NewRawOpts(`
-        avgMemoryUsageLowerBound: 10 # pct
-        avgMemoryUsageUpperBound: 100 # pct
-        avgMemoryUsageActivationLowerBound: 0.0
-        avgMemoryUsageActivationUpperBound: -0.5
-        # Min-max scaling for max memory usage on the host.
-        maxMemoryUsageLowerBound: 20 # pct
-        maxMemoryUsageUpperBound: 100 # pct
-        maxMemoryUsageActivationLowerBound: 0.0
-        maxMemoryUsageActivationUpperBound: -0.5
-    `)
+	opts := conf.NewRawOpts(`{
+        "avgMemoryUsageLowerBound": 10,
+        "avgMemoryUsageUpperBound": 100,
+        "avgMemoryUsageActivationLowerBound": 0.0,
+        "avgMemoryUsageActivationUpperBound": -0.5,
+        "maxMemoryUsageLowerBound": 20,
+        "maxMemoryUsageUpperBound": 100,
+        "maxMemoryUsageActivationLowerBound": 0.0,
+        "maxMemoryUsageActivationUpperBound": -0.5
+    }`)
 	step := &AvoidOverloadedHostsMemoryStep{}
 	if err := step.Init(testDB, opts); err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/internal/scheduler/plugins/shared/flavor_binpacking.go
+++ b/internal/scheduler/plugins/shared/flavor_binpacking.go
@@ -16,25 +16,25 @@ import (
 type FlavorBinpackingStepOpts struct {
 	// Flavor names to consider for the binpacking.
 	// If this list is empty, all flavors are considered.
-	Flavors []string `yaml:"flavors"`
+	Flavors []string `json:"flavors"`
 
-	CPUEnabled                  bool    `yaml:"cpuEnabled"`
-	CPUFreeLowerBound           float64 `yaml:"cpuFreeLowerBound"` // -> mapped to ActivationLowerBound
-	CPUFreeUpperBound           float64 `yaml:"cpuFreeUpperBound"` // -> mapped to ActivationUpperBound
-	CPUFreeActivationLowerBound float64 `yaml:"cpuFreeActivationLowerBound"`
-	CPUFreeActivationUpperBound float64 `yaml:"cpuFreeActivationUpperBound"`
+	CPUEnabled                  bool    `json:"cpuEnabled"`
+	CPUFreeLowerBound           float64 `json:"cpuFreeLowerBound"` // -> mapped to ActivationLowerBound
+	CPUFreeUpperBound           float64 `json:"cpuFreeUpperBound"` // -> mapped to ActivationUpperBound
+	CPUFreeActivationLowerBound float64 `json:"cpuFreeActivationLowerBound"`
+	CPUFreeActivationUpperBound float64 `json:"cpuFreeActivationUpperBound"`
 
-	RAMEnabled                  bool    `yaml:"ramEnabled"`
-	RAMFreeLowerBound           float64 `yaml:"ramFreeLowerBound"` // -> mapped to ActivationLowerBound
-	RAMFreeUpperBound           float64 `yaml:"ramFreeUpperBound"` // -> mapped to ActivationUpperBound
-	RAMFreeActivationLowerBound float64 `yaml:"ramFreeActivationLowerBound"`
-	RAMFreeActivationUpperBound float64 `yaml:"ramFreeActivationUpperBound"`
+	RAMEnabled                  bool    `json:"ramEnabled"`
+	RAMFreeLowerBound           float64 `json:"ramFreeLowerBound"` // -> mapped to ActivationLowerBound
+	RAMFreeUpperBound           float64 `json:"ramFreeUpperBound"` // -> mapped to ActivationUpperBound
+	RAMFreeActivationLowerBound float64 `json:"ramFreeActivationLowerBound"`
+	RAMFreeActivationUpperBound float64 `json:"ramFreeActivationUpperBound"`
 
-	DiskEnabled                  bool    `yaml:"diskEnabled"`
-	DiskFreeLowerBound           float64 `yaml:"diskFreeLowerBound"` // -> mapped to ActivationLowerBound
-	DiskFreeUpperBound           float64 `yaml:"diskFreeUpperBound"` // -> mapped to ActivationUpperBound
-	DiskFreeActivationLowerBound float64 `yaml:"diskFreeActivationLowerBound"`
-	DiskFreeActivationUpperBound float64 `yaml:"diskFreeActivationUpperBound"`
+	DiskEnabled                  bool    `json:"diskEnabled"`
+	DiskFreeLowerBound           float64 `json:"diskFreeLowerBound"` // -> mapped to ActivationLowerBound
+	DiskFreeUpperBound           float64 `json:"diskFreeUpperBound"` // -> mapped to ActivationUpperBound
+	DiskFreeActivationLowerBound float64 `json:"diskFreeActivationLowerBound"`
+	DiskFreeActivationUpperBound float64 `json:"diskFreeActivationUpperBound"`
 }
 
 func (o FlavorBinpackingStepOpts) Validate() error {

--- a/internal/scheduler/plugins/shared/flavor_binpacking_test.go
+++ b/internal/scheduler/plugins/shared/flavor_binpacking_test.go
@@ -39,23 +39,23 @@ func TestFlavorBinpackingStep_Run(t *testing.T) {
 	}
 
 	// Create an instance of the step
-	opts := conf.NewRawOpts(`
-        cpuEnabled: true
-        cpuFreeLowerBound: 0
-        cpuFreeUpperBound: 4
-        cpuFreeActivationLowerBound: 0.0
-        cpuFreeActivationUpperBound: 1.0
-        ramEnabled: true
-        ramFreeLowerBound: 0
-        ramFreeUpperBound: 2048
-        ramFreeActivationLowerBound: 0.0
-        ramFreeActivationUpperBound: 1.0
-        diskEnabled: true
-        diskFreeLowerBound: 0
-        diskFreeUpperBound: 200
-        diskFreeActivationLowerBound: 0.0
-        diskFreeActivationUpperBound: 1.0
-    `)
+	opts := conf.NewRawOpts(`{
+        "cpuEnabled": true,
+        "cpuFreeLowerBound": 0,
+        "cpuFreeUpperBound": 4,
+        "cpuFreeActivationLowerBound": 0.0,
+        "cpuFreeActivationUpperBound": 1.0,
+        "ramEnabled": true,
+        "ramFreeLowerBound": 0,
+        "ramFreeUpperBound": 2048,
+        "ramFreeActivationLowerBound": 0.0,
+        "ramFreeActivationUpperBound": 1.0,
+        "diskEnabled": true,
+        "diskFreeLowerBound": 0,
+        "diskFreeUpperBound": 200,
+        "diskFreeActivationLowerBound": 0.0,
+        "diskFreeActivationUpperBound": 1.0
+    }`)
 	step := &FlavorBinpackingStep{}
 	if err := step.Init(testDB, opts); err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/internal/scheduler/plugins/vmware/anti_affinity_noisy_projects.go
+++ b/internal/scheduler/plugins/vmware/anti_affinity_noisy_projects.go
@@ -14,11 +14,11 @@ import (
 // Options for the scheduling step, given through the step config in the service yaml file.
 // Use the options contained in this struct to configure the bounds for min-max scaling.
 type AntiAffinityNoisyProjectsStepOpts struct {
-	AvgCPUUsageLowerBound float64 `yaml:"avgCPUUsageLowerBound"` // -> mapped to ActivationLowerBound
-	AvgCPUUsageUpperBound float64 `yaml:"avgCPUUsageUpperBound"` // -> mapped to ActivationUpperBound
+	AvgCPUUsageLowerBound float64 `json:"avgCPUUsageLowerBound"` // -> mapped to ActivationLowerBound
+	AvgCPUUsageUpperBound float64 `json:"avgCPUUsageUpperBound"` // -> mapped to ActivationUpperBound
 
-	AvgCPUUsageActivationLowerBound float64 `yaml:"avgCPUUsageActivationLowerBound"`
-	AvgCPUUsageActivationUpperBound float64 `yaml:"avgCPUUsageActivationUpperBound"`
+	AvgCPUUsageActivationLowerBound float64 `json:"avgCPUUsageActivationLowerBound"`
+	AvgCPUUsageActivationUpperBound float64 `json:"avgCPUUsageActivationUpperBound"`
 }
 
 func (o AntiAffinityNoisyProjectsStepOpts) Validate() error {

--- a/internal/scheduler/plugins/vmware/anti_affinity_noisy_projects_test.go
+++ b/internal/scheduler/plugins/vmware/anti_affinity_noisy_projects_test.go
@@ -37,13 +37,12 @@ func TestAntiAffinityNoisyProjectsStep_Run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	opts := conf.NewRawOpts(`
-        # Min-max scaling for avg CPU usage of the project on a host.
-        avgCPUUsageLowerBound: 20
-        avgCPUUsageUpperBound: 100
-        avgCPUUsageActivationLowerBound: 0.0
-        avgCPUUsageActivationUpperBound: -0.5
-    `)
+	opts := conf.NewRawOpts(`{
+        "avgCPUUsageLowerBound": 20,
+        "avgCPUUsageUpperBound": 100,
+        "avgCPUUsageActivationLowerBound": 0.0,
+        "avgCPUUsageActivationUpperBound": -0.5
+    }`)
 	step := &AntiAffinityNoisyProjectsStep{}
 	if err := step.Init(testDB, opts); err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/internal/scheduler/plugins/vmware/avoid_contended_hosts.go
+++ b/internal/scheduler/plugins/vmware/avoid_contended_hosts.go
@@ -14,17 +14,17 @@ import (
 // Options for the scheduling step, given through the
 // step config in the service yaml file.
 type AvoidContendedHostsStepOpts struct {
-	AvgCPUContentionLowerBound float64 `yaml:"avgCPUContentionLowerBound"` // -> mapped to ActivationLowerBound
-	AvgCPUContentionUpperBound float64 `yaml:"avgCPUContentionUpperBound"` // -> mapped to ActivationUpperBound
+	AvgCPUContentionLowerBound float64 `json:"avgCPUContentionLowerBound"` // -> mapped to ActivationLowerBound
+	AvgCPUContentionUpperBound float64 `json:"avgCPUContentionUpperBound"` // -> mapped to ActivationUpperBound
 
-	AvgCPUContentionActivationLowerBound float64 `yaml:"avgCPUContentionActivationLowerBound"`
-	AvgCPUContentionActivationUpperBound float64 `yaml:"avgCPUContentionActivationUpperBound"`
+	AvgCPUContentionActivationLowerBound float64 `json:"avgCPUContentionActivationLowerBound"`
+	AvgCPUContentionActivationUpperBound float64 `json:"avgCPUContentionActivationUpperBound"`
 
-	MaxCPUContentionLowerBound float64 `yaml:"maxCPUContentionLowerBound"` // -> mapped to ActivationLowerBound
-	MaxCPUContentionUpperBound float64 `yaml:"maxCPUContentionUpperBound"` // -> mapped to ActivationUpperBound
+	MaxCPUContentionLowerBound float64 `json:"maxCPUContentionLowerBound"` // -> mapped to ActivationLowerBound
+	MaxCPUContentionUpperBound float64 `json:"maxCPUContentionUpperBound"` // -> mapped to ActivationUpperBound
 
-	MaxCPUContentionActivationLowerBound float64 `yaml:"maxCPUContentionActivationLowerBound"`
-	MaxCPUContentionActivationUpperBound float64 `yaml:"maxCPUContentionActivationUpperBound"`
+	MaxCPUContentionActivationLowerBound float64 `json:"maxCPUContentionActivationLowerBound"`
+	MaxCPUContentionActivationUpperBound float64 `json:"maxCPUContentionActivationUpperBound"`
 }
 
 func (o AvoidContendedHostsStepOpts) Validate() error {

--- a/internal/scheduler/plugins/vmware/avoid_contended_hosts_test.go
+++ b/internal/scheduler/plugins/vmware/avoid_contended_hosts_test.go
@@ -38,18 +38,16 @@ func TestAvoidContendedHostsStep_Run(t *testing.T) {
 	}
 
 	// Create an instance of the step
-	opts := conf.NewRawOpts(`
-        # Min-max scaling for avg CPU contention on the host.
-        avgCPUContentionLowerBound: 10
-        avgCPUContentionUpperBound: 100
-        avgCPUContentionActivationLowerBound: 0.0
-        avgCPUContentionActivationUpperBound: -0.5
-        # Min-max scaling for max CPU contention on the host.
-        maxCPUContentionLowerBound: 20
-        maxCPUContentionUpperBound: 100
-        maxCPUContentionActivationLowerBound: 0.0
-        maxCPUContentionActivationUpperBound: -0.5
-    `)
+	opts := conf.NewRawOpts(`{
+        "avgCPUContentionLowerBound": 10,
+        "avgCPUContentionUpperBound": 100,
+        "avgCPUContentionActivationLowerBound": 0.0,
+        "avgCPUContentionActivationUpperBound": -0.5,
+        "maxCPUContentionLowerBound": 20,
+        "maxCPUContentionUpperBound": 100,
+        "maxCPUContentionActivationLowerBound": 0.0,
+        "maxCPUContentionActivationUpperBound": -0.5
+    }`)
 	step := &AvoidContendedHostsStep{}
 	if err := step.Init(testDB, opts); err != nil {
 		t.Fatalf("expected no error, got %v", err)


### PR DESCRIPTION
`gopkg.in/yaml.v3` was archived on the 1st of April 2025. This pull request removes the direct dependency, and instead uses the json parsing built into golang for config handling. The config will now be serialized to json before it is passed to the services.