### PR TITLE
PoC: Introduce read-only postgres replicas for accelerated scheduling queries

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -76,9 +76,10 @@ k8s_resource('cortex-mqtt', port_forwards=[
 ########### Postgres DB for Cortex Core Service
 local('sh helm/sync.sh helm/cortex-postgres')
 k8s_yaml(helm('./helm/cortex-postgres', name='cortex-postgres'))
-k8s_resource('cortex-postgresql', port_forwards=[
+k8s_resource('cortex-postgresql-primary', port_forwards=[
     port_forward(5432, 5432),
 ], labels=['Core-Services'])
+k8s_resource('cortex-postgresql-read', labels=['Core-Services'])
 
 ########### Monitoring
 local('sh helm/sync.sh helm/cortex-prometheus-operator')

--- a/commands/fillup/fillup.go
+++ b/commands/fillup/fillup.go
@@ -45,7 +45,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	db := db.NewPostgresDB(conf.DBConfig{
+	db := db.NewPostgresDB(conf.DBConnectionConfig{
 		Host:     "localhost",
 		Port:     5432,
 		User:     "postgres",

--- a/helm/cortex-postgres/Chart.yaml
+++ b/helm/cortex-postgres/Chart.yaml
@@ -5,11 +5,10 @@ apiVersion: v2
 name: cortex-postgres
 description: Postgres setup for Cortex.
 type: application
-version: 0.1.1
+version: 0.2.0
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
-    # Use a specific version of this chart which contains compliant images.
     version: 15.5.27
   # Owner info adds a configmap to the kubernetes cluster with information on
   # the service owner. This makes it easier to find out who to contact in case

--- a/helm/cortex-postgres/values.yaml
+++ b/helm/cortex-postgres/values.yaml
@@ -11,6 +11,10 @@ owner-info:
   enabled: true
 
 postgresql:
+  architecture: replication
+  readReplicas:
+    replicaCount: 2
+
   fullnameOverride: cortex-postgresql
   volumePermissions:
     enabled: true

--- a/helm/cortex-postgres/values.yaml
+++ b/helm/cortex-postgres/values.yaml
@@ -20,6 +20,7 @@ postgresql:
     enabled: true
   auth:
     postgresPassword: secret
+    replicationPassword: secret
   service:
     ports:
       postgresql: 5432

--- a/helm/cortex/Chart.yaml
+++ b/helm/cortex/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cortex
 description: A Helm chart for deploying Cortex.
 type: application
-version: 0.19.0
+version: 0.20.0
 appVersion: 0.1.0
 dependencies:
   # Owner info adds a configmap to the kubernetes cluster with information on

--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -108,15 +108,21 @@ conf:
 
   # Connection parameters for the database where data is stored.
   db:
-    host: cortex-postgresql
-    port: 5432
-    user: postgres
-    password: secret
-    database: postgres
-    reconnect:
-      maxRetries: 20
-      retryIntervalSeconds: 1
-      livenessPingIntervalSeconds: 5
+    sharedDBConf: &sharedDBConf
+      port: 5432
+      user: postgres
+      password: secret
+      database: postgres
+      reconnect:
+        maxRetries: 20
+        retryIntervalSeconds: 1
+        livenessPingIntervalSeconds: 5
+    primary:
+      <<: *sharedDBConf
+      host: cortex-postgresql-primary
+    readonly:
+      <<: *sharedDBConf
+      host: cortex-postgresql-read
 
   # Sync plugins config.
   sync:

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -35,14 +35,19 @@ type DBReconnectConfig struct {
 	MaxRetries int `json:"maxRetries"`
 }
 
-// Database configuration.
-type DBConfig struct {
+type DBConnectionConfig struct {
 	Host      string            `json:"host"`
 	Port      int               `json:"port"`
 	Database  string            `json:"database"`
 	User      string            `json:"user"`
 	Password  string            `json:"password"`
 	Reconnect DBReconnectConfig `json:"reconnect"`
+}
+
+// Database configuration.
+type DBConfig struct {
+	Primary  DBConnectionConfig `json:"primary"`
+	ReadOnly DBConnectionConfig `json:"readonly"`
 }
 
 // Metric configuration for the sync/prometheus module.

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -97,12 +97,21 @@ func TestNewConfig(t *testing.T) {
     "format": "text"
   },
   "db": {
-    "host": "cortex-postgresql",
-    "port": 5432,
-    "user": "postgres",
-    "password": "secret",
-    "database": "postgres"
-  },
+    "primary": {
+      "host": "cortex-postgresql-primary",
+      "port": 5432,
+      "user": "postgres",
+      "password": "secret",
+      "database": "postgres"
+    },
+	"readonly": {
+      "host": "cortex-postgresql-readonly",
+      "port": 5432,
+      "user": "postgres",
+      "password": "secret",
+      "database": "postgres"
+    },
+},
   "monitoring": {
     "port": 2112,
     "labels": {
@@ -176,20 +185,36 @@ func TestNewConfig(t *testing.T) {
 
 	// Test DBConfig
 	dbConfig := config.GetDBConfig()
-	if dbConfig.Host == "" {
+	if dbConfig.Primary.Host == "" {
 		t.Errorf("Expected non-empty DB host, got empty string")
 	}
-	if dbConfig.Port == 0 {
+	if dbConfig.Primary.Port == 0 {
 		t.Errorf("Expected non-zero DB port, got 0")
 	}
-	if dbConfig.Database == "" {
+	if dbConfig.Primary.Database == "" {
 		t.Errorf("Expected non-empty DB name, got empty string")
 	}
-	if dbConfig.User == "" {
+	if dbConfig.Primary.User == "" {
 		t.Errorf("Expected non-empty DB user, got empty string")
 	}
-	if dbConfig.Password == "" {
+	if dbConfig.Primary.Password == "" {
 		t.Errorf("Expected non-empty DB password, got empty string")
+	}
+	// Check the read-only DB configuration as well
+	if dbConfig.ReadOnly.Host == "" {
+		t.Errorf("Expected non-empty read-only DB host, got empty string")
+	}
+	if dbConfig.ReadOnly.Port == 0 {
+		t.Errorf("Expected non-zero read-only DB port, got 0")
+	}
+	if dbConfig.ReadOnly.Database == "" {
+		t.Errorf("Expected non-empty read-only DB name, got empty string")
+	}
+	if dbConfig.ReadOnly.User == "" {
+		t.Errorf("Expected non-empty read-only DB user, got empty string")
+	}
+	if dbConfig.ReadOnly.Password == "" {
+		t.Errorf("Expected non-empty read-only DB password, got empty string")
 	}
 
 	// Test MonitoringConfig

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -110,7 +110,7 @@ func TestNewConfig(t *testing.T) {
       "user": "postgres",
       "password": "secret",
       "database": "postgres"
-    },
+    }
 },
   "monitoring": {
     "port": 2112,

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -23,7 +23,7 @@ import (
 // Wrapper around gorp.DbMap that adds some convenience functions.
 type DB struct {
 	*gorp.DbMap
-	conf conf.DBConfig
+	conf conf.DBConnectionConfig
 	// Monitor for database related metrics like connection attempts.
 	monitor Monitor
 }
@@ -39,7 +39,7 @@ type Index struct {
 }
 
 // Create a new postgres database and wait until it is connected.
-func NewPostgresDB(c conf.DBConfig, registry *monitoring.Registry, monitor Monitor) DB {
+func NewPostgresDB(c conf.DBConnectionConfig, registry *monitoring.Registry, monitor Monitor) DB {
 	strip := func(s string) string { return strings.ReplaceAll(s, "\n", "") }
 	dbURL, err := easypg.URLFrom(easypg.URLParts{
 		HostName:          strip(c.Host),

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -42,7 +42,7 @@ func TestNewDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to convert port: %v", err)
 	}
-	config := conf.DBConfig{
+	config := conf.DBConnectionConfig{
 		Host:     "localhost",
 		Port:     port,
 		User:     "postgres",
@@ -290,7 +290,7 @@ func TestUnexpectedConnectionLoss(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to convert port: %v", err)
 	}
-	config := conf.DBConfig{
+	config := conf.DBConnectionConfig{
 		Host:     "localhost",
 		Port:     port,
 		User:     "postgres",


### PR DESCRIPTION
This is a proof-of-concept of how we can decrease the query time in the scheduler service further by introducing 2 read-only replicas for the postgres instance. This is a breaking change in the postgres chart, meaning we need to either migrate the dbs by hand or reset them. 

In preliminary testing this reduced query time in the scheduler by ~80%, caveat this was no reproducable clean measurement.