### PR TITLE
Avoid unnecessary burst calculation of features

### DIFF
--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -236,7 +236,6 @@ conf:
                   - hypervisors
                   - servers
       - name: vrops_hostsystem_contention_long_term_extractor
-        recencySeconds: 3600 # 1 hour
         dependencies:
           features:
             extractors:

--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -236,6 +236,7 @@ conf:
                   - hypervisors
                   - servers
       - name: vrops_hostsystem_contention_long_term_extractor
+        recencySeconds: 3600 # 1 hour
         dependencies:
           features:
             extractors:

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -138,6 +138,8 @@ type FeatureExtractorConfig struct {
 	Options RawOpts `json:"options,omitempty"`
 	// The dependencies this extractor needs.
 	DependencyConfig `json:"dependencies,omitempty"`
+	// Recency that tells how old a feature needs to be to be recalculated
+	RecencySeconds *int `json:"recencySeconds,omitempty"`
 }
 
 // Configuration for the features module.

--- a/internal/extractor/monitor.go
+++ b/internal/extractor/monitor.go
@@ -75,9 +75,9 @@ func (m FeatureExtractorMonitor[F]) Triggers() []string {
 }
 
 // Initialize the wrapped feature extractor with the database and options.
-func (m FeatureExtractorMonitor[F]) Init(db db.DB, opts conf.RawOpts) error {
+func (m FeatureExtractorMonitor[F]) Init(db db.DB, conf conf.FeatureExtractorConfig) error {
 	// Configure the wrapped feature extractor.
-	return m.FeatureExtractor.Init(db, opts)
+	return m.FeatureExtractor.Init(db, conf)
 }
 
 // Extract features using the wrapped feature extractor and measure the time it takes.

--- a/internal/extractor/monitor.go
+++ b/internal/extractor/monitor.go
@@ -80,6 +80,16 @@ func (m FeatureExtractorMonitor[F]) Init(db db.DB, conf conf.FeatureExtractorCon
 	return m.FeatureExtractor.Init(db, conf)
 }
 
+func (m FeatureExtractorMonitor[F]) NeedsUpdate() bool {
+	// Check if the wrapped feature extractor needs an update.
+	return m.FeatureExtractor.NeedsUpdate()
+}
+
+func (m FeatureExtractorMonitor[F]) MarkAsUpdated() {
+	// Mark the wrapped feature extractor as updated.
+	m.FeatureExtractor.MarkAsUpdated()
+}
+
 // Extract features using the wrapped feature extractor and measure the time it takes.
 func monitorFeatureExtractor[F plugins.FeatureExtractor](f F, m Monitor) FeatureExtractorMonitor[F] {
 	featureExtractorName := f.GetName()

--- a/internal/extractor/pipeline.go
+++ b/internal/extractor/pipeline.go
@@ -195,10 +195,15 @@ func (p *FeatureExtractorPipeline) extract(order [][]plugins.FeatureExtractor) {
 			wg.Add(1)
 			go func(extractor plugins.FeatureExtractor) {
 				defer wg.Done()
+				if !extractor.NeedsUpdate() {
+					slog.Info("feature extractor: skipping extraction", "extractor", extractor.GetName())
+					return
+				}
 				if _, err := extractor.Extract(); err != nil {
 					slog.Error("feature extractor: failed to extract features", "error", err)
 					return
 				}
+				extractor.MarkAsUpdated()
 			}(extractor)
 		}
 		wg.Wait()

--- a/internal/extractor/pipeline.go
+++ b/internal/extractor/pipeline.go
@@ -89,7 +89,7 @@ func (p *FeatureExtractorPipeline) initDependencyGraph(supportedExtractors []plu
 			panic("unknown feature extractor: " + extractorConfig.Name)
 		}
 		wrappedExtractor := monitorFeatureExtractor(extractorFunc, p.monitor)
-		if err := wrappedExtractor.Init(p.db, extractorConfig.Options); err != nil {
+		if err := wrappedExtractor.Init(p.db, extractorConfig); err != nil {
 			panic("failed to initialize feature extractor: " + err.Error())
 		}
 		extractorsByName[extractorConfig.Name] = wrappedExtractor

--- a/internal/extractor/pipeline_test.go
+++ b/internal/extractor/pipeline_test.go
@@ -45,6 +45,15 @@ func (m *mockFeatureExtractor) Triggers() []string {
 	return m.triggers
 }
 
+func (m *mockFeatureExtractor) NeedsUpdate() bool {
+	// For simplicity, we assume it always needs an update.
+	return true
+}
+
+func (m *mockFeatureExtractor) MarkAsUpdated() {
+	// not implemented for mock
+}
+
 func TestFeatureExtractorPipeline_Extract(t *testing.T) {
 	// Test case: All extractors extract successfully
 	pipeline := &FeatureExtractorPipeline{}

--- a/internal/extractor/pipeline_test.go
+++ b/internal/extractor/pipeline_test.go
@@ -19,15 +19,15 @@ import (
 type mockFeatureExtractor struct {
 	name        string
 	triggers    []string
-	initFunc    func(db.DB, conf.RawOpts) error
+	initFunc    func(db.DB, conf.FeatureExtractorConfig) error
 	extractFunc func() ([]plugins.Feature, error)
 }
 
-func (m *mockFeatureExtractor) Init(db db.DB, opts conf.RawOpts) error {
+func (m *mockFeatureExtractor) Init(db db.DB, conf conf.FeatureExtractorConfig) error {
 	if m.initFunc == nil {
 		return nil
 	}
-	return m.initFunc(db, opts)
+	return m.initFunc(db, conf)
 }
 
 func (m *mockFeatureExtractor) Extract() ([]plugins.Feature, error) {

--- a/internal/extractor/plugins/base.go
+++ b/internal/extractor/plugins/base.go
@@ -16,15 +16,20 @@ type BaseExtractor[Opts any, Feature db.Table] struct {
 	// Options to pass via yaml to this step.
 	conf.JsonOpts[Opts]
 	// Database connection.
-	DB db.DB
+	DB             db.DB
+	RecencySeconds int
 }
 
 // Init the extractor with the database and options.
-func (e *BaseExtractor[Opts, Feature]) Init(db db.DB, opts conf.RawOpts) error {
-	if err := e.Load(opts); err != nil {
+func (e *BaseExtractor[Opts, Feature]) Init(db db.DB, conf conf.FeatureExtractorConfig) error {
+	if err := e.Load(conf.Options); err != nil {
 		return err
 	}
 	e.DB = db
+	e.RecencySeconds = 0
+	if conf.RecencySeconds != nil {
+		e.RecencySeconds = *conf.RecencySeconds
+	}
 	var f Feature
 	return db.CreateTable(db.AddTable(f))
 }

--- a/internal/extractor/plugins/base_test.go
+++ b/internal/extractor/plugins/base_test.go
@@ -40,8 +40,14 @@ func TestBaseExtractor_Init(t *testing.T) {
         "option2": 2
     }`)
 
+	config := conf.FeatureExtractorConfig{
+		Name:           "mock_extractor",
+		Options:        opts,
+		RecencySeconds: nil, // No recency for this test
+	}
+
 	extractor := BaseExtractor[MockOptions, MockFeature]{}
-	err := extractor.Init(testDB, opts)
+	err := extractor.Init(testDB, config)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/extractor/plugins/interface.go
+++ b/internal/extractor/plugins/interface.go
@@ -21,6 +21,10 @@ type FeatureExtractor interface {
 	GetName() string
 	// Get message topics that trigger a re-execution of this extractor.
 	Triggers() []string
+	// Check if the extractors last update is older than the configured recency.
+	NeedsUpdate() bool
+	// Update the last update timestamp of the extractor.
+	MarkAsUpdated()
 }
 
 type Feature any

--- a/internal/extractor/plugins/interface.go
+++ b/internal/extractor/plugins/interface.go
@@ -12,7 +12,7 @@ import (
 type FeatureExtractor interface {
 	// Configure the feature extractor with a database and options.
 	// This function should also create the needed database structures.
-	Init(db db.DB, opts conf.RawOpts) error
+	Init(db db.DB, conf conf.FeatureExtractorConfig) error
 	// Extract features from the given data.
 	Extract() ([]Feature, error)
 	// Get the name of this feature extractor.

--- a/internal/extractor/plugins/kvm/node_exporter_host_cpu_usage_test.go
+++ b/internal/extractor/plugins/kvm/node_exporter_host_cpu_usage_test.go
@@ -19,8 +19,18 @@ func TestNodeExporterHostCPUUsageExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &NodeExporterHostCPUUsageExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+
+	config := conf.FeatureExtractorConfig{
+		Name:           "node_exporter_host_cpu_usage_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if extractor.RecencySeconds != 0 {
+		t.Errorf("expected RecencySeconds to be 0, got %d", extractor.RecencySeconds)
 	}
 
 	if !testDB.TableExists(NodeExporterHostCPUUsage{}) {
@@ -54,7 +64,13 @@ func TestNodeExporterHostCPUUsageExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &NodeExporterHostCPUUsageExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+
+	config := conf.FeatureExtractorConfig{
+		Name:           "node_exporter_host_cpu_usage_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err = extractor.Extract(); err != nil {

--- a/internal/extractor/plugins/kvm/node_exporter_host_memory_active_test.go
+++ b/internal/extractor/plugins/kvm/node_exporter_host_memory_active_test.go
@@ -19,8 +19,17 @@ func TestNodeExporterHostMemoryActiveExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &NodeExporterHostMemoryActiveExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "node_exporter_host_memory_active_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if extractor.RecencySeconds != 0 {
+		t.Errorf("expected RecencySeconds to be 0, got %d", extractor.RecencySeconds)
 	}
 
 	if !testDB.TableExists(NodeExporterHostMemoryActive{}) {
@@ -54,7 +63,12 @@ func TestNodeExporterHostMemoryActiveExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &NodeExporterHostMemoryActiveExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "node_exporter_host_memory_active_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err = extractor.Extract(); err != nil {

--- a/internal/extractor/plugins/shared/flavor_host_space_test.go
+++ b/internal/extractor/plugins/shared/flavor_host_space_test.go
@@ -19,8 +19,17 @@ func TestFlavorHostSpaceExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &FlavorHostSpaceExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "flavor_host_space_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil, // No recency for this test
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if extractor.RecencySeconds != 0 {
+		t.Errorf("expected RecencySeconds to be 0, got %d", extractor.RecencySeconds)
 	}
 
 	if !testDB.TableExists(FlavorHostSpace{}) {
@@ -60,7 +69,12 @@ func TestFlavorHostSpaceExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &FlavorHostSpaceExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "flavor_host_space_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil, // No recency for this test
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err := extractor.Extract(); err != nil {

--- a/internal/extractor/plugins/shared/vm_host_residency_test.go
+++ b/internal/extractor/plugins/shared/vm_host_residency_test.go
@@ -20,8 +20,17 @@ func TestVMHostResidencyExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &VMHostResidencyExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "vm_host_residency_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error during initialization, got %v", err)
+	}
+
+	if extractor.RecencySeconds != 0 {
+		t.Errorf("expected RecencySeconds to be 0, got %d", extractor.RecencySeconds)
 	}
 
 	if !testDB.TableExists(VMHostResidency{}) {
@@ -76,7 +85,12 @@ func TestVMHostResidencyExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &VMHostResidencyExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "vm_host_residency_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil, // No recency for this test
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error during initialization, got %v", err)
 	}
 

--- a/internal/extractor/plugins/shared/vm_life_span_test.go
+++ b/internal/extractor/plugins/shared/vm_life_span_test.go
@@ -23,8 +23,17 @@ func TestVMLifeSpanExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &VMLifeSpanExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "vm_life_span_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil, // No recency for this test
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error during initialization, got %v", err)
+	}
+
+	if extractor.RecencySeconds != 0 {
+		t.Errorf("expected RecencySeconds to be 0, got %d", extractor.RecencySeconds)
 	}
 
 	if !testDB.TableExists(VMLifeSpan{}) {
@@ -70,7 +79,12 @@ func TestVMLifeSpanExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &VMLifeSpanExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "vm_life_span_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil, // No recency for this test
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error during initialization, got %v", err)
 	}
 

--- a/internal/extractor/plugins/vmware/vrops_hostsystem_contention_long_term_test.go
+++ b/internal/extractor/plugins/vmware/vrops_hostsystem_contention_long_term_test.go
@@ -19,8 +19,19 @@ func TestVROpsHostsystemContentionLongTermExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &VROpsHostsystemContentionLongTermExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+
+	recencySeconds := 1
+	config := conf.FeatureExtractorConfig{
+		Name:           "vrops_hostsystem_contention_long_term_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: &recencySeconds,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if extractor.RecencySeconds != 1 {
+		t.Errorf("expected RecencySeconds to be 1, got %d", extractor.RecencySeconds)
 	}
 
 	if !testDB.TableExists(VROpsHostsystemContentionLongTerm{}) {
@@ -66,7 +77,12 @@ func TestVROpsHostsystemContentionLongTermExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &VROpsHostsystemContentionLongTermExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "vrops_hostsystem_contention_long_term_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err = extractor.Extract(); err != nil {

--- a/internal/extractor/plugins/vmware/vrops_hostsystem_contention_short_term_test.go
+++ b/internal/extractor/plugins/vmware/vrops_hostsystem_contention_short_term_test.go
@@ -19,8 +19,18 @@ func TestVROpsHostsystemContentionShortTermExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &VROpsHostsystemContentionShortTermExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+
+	config := conf.FeatureExtractorConfig{
+		Name:           "vrops_hostsystem_contention_short_term_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if extractor.RecencySeconds != 0 {
+		t.Errorf("expected RecencySeconds to be 0, got %d", extractor.RecencySeconds)
 	}
 
 	if !testDB.TableExists(VROpsHostsystemContentionShortTerm{}) {
@@ -66,7 +76,12 @@ func TestVROpsHostsystemContentionShortTermExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &VROpsHostsystemContentionShortTermExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "vrops_hostsystem_contention_short_term_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err = extractor.Extract(); err != nil {

--- a/internal/extractor/plugins/vmware/vrops_hostsystem_resolver_test.go
+++ b/internal/extractor/plugins/vmware/vrops_hostsystem_resolver_test.go
@@ -20,8 +20,18 @@ func TestVROpsHostsystemResolver_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &VROpsHostsystemResolver{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+
+	config := conf.FeatureExtractorConfig{
+		Name:           "vrops_hostsystem_resolver",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if extractor.RecencySeconds != 0 {
+		t.Errorf("expected RecencySeconds to be 0, got %d", extractor.RecencySeconds)
 	}
 
 	// Verify the table was created
@@ -67,7 +77,12 @@ func TestVROpsHostsystemResolver_Extract(t *testing.T) {
 	}
 
 	extractor := &VROpsHostsystemResolver{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+	config := conf.FeatureExtractorConfig{
+		Name:           "vrops_hostsystem_resolver",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err := extractor.Extract(); err != nil {

--- a/internal/extractor/plugins/vmware/vrops_project_noisiness_test.go
+++ b/internal/extractor/plugins/vmware/vrops_project_noisiness_test.go
@@ -20,8 +20,18 @@ func TestVROpsProjectNoisinessExtractor_Init(t *testing.T) {
 	defer dbEnv.Close()
 
 	extractor := &VROpsProjectNoisinessExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+
+	config := conf.FeatureExtractorConfig{
+		Name:           "vrops_project_noisiness_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if extractor.RecencySeconds != 0 {
+		t.Errorf("expected RecencySeconds to be 0, got %d", extractor.RecencySeconds)
 	}
 	// Will fail when the table does not exist
 	err := testDB.SelectOne(&VROpsProjectNoisiness{}, "SELECT * FROM feature_vrops_project_noisiness LIMIT 1")
@@ -78,7 +88,14 @@ func TestVROpsProjectNoisinessExtractor_Extract(t *testing.T) {
 	}
 
 	extractor := &VROpsProjectNoisinessExtractor{}
-	if err := extractor.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+
+	config := conf.FeatureExtractorConfig{
+		Name:           "vrops_project_noisines_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+
+	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if _, err := extractor.Extract(); err != nil {


### PR DESCRIPTION
- Added a `recencySeconds` config option so you can control how much time needs to pass before a feature extractor runs again.
- Implemented logic to check if the last update is at least `recencySeconds` ago before extracting features.
- Adjusted tests and code to work with the new recency logic.

@PhilippMatthes after your vacation I’d like to discuss with you what a suitable recency would be for each feature extractor.
