### PR TITLE
Added Short Term CPU Contention Weigher

### DIFF
--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -140,10 +140,17 @@ conf:
           query: |
             vrops_virtualmachine_cpu_demand_ratio{}
           type: vrops_vm_metric
-        - alias: vrops_hostsystem_cpu_contention_percentage
+        - alias: vrops_hostsystem_cpu_contention_long_term_percentage
           query: |
             vrops_hostsystem_cpu_contention_percentage{}
           type: vrops_host_metric
+        - alias: vrops_hostsystem_cpu_contention_short_term_percentage
+          query: |
+            vrops_hostsystem_cpu_contention_percentage{}
+          type: vrops_host_metric
+          timeRangeSeconds: 43200 # 12 hours
+          intervalSeconds: 3600 # 1 hour
+          resolutionSeconds: 600 # 10 minutes
         # Node exporter metrics for KVM hosts.
         - alias: node_exporter_cpu_usage_pct
           query: |
@@ -234,7 +241,7 @@ conf:
           sync:
             prometheus:
               metrics:
-                - alias: vrops_hostsystem_cpu_contention_percentage
+                - alias: vrops_hostsystem_cpu_contention_long_term_percentage
 
       # KVM-specific extractors.
       - name: node_exporter_host_cpu_usage_extractor

--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -233,7 +233,7 @@ conf:
                 types:
                   - hypervisors
                   - servers
-      - name: vrops_hostsystem_contention_extractor
+      - name: vrops_hostsystem_contention_long_term_extractor
         dependencies:
           features:
             extractors:
@@ -242,6 +242,15 @@ conf:
             prometheus:
               metrics:
                 - alias: vrops_hostsystem_cpu_contention_long_term_percentage
+      - name: vrops_hostsystem_contention_short_term_extractor
+        dependencies:
+          features:
+            extractors:
+              - vrops_hostsystem_resolver
+          sync:
+            prometheus:
+              metrics:
+                - alias: vrops_hostsystem_cpu_contention_short_term_percentage
 
       # KVM-specific extractors.
       - name: node_exporter_host_cpu_usage_extractor
@@ -296,7 +305,7 @@ conf:
         dependencies:
           features:
             extractors:
-              - vrops_hostsystem_contention_extractor
+              - vrops_hostsystem_contention_long_term_extractor
       - name: vmware_project_noisiness_kpi
         dependencies:
           features:
@@ -361,7 +370,7 @@ conf:
         dependencies:
           features:
             extractors:
-              - vrops_hostsystem_contention_extractor
+              - vrops_hostsystem_contention_long_term_extractor
 
       # KVM specific scheduler steps.
       - name: kvm_avoid_overloaded_hosts_cpu

--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -355,7 +355,7 @@ conf:
           features:
             extractors:
               - vrops_project_noisiness_extractor
-      - name: vmware_avoid_contended_hosts
+      - name: vmware_avoid_long_term_contended_hosts
         options:
           # Min-max scaling for avg CPU contention on the host.
           avgCPUContentionLowerBound: 0 # pct
@@ -371,6 +371,22 @@ conf:
           features:
             extractors:
               - vrops_hostsystem_contention_long_term_extractor
+      - name: vmware_avoid_short_term_contended_hosts
+        options:
+          # Min-max scaling for avg CPU contention on the host.
+          avgCPUContentionLowerBound: 0 # pct
+          avgCPUContentionUpperBound: 10 # pct
+          avgCPUContentionActivationLowerBound: 0.0
+          avgCPUContentionActivationUpperBound: -0.75
+          # Min-max scaling for max CPU contention on the host.
+          maxCPUContentionLowerBound: 0 # pct
+          maxCPUContentionUpperBound: 10 # pct
+          maxCPUContentionActivationLowerBound: 0.0
+          maxCPUContentionActivationUpperBound: -0.25
+        dependencies:
+          features:
+            extractors:
+              - vrops_hostsystem_contention_short_term_extractor
 
       # KVM specific scheduler steps.
       - name: kvm_avoid_overloaded_hosts_cpu

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -40,7 +40,7 @@ func TestNewConfig(t *testing.T) {
           "resolutionSeconds": 43200
         },
         {
-          "name": "vrops_hostsystem_cpu_contention_percentage",
+          "name": "vrops_hostsystem_cpu_contention_long_term_percentage",
           "type": "vrops_host_metric"
         }
       ]

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -63,7 +63,7 @@ func TestNewConfig(t *testing.T) {
         "name": "vrops_project_noisiness_extractor"
       },
       {
-        "name": "vrops_hostsystem_contention_extractor"
+        "name": "vrops_hostsystem_contention_long_term_extractor"
       }
     ]
   },
