### PR TITLE
Execute db migrations as pre-upgrade hook

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -72,6 +72,7 @@ local_resource(
     trigger_mode=TRIGGER_MODE_MANUAL,
     auto_init=False,
 )
+k8s_resource('cortex-migrations', labels=['Commands'])
 
 ########### Postgres DB for Cortex Core Service
 k8s_yaml(helm('./helm/postgres', name='cortex-postgres'))

--- a/helm/cortex/templates/migrations.yaml
+++ b/helm/cortex/templates/migrations.yaml
@@ -1,0 +1,40 @@
+# Copyright 2025 SAP SE
+# SPDX-License-Identifier: Apache-2.0
+
+# Declare a hook that migrates the database after a Helm upgrade.
+# See: https://helm.sh/docs/topics/charts_hooks/
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "cortex.fullname" $ }}-migrations
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # Run this job before Helm upgrades are applied.
+    # Note: since we use pre-upgrade here, it is assumed that the configmap
+    # is already present in the cluster and can be mounted.
+    "helm.sh/hook": pre-upgrade
+spec:
+  template:
+    metadata:
+      name: {{ include "cortex.fullname" $ }}-migrations
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: {{ include "cortex.fullname" $ }}-migrations
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+          args: ["migrate"]
+          volumeMounts:
+            - name: {{ include "cortex.fullname" $ }}-config-volume
+              mountPath: /etc/config
+      volumes:
+        - name: {{ include "cortex.fullname" $ }}-config-volume
+          configMap:
+            name: {{ include "cortex.fullname" $ }}-config

--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -241,8 +241,6 @@ conf:
           # Needs resource_providers.
           # - traits
 
-  bla: blub
-
   features:
     # Configuration of features that should be extracted from the synced data.
     # Each extractor can specify its own dependencies on other extractors or

--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -241,6 +241,8 @@ conf:
           # Needs resource_providers.
           # - traits
 
+  bla: blub
+
   features:
     # Configuration of features that should be extracted from the synced data.
     # Each extractor can specify its own dependencies on other extractors or


### PR DESCRIPTION
Before, every service would perform its own migrations. Now, this is a separate kubernetes job that gets executed before the kubernetes templates are applied.