### PR TITLE
Test step monitor run function and fix found bug

### DIFF
--- a/internal/scheduler/validation_test.go
+++ b/internal/scheduler/validation_test.go
@@ -11,29 +11,11 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/scheduler/api"
 	testlibAPI "github.com/cobaltcore-dev/cortex/testlib/scheduler/api"
+	"github.com/cobaltcore-dev/cortex/testlib/scheduler/plugins"
 )
 
-// MockStep is a manual mock implementation of the plugins.Step interface.
-type MockStep struct {
-	Name     string
-	InitFunc func(db db.DB, opts conf.RawOpts) error
-	RunFunc  func(request api.Request) (map[string]float64, error)
-}
-
-func (m *MockStep) GetName() string {
-	return m.Name
-}
-
-func (m *MockStep) Init(db db.DB, opts conf.RawOpts) error {
-	return m.InitFunc(db, opts)
-}
-
-func (m *MockStep) Run(request api.Request) (map[string]float64, error) {
-	return m.RunFunc(request)
-}
-
 func TestStepValidator_GetName(t *testing.T) {
-	mockStep := &MockStep{
+	mockStep := &plugins.MockStep{
 		Name: "mock-step",
 	}
 
@@ -47,7 +29,7 @@ func TestStepValidator_GetName(t *testing.T) {
 }
 
 func TestStepValidator_Init(t *testing.T) {
-	mockStep := &MockStep{
+	mockStep := &plugins.MockStep{
 		InitFunc: func(db db.DB, opts conf.RawOpts) error {
 			return nil
 		},
@@ -66,7 +48,7 @@ func TestStepValidator_Init(t *testing.T) {
 }
 
 func TestStepValidator_Run_ValidHosts(t *testing.T) {
-	mockStep := &MockStep{
+	mockStep := &plugins.MockStep{
 		RunFunc: func(request api.Request) (map[string]float64, error) {
 			return map[string]float64{
 				"host1": 1.0,
@@ -102,7 +84,7 @@ func TestStepValidator_Run_ValidHosts(t *testing.T) {
 }
 
 func TestStepValidator_Run_HostNumberMismatch(t *testing.T) {
-	mockStep := &MockStep{
+	mockStep := &plugins.MockStep{
 		RunFunc: func(request api.Request) (map[string]float64, error) {
 			return map[string]float64{
 				"host1": 1.0,
@@ -137,7 +119,7 @@ func TestStepValidator_Run_HostNumberMismatch(t *testing.T) {
 }
 
 func TestStepValidator_Run_DisabledValidation(t *testing.T) {
-	mockStep := &MockStep{
+	mockStep := &plugins.MockStep{
 		RunFunc: func(request api.Request) (map[string]float64, error) {
 			return map[string]float64{
 				"host1": 1.0,
@@ -171,7 +153,7 @@ func TestStepValidator_Run_DisabledValidation(t *testing.T) {
 }
 
 func TestValidateStep(t *testing.T) {
-	mockStep := &MockStep{}
+	mockStep := &plugins.MockStep{}
 	disabledValidations := conf.SchedulerStepDisabledValidationsConfig{
 		SameHostNumberInOut: true,
 	}

--- a/testlib/monitoring/mock.go
+++ b/testlib/monitoring/mock.go
@@ -1,0 +1,13 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package monitoring
+
+type MockObserver struct {
+	// Observations recorded by the mock observer.
+	Observations []float64
+}
+
+func (m *MockObserver) Observe(value float64) {
+	m.Observations = append(m.Observations, value)
+}

--- a/testlib/scheduler/plugins/interface.go
+++ b/testlib/scheduler/plugins/interface.go
@@ -1,0 +1,29 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package plugins
+
+import (
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	"github.com/cobaltcore-dev/cortex/internal/scheduler/api"
+)
+
+// MockStep is a manual mock implementation of the plugins.Step interface.
+type MockStep struct {
+	Name     string
+	InitFunc func(db db.DB, opts conf.RawOpts) error
+	RunFunc  func(request api.Request) (map[string]float64, error)
+}
+
+func (m *MockStep) GetName() string {
+	return m.Name
+}
+
+func (m *MockStep) Init(db db.DB, opts conf.RawOpts) error {
+	return m.InitFunc(db, opts)
+}
+
+func (m *MockStep) Run(request api.Request) (map[string]float64, error) {
+	return m.RunFunc(request)
+}


### PR DESCRIPTION
This PR fixes an issue where the step monitor calculates the number of reorderings based on the `hosts` list provided by Nova, which may not necessarily be sorted by the hosts' weights. Now, we compare the input and output weights correctly.