@@ -76,7 +76,7 @@ func TestNewConfig(t *testing.T) {
         }
       },
       {
-        "name": "vmware_avoid_contended_hosts",
+        "name": "vmware_avoid_long_term_contended_hosts",
         "options": {
           "maxCPUContentionThreshold": 50
         }

--- a/internal/features/pipeline.go
+++ b/internal/features/pipeline.go
@@ -24,7 +24,8 @@ var SupportedExtractors = []plugins.FeatureExtractor{
 	// VMware-specific extractors
 	&vmware.VROpsHostsystemResolver{},
 	&vmware.VROpsProjectNoisinessExtractor{},
-	&vmware.VROpsHostsystemContentionExtractor{},
+	&vmware.VROpsHostsystemContentionLongTermExtractor{},
+	&vmware.VROpsHostsystemContentionShortTermExtractor{},
 	// KVM-specific extractors
 	&kvm.NodeExporterHostCPUUsageExtractor{},
 	&kvm.NodeExporterHostMemoryActiveExtractor{},

--- a/internal/features/plugins/vmware/vrops_hostsystem_contention_long_term.go
+++ b/internal/features/plugins/vmware/vrops_hostsystem_contention_long_term.go
@@ -12,49 +12,49 @@ import (
 )
 
 // Feature that maps CPU contention of vROps hostsystems.
-type VROpsHostsystemContention struct {
+type VROpsHostsystemContentionLongTerm struct {
 	ComputeHost      string  `db:"compute_host"`
 	AvgCPUContention float64 `db:"avg_cpu_contention"`
 	MaxCPUContention float64 `db:"max_cpu_contention"`
 }
 
 // Table under which the feature is stored.
-func (VROpsHostsystemContention) TableName() string {
-	return "feature_vrops_hostsystem_contention"
+func (VROpsHostsystemContentionLongTerm) TableName() string {
+	return "feature_vrops_hostsystem_contention_long_term"
 }
 
 // Indexes for the feature.
-func (VROpsHostsystemContention) Indexes() []db.Index {
+func (VROpsHostsystemContentionLongTerm) Indexes() []db.Index {
 	return nil
 }
 
 // Extractor that extracts CPU contention of vROps hostsystems and stores
 // it as a feature into the database.
-type VROpsHostsystemContentionExtractor struct {
+type VROpsHostsystemContentionLongTermExtractor struct {
 	// Common base for all extractors that provides standard functionality.
 	plugins.BaseExtractor[
-		struct{},                  // No options passed through yaml config
-		VROpsHostsystemContention, // Feature model
+		struct{},                          // No options passed through yaml config
+		VROpsHostsystemContentionLongTerm, // Feature model
 	]
 }
 
 // Name of this feature extractor that is used in the yaml config, for logging etc.
-func (*VROpsHostsystemContentionExtractor) GetName() string {
-	return "vrops_hostsystem_contention_extractor"
+func (*VROpsHostsystemContentionLongTermExtractor) GetName() string {
+	return "vrops_hostsystem_contention_long_term_extractor"
 }
 
 // Get message topics that trigger a re-execution of this extractor.
-func (VROpsHostsystemContentionExtractor) Triggers() []string {
+func (VROpsHostsystemContentionLongTermExtractor) Triggers() []string {
 	return []string{
-		prometheus.TriggerMetricAliasSynced("vrops_hostsystem_cpu_contention_percentage"),
+		prometheus.TriggerMetricAliasSynced("vrops_hostsystem_cpu_contention_long_term_percentage"),
 	}
 }
 
-//go:embed vrops_hostsystem_contention.sql
-var vropsHostsystemContentionSQL string
+//go:embed vrops_hostsystem_contention_long_term.sql
+var vropsHostsystemContentionLongTermSQL string
 
-// Extract CPU contention of hostsystems.
+// Extract long term CPU contention of hostsystems.
 // Depends on resolved vROps hostsystems (feature_vrops_resolved_hostsystem).
-func (e *VROpsHostsystemContentionExtractor) Extract() ([]plugins.Feature, error) {
-	return e.ExtractSQL(vropsHostsystemContentionSQL)
+func (e *VROpsHostsystemContentionLongTermExtractor) Extract() ([]plugins.Feature, error) {
+	return e.ExtractSQL(vropsHostsystemContentionLongTermSQL)
 }

--- a/internal/features/plugins/vmware/vrops_hostsystem_contention_long_term.sql
+++ b/internal/features/plugins/vmware/vrops_hostsystem_contention_long_term.sql
@@ -4,5 +4,5 @@ SELECT
     MAX(m.value) AS max_cpu_contention
 FROM vrops_host_metrics m
 JOIN feature_vrops_resolved_hostsystem h ON m.hostsystem = h.vrops_hostsystem
-WHERE m.name = 'vrops_hostsystem_cpu_contention_percentage'
+WHERE m.name = 'vrops_hostsystem_cpu_contention_long_term_percentage'
 GROUP BY h.nova_compute_host;

--- a/internal/features/plugins/vmware/vrops_hostsystem_contention_long_term_test.go
+++ b/internal/features/plugins/vmware/vrops_hostsystem_contention_long_term_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package vmware
+
+import (
+	"testing"
+
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	"github.com/cobaltcore-dev/cortex/internal/sync/prometheus"
+	testlibDB "github.com/cobaltcore-dev/cortex/testlib/db"
+)
+
+func TestVROpsHostsystemContentionLongTermExtractor_Init(t *testing.T) {
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	extractor := &VROpsHostsystemContentionLongTermExtractor{}
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !testDB.TableExists(VROpsHostsystemContentionLongTerm{}) {
+		t.Error("expected table to be created")
+	}
+}
+
+func TestVROpsHostsystemContentionLongTermExtractor_Extract(t *testing.T) {
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	// Create dependency tables
+	if err := testDB.CreateTable(
+		testDB.AddTable(ResolvedVROpsHostsystem{}),
+		testDB.AddTable(prometheus.VROpsHostMetric{}),
+	); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Insert mock data into the vrops_host_metrics table
+	_, err := testDB.Exec(`
+        INSERT INTO vrops_host_metrics (hostsystem, name, value)
+        VALUES
+            ('hostsystem1', 'vrops_hostsystem_cpu_contention_long_term_percentage', 30.0),
+            ('hostsystem2', 'vrops_hostsystem_cpu_contention_long_term_percentage', 40.0),
+            ('hostsystem1', 'vrops_hostsystem_cpu_contention_long_term_percentage', 50.0)
+    `)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Insert mock data into the feature_vrops_resolved_hostsystem table
+	_, err = testDB.Exec(`
+        INSERT INTO feature_vrops_resolved_hostsystem (vrops_hostsystem, nova_compute_host)
+        VALUES
+            ('hostsystem1', 'compute_host1'),
+            ('hostsystem2', 'compute_host2')
+    `)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	extractor := &VROpsHostsystemContentionLongTermExtractor{}
+	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, err = extractor.Extract(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify the data was inserted into the feature_vrops_hostsystem_contention table
+	var contentions []VROpsHostsystemContentionLongTerm
+	_, err = testDB.Select(&contentions, "SELECT * FROM feature_vrops_hostsystem_contention_long_term")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(contentions) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(contentions))
+	}
+	expected := map[string]struct {
+		AvgCPUContention float64
+		MaxCPUContention float64
+	}{
+		"compute_host1": {AvgCPUContention: 40.0, MaxCPUContention: 50.0}, // Average of 30.0 and 50.0, Max of 50.0
+		"compute_host2": {AvgCPUContention: 40.0, MaxCPUContention: 40.0}, // Single value of 40.0
+	}
+	for _, c := range contentions {
+		if expected[c.ComputeHost].AvgCPUContention != c.AvgCPUContention {
+			t.Errorf(
+				"expected avg_cpu_contention for compute_host %s to be %f, got %f",
+				c.ComputeHost, expected[c.ComputeHost].AvgCPUContention, c.AvgCPUContention,
+			)
+		}
+		if expected[c.ComputeHost].MaxCPUContention != c.MaxCPUContention {
+			t.Errorf(
+				"expected max_cpu_contention for compute_host %s to be %f, got %f",
+				c.ComputeHost, expected[c.ComputeHost].MaxCPUContention, c.MaxCPUContention,
+			)
+		}
+	}
+}

--- a/internal/features/plugins/vmware/vrops_hostsystem_contention_short_term.go
+++ b/internal/features/plugins/vmware/vrops_hostsystem_contention_short_term.go
@@ -1,0 +1,60 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package vmware
+
+import (
+	_ "embed"
+
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	"github.com/cobaltcore-dev/cortex/internal/features/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/sync/prometheus"
+)
+
+// Feature that maps CPU contention of vROps hostsystems.
+type VROpsHostsystemContentionShortTerm struct {
+	ComputeHost      string  `db:"compute_host"`
+	AvgCPUContention float64 `db:"avg_cpu_contention"`
+	MaxCPUContention float64 `db:"max_cpu_contention"`
+}
+
+// Table under which the feature is stored.
+func (VROpsHostsystemContentionShortTerm) TableName() string {
+	return "feature_vrops_hostsystem_contention_short_term"
+}
+
+// Indexes for the feature.
+func (VROpsHostsystemContentionShortTerm) Indexes() []db.Index {
+	return nil
+}
+
+// Extractor that extracts CPU contention of vROps hostsystems and stores
+// it as a feature into the database.
+type VROpsHostsystemContentionShortTermExtractor struct {
+	// Common base for all extractors that provides standard functionality.
+	plugins.BaseExtractor[
+		struct{},                           // No options passed through yaml config
+		VROpsHostsystemContentionShortTerm, // Feature model
+	]
+}
+
+// Name of this feature extractor that is used in the yaml config, for logging etc.
+func (*VROpsHostsystemContentionShortTermExtractor) GetName() string {
+	return "vrops_hostsystem_contention_short_term_extractor"
+}
+
+// Get message topics that trigger a re-execution of this extractor.
+func (VROpsHostsystemContentionShortTermExtractor) Triggers() []string {
+	return []string{
+		prometheus.TriggerMetricAliasSynced("vrops_hostsystem_cpu_contention_short_term_percentage"),
+	}
+}
+
+//go:embed vrops_hostsystem_contention_short_term.sql
+var vropsHostsystemContentionShortTermSQL string
+
+// Extract short term CPU contention of hostsystems.
+// Depends on resolved vROps hostsystems (feature_vrops_resolved_hostsystem).
+func (e *VROpsHostsystemContentionShortTermExtractor) Extract() ([]plugins.Feature, error) {
+	return e.ExtractSQL(vropsHostsystemContentionShortTermSQL)
+}

--- a/internal/features/plugins/vmware/vrops_hostsystem_contention_short_term.sql
+++ b/internal/features/plugins/vmware/vrops_hostsystem_contention_short_term.sql
@@ -1,0 +1,8 @@
+SELECT
+    h.nova_compute_host AS compute_host,
+    AVG(m.value) AS avg_cpu_contention,
+    MAX(m.value) AS max_cpu_contention
+FROM vrops_host_metrics m
+JOIN feature_vrops_resolved_hostsystem h ON m.hostsystem = h.vrops_hostsystem
+WHERE m.name = 'vrops_hostsystem_cpu_contention_short_term_percentage'
+GROUP BY h.nova_compute_host;

--- a/internal/features/plugins/vmware/vrops_hostsystem_contention_short_term_test.go
+++ b/internal/features/plugins/vmware/vrops_hostsystem_contention_short_term_test.go
@@ -12,23 +12,23 @@ import (
 	testlibDB "github.com/cobaltcore-dev/cortex/testlib/db"
 )
 
-func TestVROpsHostsystemContentionExtractor_Init(t *testing.T) {
+func TestVROpsHostsystemContentionShortTermExtractor_Init(t *testing.T) {
 	dbEnv := testlibDB.SetupDBEnv(t)
 	testDB := db.DB{DbMap: dbEnv.DbMap}
 	defer testDB.Close()
 	defer dbEnv.Close()
 
-	extractor := &VROpsHostsystemContentionExtractor{}
+	extractor := &VROpsHostsystemContentionShortTermExtractor{}
 	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if !testDB.TableExists(VROpsHostsystemContention{}) {
+	if !testDB.TableExists(VROpsHostsystemContentionShortTerm{}) {
 		t.Error("expected table to be created")
 	}
 }
 
-func TestVROpsHostsystemContentionExtractor_Extract(t *testing.T) {
+func TestVROpsHostsystemContentionShortTermExtractor_Extract(t *testing.T) {
 	dbEnv := testlibDB.SetupDBEnv(t)
 	testDB := db.DB{DbMap: dbEnv.DbMap}
 	defer testDB.Close()
@@ -46,9 +46,9 @@ func TestVROpsHostsystemContentionExtractor_Extract(t *testing.T) {
 	_, err := testDB.Exec(`
         INSERT INTO vrops_host_metrics (hostsystem, name, value)
         VALUES
-            ('hostsystem1', 'vrops_hostsystem_cpu_contention_percentage', 30.0),
-            ('hostsystem2', 'vrops_hostsystem_cpu_contention_percentage', 40.0),
-            ('hostsystem1', 'vrops_hostsystem_cpu_contention_percentage', 50.0)
+            ('hostsystem1', 'vrops_hostsystem_cpu_contention_short_term_percentage', 30.0),
+            ('hostsystem2', 'vrops_hostsystem_cpu_contention_short_term_percentage', 40.0),
+            ('hostsystem1', 'vrops_hostsystem_cpu_contention_short_term_percentage', 50.0)
     `)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -65,7 +65,7 @@ func TestVROpsHostsystemContentionExtractor_Extract(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	extractor := &VROpsHostsystemContentionExtractor{}
+	extractor := &VROpsHostsystemContentionShortTermExtractor{}
 	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -74,8 +74,8 @@ func TestVROpsHostsystemContentionExtractor_Extract(t *testing.T) {
 	}
 
 	// Verify the data was inserted into the feature_vrops_hostsystem_contention table
-	var contentions []VROpsHostsystemContention
-	_, err = testDB.Select(&contentions, "SELECT * FROM feature_vrops_hostsystem_contention")
+	var contentions []VROpsHostsystemContentionShortTerm
+	_, err = testDB.Select(&contentions, "SELECT * FROM feature_vrops_hostsystem_contention_short_term")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/kpis/plugins/vmware/host_contention.go
+++ b/internal/kpis/plugins/vmware/host_contention.go
@@ -48,27 +48,27 @@ func (k *VMwareHostContentionKPI) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (k *VMwareHostContentionKPI) Collect(ch chan<- prometheus.Metric) {
-	var contentions []vmware.VROpsHostsystemContention
-	tableName := vmware.VROpsHostsystemContention{}.TableName()
+	var contentions []vmware.VROpsHostsystemContentionLongTerm
+	tableName := vmware.VROpsHostsystemContentionLongTerm{}.TableName()
 	if _, err := k.DB.Select(&contentions, "SELECT * FROM "+tableName); err != nil {
 		slog.Error("failed to select hostsystem contention", "err", err)
 		return
 	}
 	buckets := prometheus.LinearBuckets(0, 5, 20)
-	keysFunc := func(contention vmware.VROpsHostsystemContention) []string {
+	keysFunc := func(contention vmware.VROpsHostsystemContentionLongTerm) []string {
 		return []string{"cpu_contention_max"}
 	}
-	valueFunc := func(contention vmware.VROpsHostsystemContention) float64 {
+	valueFunc := func(contention vmware.VROpsHostsystemContentionLongTerm) float64 {
 		return contention.MaxCPUContention
 	}
 	hists, counts, sums := plugins.Histogram(contentions, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.hostCPUContentionMax, counts[key], sums[key], hist)
 	}
-	keysFunc = func(contention vmware.VROpsHostsystemContention) []string {
+	keysFunc = func(contention vmware.VROpsHostsystemContentionLongTerm) []string {
 		return []string{"cpu_contention_avg"}
 	}
-	valueFunc = func(contention vmware.VROpsHostsystemContention) float64 {
+	valueFunc = func(contention vmware.VROpsHostsystemContentionLongTerm) float64 {
 		return float64(contention.AvgCPUContention)
 	}
 	hists, counts, sums = plugins.Histogram(contentions, buckets, keysFunc, valueFunc)

--- a/internal/kpis/plugins/vmware/host_contention_test.go
+++ b/internal/kpis/plugins/vmware/host_contention_test.go
@@ -33,14 +33,14 @@ func TestVMwareHostContentionKPI_Collect(t *testing.T) {
 
 	// Create dependency tables
 	if err := testDB.CreateTable(
-		testDB.AddTable(vmware.VROpsHostsystemContention{}),
+		testDB.AddTable(vmware.VROpsHostsystemContentionLongTerm{}),
 	); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	// Insert mock data into the feature_vrops_hostsystem_contention table
 	_, err := testDB.Exec(`
-        INSERT INTO feature_vrops_hostsystem_contention (
+        INSERT INTO feature_vrops_hostsystem_contention_long_term (
             compute_host, avg_cpu_contention, max_cpu_contention
         )
         VALUES

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -28,6 +28,7 @@ var SupportedSteps = []plugins.Step{
 	// VMware-specific steps
 	&vmware.AntiAffinityNoisyProjectsStep{},
 	&vmware.AvoidLongTermContendedHostsStep{},
+	&vmware.AvoidShortTermContendedHostsStep{},
 	// KVM-specific steps
 	&kvm.AvoidOverloadedHostsCPUStep{},
 	&kvm.AvoidOverloadedHostsMemoryStep{},

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -27,7 +27,7 @@ import (
 var SupportedSteps = []plugins.Step{
 	// VMware-specific steps
 	&vmware.AntiAffinityNoisyProjectsStep{},
-	&vmware.AvoidContendedHostsStep{},
+	&vmware.AvoidLongTermContendedHostsStep{},
 	// KVM-specific steps
 	&kvm.AvoidOverloadedHostsCPUStep{},
 	&kvm.AvoidOverloadedHostsMemoryStep{},

--- a/internal/scheduler/plugins/vmware/avoid_long_term_contended_hosts.go
+++ b/internal/scheduler/plugins/vmware/avoid_long_term_contended_hosts.go
@@ -39,7 +39,7 @@ func (o AvoidLongTermContendedHostsStepOpts) Validate() error {
 	return nil
 }
 
-// Step to avoid contended hosts by downvoting them.
+// Step to avoid long term contended hosts by downvoting them.
 type AvoidLongTermContendedHostsStep struct {
 	// BaseStep is a helper struct that provides common functionality for all steps.
 	plugins.BaseStep[AvoidLongTermContendedHostsStepOpts]
@@ -47,7 +47,7 @@ type AvoidLongTermContendedHostsStep struct {
 
 // Get the name of this step, used for identification in config, logs, metrics, etc.
 func (s *AvoidLongTermContendedHostsStep) GetName() string {
-	return "vmware_avoid_contended_hosts"
+	return "vmware_avoid_long_term_contended_hosts"
 }
 
 // Downvote hosts that are highly contended.

--- a/internal/scheduler/plugins/vmware/avoid_long_term_contended_hosts.go
+++ b/internal/scheduler/plugins/vmware/avoid_long_term_contended_hosts.go
@@ -14,7 +14,7 @@ import (
 
 // Options for the scheduling step, given through the
 // step config in the service yaml file.
-type AvoidContendedHostsStepOpts struct {
+type AvoidLongTermContendedHostsStepOpts struct {
 	AvgCPUContentionLowerBound float64 `json:"avgCPUContentionLowerBound"` // -> mapped to ActivationLowerBound
 	AvgCPUContentionUpperBound float64 `json:"avgCPUContentionUpperBound"` // -> mapped to ActivationUpperBound
 
@@ -28,7 +28,7 @@ type AvoidContendedHostsStepOpts struct {
 	MaxCPUContentionActivationUpperBound float64 `json:"maxCPUContentionActivationUpperBound"`
 }
 
-func (o AvoidContendedHostsStepOpts) Validate() error {
+func (o AvoidLongTermContendedHostsStepOpts) Validate() error {
 	// Avoid zero-division during min-max scaling.
 	if o.AvgCPUContentionLowerBound == o.AvgCPUContentionUpperBound {
 		return errors.New("avgCPUContentionLowerBound and avgCPUContentionUpperBound must not be equal")
@@ -40,18 +40,18 @@ func (o AvoidContendedHostsStepOpts) Validate() error {
 }
 
 // Step to avoid contended hosts by downvoting them.
-type AvoidContendedHostsStep struct {
+type AvoidLongTermContendedHostsStep struct {
 	// BaseStep is a helper struct that provides common functionality for all steps.
-	plugins.BaseStep[AvoidContendedHostsStepOpts]
+	plugins.BaseStep[AvoidLongTermContendedHostsStepOpts]
 }
 
 // Get the name of this step, used for identification in config, logs, metrics, etc.
-func (s *AvoidContendedHostsStep) GetName() string {
+func (s *AvoidLongTermContendedHostsStep) GetName() string {
 	return "vmware_avoid_contended_hosts"
 }
 
 // Downvote hosts that are highly contended.
-func (s *AvoidContendedHostsStep) Run(traceLog *slog.Logger, request api.Request) (*plugins.StepResult, error) {
+func (s *AvoidLongTermContendedHostsStep) Run(traceLog *slog.Logger, request api.Request) (*plugins.StepResult, error) {
 	result := s.PrepareResult(request)
 	result.Statistics["avg cpu contention"] = s.PrepareStats(request, "%")
 	result.Statistics["max cpu contention"] = s.PrepareStats(request, "%")
@@ -61,9 +61,9 @@ func (s *AvoidContendedHostsStep) Run(traceLog *slog.Logger, request api.Request
 		return result, nil
 	}
 
-	var highlyContendedHosts []vmware.VROpsHostsystemContention
+	var highlyContendedHosts []vmware.VROpsHostsystemContentionLongTerm
 	if _, err := s.DB.Select(&highlyContendedHosts, `
-		SELECT * FROM feature_vrops_hostsystem_contention
+		SELECT * FROM feature_vrops_hostsystem_contention_long_term
 	`); err != nil {
 		return nil, err
 	}

--- a/internal/scheduler/plugins/vmware/avoid_long_term_contended_hosts_test.go
+++ b/internal/scheduler/plugins/vmware/avoid_long_term_contended_hosts_test.go
@@ -21,14 +21,14 @@ func TestAvoidContendedHostsStep_Run(t *testing.T) {
 	defer dbEnv.Close()
 
 	// Create dependency tables
-	err := testDB.CreateTable(testDB.AddTable(vmware.VROpsHostsystemContention{}))
+	err := testDB.CreateTable(testDB.AddTable(vmware.VROpsHostsystemContentionLongTerm{}))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	// Insert mock data into the feature_vrops_hostsystem_contention table
 	_, err = testDB.Exec(`
-        INSERT INTO feature_vrops_hostsystem_contention (compute_host, avg_cpu_contention, max_cpu_contention)
+        INSERT INTO feature_vrops_hostsystem_contention_long_term (compute_host, avg_cpu_contention, max_cpu_contention)
         VALUES
             ('host1', 0.0, 0.0),
             ('host2', 100.0, 0.0),
@@ -50,7 +50,7 @@ func TestAvoidContendedHostsStep_Run(t *testing.T) {
         "maxCPUContentionActivationLowerBound": 0.0,
         "maxCPUContentionActivationUpperBound": -1.0
     }`)
-	step := &AvoidContendedHostsStep{}
+	step := &AvoidLongTermContendedHostsStep{}
 	if err := step.Init(testDB, opts); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/scheduler/plugins/vmware/avoid_short_term_contended_hosts.go
+++ b/internal/scheduler/plugins/vmware/avoid_short_term_contended_hosts.go
@@ -1,0 +1,10 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package vmware
+
+type AvoidShortTermContendedHostsStepOpts struct {
+}
+
+type AvoidShortTermContentedHostsStep struct {
+}

--- a/internal/scheduler/plugins/vmware/avoid_short_term_contended_hosts.go
+++ b/internal/scheduler/plugins/vmware/avoid_short_term_contended_hosts.go
@@ -3,8 +3,94 @@
 
 package vmware
 
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/cobaltcore-dev/cortex/internal/features/plugins/vmware"
+	"github.com/cobaltcore-dev/cortex/internal/scheduler/api"
+	"github.com/cobaltcore-dev/cortex/internal/scheduler/plugins"
+)
+
+// Options for the scheduling step, given through the
+// step config in the service yaml file.
 type AvoidShortTermContendedHostsStepOpts struct {
+	AvgCPUContentionLowerBound float64 `json:"avgCPUContentionLowerBound"` // -> mapped to ActivationLowerBound
+	AvgCPUContentionUpperBound float64 `json:"avgCPUContentionUpperBound"` // -> mapped to ActivationUpperBound
+
+	AvgCPUContentionActivationLowerBound float64 `json:"avgCPUContentionActivationLowerBound"`
+	AvgCPUContentionActivationUpperBound float64 `json:"avgCPUContentionActivationUpperBound"`
+
+	MaxCPUContentionLowerBound float64 `json:"maxCPUContentionLowerBound"` // -> mapped to ActivationLowerBound
+	MaxCPUContentionUpperBound float64 `json:"maxCPUContentionUpperBound"` // -> mapped to ActivationUpperBound
+
+	MaxCPUContentionActivationLowerBound float64 `json:"maxCPUContentionActivationLowerBound"`
+	MaxCPUContentionActivationUpperBound float64 `json:"maxCPUContentionActivationUpperBound"`
 }
 
-type AvoidShortTermContentedHostsStep struct {
+func (o AvoidShortTermContendedHostsStepOpts) Validate() error {
+	// Avoid zero-division during min-max scaling.
+	if o.AvgCPUContentionLowerBound == o.AvgCPUContentionUpperBound {
+		return errors.New("avgCPUContentionLowerBound and avgCPUContentionUpperBound must not be equal")
+	}
+	if o.MaxCPUContentionLowerBound == o.MaxCPUContentionUpperBound {
+		return errors.New("maxCPUContentionLowerBound and maxCPUContentionUpperBound must not be equal")
+	}
+	return nil
+}
+
+// Step to avoid recently contended hosts by downvoting them.
+type AvoidShortTermContendedHostsStep struct {
+	// BaseStep is a helper struct that provides common functionality for all steps.
+	plugins.BaseStep[AvoidShortTermContendedHostsStepOpts]
+}
+
+// Get the name of this step, used for identification in config, logs, metrics, etc.
+func (s *AvoidShortTermContendedHostsStep) GetName() string {
+	return "vmware_avoid_short_term_contended_hosts"
+}
+
+// Downvote hosts that are highly contended.
+func (s *AvoidShortTermContendedHostsStep) Run(traceLog *slog.Logger, request api.Request) (*plugins.StepResult, error) {
+	result := s.PrepareResult(request)
+	result.Statistics["avg cpu contention"] = s.PrepareStats(request, "%")
+	result.Statistics["max cpu contention"] = s.PrepareStats(request, "%")
+
+	if !request.GetVMware() {
+		// Only run this step for VMware VMs.
+		return result, nil
+	}
+
+	var highlyContendedHosts []vmware.VROpsHostsystemContentionShortTerm
+	if _, err := s.DB.Select(&highlyContendedHosts, `
+		SELECT * FROM feature_vrops_hostsystem_contention_short_term
+	`); err != nil {
+		return nil, err
+	}
+
+	// Push the VM away from highly contended hosts.
+	for _, host := range highlyContendedHosts {
+		// Only modify the weight if the host is in the scenario.
+		if _, ok := result.Activations[host.ComputeHost]; !ok {
+			continue
+		}
+		activationAvg := plugins.MinMaxScale(
+			host.AvgCPUContention,
+			s.Options.AvgCPUContentionLowerBound,
+			s.Options.AvgCPUContentionUpperBound,
+			s.Options.AvgCPUContentionActivationLowerBound,
+			s.Options.AvgCPUContentionActivationUpperBound,
+		)
+		activationMax := plugins.MinMaxScale(
+			host.MaxCPUContention,
+			s.Options.MaxCPUContentionLowerBound,
+			s.Options.MaxCPUContentionUpperBound,
+			s.Options.MaxCPUContentionActivationLowerBound,
+			s.Options.MaxCPUContentionActivationUpperBound,
+		)
+		result.Activations[host.ComputeHost] = activationAvg + activationMax
+		result.Statistics["avg cpu contention"].Hosts[host.ComputeHost] = host.AvgCPUContention
+		result.Statistics["max cpu contention"].Hosts[host.ComputeHost] = host.MaxCPUContention
+	}
+	return result, nil
 }

--- a/internal/scheduler/plugins/vmware/avoid_short_term_contended_hosts_test.go
+++ b/internal/scheduler/plugins/vmware/avoid_short_term_contended_hosts_test.go
@@ -14,21 +14,21 @@ import (
 	testlibAPI "github.com/cobaltcore-dev/cortex/testlib/scheduler/api"
 )
 
-func TestAvoidLongTermContendedHostsStep_Run(t *testing.T) {
+func TestAvoidShortTermContendedHostsStep_Run(t *testing.T) {
 	dbEnv := testlibDB.SetupDBEnv(t)
 	testDB := db.DB{DbMap: dbEnv.DbMap}
 	defer testDB.Close()
 	defer dbEnv.Close()
 
 	// Create dependency tables
-	err := testDB.CreateTable(testDB.AddTable(vmware.VROpsHostsystemContentionLongTerm{}))
+	err := testDB.CreateTable(testDB.AddTable(vmware.VROpsHostsystemContentionShortTerm{}))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	// Insert mock data into the feature_vrops_hostsystem_contention table
 	_, err = testDB.Exec(`
-        INSERT INTO feature_vrops_hostsystem_contention_long_term (compute_host, avg_cpu_contention, max_cpu_contention)
+        INSERT INTO feature_vrops_hostsystem_contention_short_term (compute_host, avg_cpu_contention, max_cpu_contention)
         VALUES
             ('host1', 0.0, 0.0),
             ('host2', 100.0, 0.0),
@@ -50,7 +50,7 @@ func TestAvoidLongTermContendedHostsStep_Run(t *testing.T) {
         "maxCPUContentionActivationLowerBound": 0.0,
         "maxCPUContentionActivationUpperBound": -1.0
     }`)
-	step := &AvoidLongTermContendedHostsStep{}
+	step := &AvoidShortTermContendedHostsStep{}
 	if err := step.Init(testDB, opts); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/sync/prometheus/sync.go
+++ b/internal/sync/prometheus/sync.go
@@ -236,7 +236,7 @@ func (s *syncer[M]) sync(start time.Time) {
 		"syncing Prometheus data", "metricAlias", s.MetricConf.Alias,
 		"start", start, "end", end, "tableName", tableName,
 	)
-	// Drop all metrics that are older than 4 weeks.
+	// Drop all metrics that are older than <timeRangeSeconds> from the config file. (Default is 4 weeks)
 	result, err := s.DB.Exec(
 		fmt.Sprintf("DELETE FROM %s WHERE name = :name AND timestamp < :timestamp", tableName),
 		map[string]any{"name": s.MetricConf.Alias, "timestamp": time.Now().Add(-s.SyncTimeRange)},


### PR DESCRIPTION
This PR introduces a new short-term CPU contention weigher for VMware hosts, complementing the existing long-term CPU contention logic. The short-term weigher uses more recent and higher-resolution data to improve scheduling decisions in dynamic environments. These changes improve the scheduler’s responsiveness to recent host contention and make the codebase more maintainable by clarifying the distinction between short-term and long-term metrics.

## Key Changes

### Short-Term CPU Contention Weigher:
Added a new scheduling step that downvotes recently contended hosts based on short-term CPU contention metrics.

### Short-Term Feature Extractor:
Implemented a new feature extractor for short-term CPU contention, enabling the pipeline to utilize up-to-date contention data.

### Short-Term Prometheus Syncer:
Added a syncer to fetch and store short-term CPU contention metrics from Prometheus.

### Renaming for Clarity:
Renamed the existing CPU contention weigher, feature, and syncer to "long term" to clearly distinguish between short-term and long-term contention logic.

