### PR TITLE
Reduce number of features calculated by vm_life_span extractor

### DIFF
--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -300,7 +300,7 @@ conf:
                   - flavors
                   - servers
                   - migrations
-      - name: vm_life_span_extractor
+      - name: vm_life_span_histogram_extractor
         recencySeconds: 60 # 1 minute
         dependencies:
           sync:
@@ -345,7 +345,7 @@ conf:
         dependencies:
           features:
             extractors:
-              - vm_life_span_extractor
+              - vm_life_span_histogram_extractor
 
   scheduler:
     api:

--- a/internal/extractor/monitor.go
+++ b/internal/extractor/monitor.go
@@ -144,6 +144,9 @@ func monitorFeatureExtractor[F plugins.FeatureExtractor](f F, m Monitor) Feature
 // Run the wrapped feature extractor and measure the time it takes.
 func (m FeatureExtractorMonitor[F]) Extract() ([]plugins.Feature, error) {
 	slog.Info("features: extracting", "extractor", m.GetName())
+
+	// Only measure and record extraction duration if an update is actually needed.
+	// This prevents unnecessary measurements from skewing the average and minimum values of the timing metric.
 	if m.runTimer != nil && m.NeedsUpdate() {
 		timer := prometheus.NewTimer(m.runTimer)
 		defer timer.ObserveDuration()

--- a/internal/extractor/monitor.go
+++ b/internal/extractor/monitor.go
@@ -144,7 +144,7 @@ func monitorFeatureExtractor[F plugins.FeatureExtractor](f F, m Monitor) Feature
 // Run the wrapped feature extractor and measure the time it takes.
 func (m FeatureExtractorMonitor[F]) Extract() ([]plugins.Feature, error) {
 	slog.Info("features: extracting", "extractor", m.GetName())
-	if m.runTimer != nil {
+	if m.runTimer != nil && m.NeedsUpdate() {
 		timer := prometheus.NewTimer(m.runTimer)
 		defer timer.ObserveDuration()
 	}

--- a/internal/extractor/pipeline.go
+++ b/internal/extractor/pipeline.go
@@ -33,7 +33,7 @@ var SupportedExtractors = []plugins.FeatureExtractor{
 	&shared.HostSpaceExtractor{},
 	&shared.HostCapabilitiesExtractor{},
 	&shared.VMHostResidencyExtractor{},
-	&shared.VMLifeSpanExtractor{},
+	&shared.VMLifeSpanHistogramExtractor{},
 }
 
 // Pipeline that contains multiple feature extractors and executes them.

--- a/internal/extractor/plugins/shared/vm_life_span.go
+++ b/internal/extractor/plugins/shared/vm_life_span.go
@@ -5,48 +5,63 @@ package shared
 
 import (
 	_ "embed"
+	"log/slog"
+	"strings"
 
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/extractor/plugins"
 	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/nova"
+	"github.com/cobaltcore-dev/cortex/internal/tools"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-// Feature that describes how long a vm existed before it was deleted.
-type VMLifeSpan struct {
+type VMLifeSpanRaw struct {
 	// Time the vm stayed on the host in seconds.
 	Duration int `db:"duration"`
 	// Flavor name of the virtual machine.
 	FlavorName string `db:"flavor_name"`
-	// The UUID of the virtual machine.
-	InstanceUUID string `db:"instance_uuid"`
+}
+
+// Feature that describes how long a vm existed before it was deleted.
+type VMLifeSpanHistogramBucket struct {
+	// Flavor name of the virtual machine.
+	FlavorName string `db:"flavor_name"`
+	// The bucket this life span falls into.
+	Bucket float64 `db:"bucket"`
+	// The value of the bucket.
+	Value uint64 `db:"value"`
+	// The count of vms that fell into this bucket.
+	Count uint64 `db:"count"`
+	// The sum of all durations that fell into this bucket.
+	Sum float64 `db:"sum"`
 }
 
 // Table under which the feature is stored.
-func (VMLifeSpan) TableName() string {
-	return "feature_vm_life_span"
+func (VMLifeSpanHistogramBucket) TableName() string {
+	return "feature_vm_life_span_histogram_bucket"
 }
 
 // Indexes for the feature.
-func (VMLifeSpan) Indexes() []db.Index {
+func (VMLifeSpanHistogramBucket) Indexes() []db.Index {
 	return nil
 }
 
 // Extractor that extracts the time elapsed until the vm was deleted.
-type VMLifeSpanExtractor struct {
+type VMLifeSpanHistogramExtractor struct {
 	// Common base for all extractors that provides standard functionality.
 	plugins.BaseExtractor[
-		struct{},   // No options passed through yaml config
-		VMLifeSpan, // Feature model
+		struct{},                  // No options passed through yaml config
+		VMLifeSpanHistogramBucket, // Feature model
 	]
 }
 
 // Name of this feature extractor that is used in the yaml config, for logging etc.
-func (*VMLifeSpanExtractor) GetName() string {
-	return "vm_life_span_extractor"
+func (*VMLifeSpanHistogramExtractor) GetName() string {
+	return "vm_life_span_histogram_extractor"
 }
 
 // Get message topics that trigger a re-execution of this extractor.
-func (VMLifeSpanExtractor) Triggers() []string {
+func (VMLifeSpanHistogramExtractor) Triggers() []string {
 	return []string{
 		nova.TriggerNovaServersSynced,
 		nova.TriggerNovaFlavorsSynced,
@@ -58,6 +73,37 @@ var vmLifeSpanQuery string
 
 // Extract the time elapsed until the first migration of a virtual machine.
 // Depends on the OpenStack servers and migrations to be synced.
-func (e *VMLifeSpanExtractor) Extract() ([]plugins.Feature, error) {
-	return e.ExtractSQL(vmLifeSpanQuery)
+func (e *VMLifeSpanHistogramExtractor) Extract() ([]plugins.Feature, error) {
+	var lifeSpansRaw []VMLifeSpanRaw
+	if _, err := e.DB.Select(&lifeSpansRaw, vmLifeSpanQuery); err != nil {
+		return nil, err
+	}
+	// Calculate the histogram based on the extracted features.
+	buckets := prometheus.ExponentialBucketsRange(5, 365*24*60*60, 30)
+	keysFunc := func(lifeSpan VMLifeSpanRaw) []string {
+		return []string{lifeSpan.FlavorName, "all"}
+	}
+	valueFunc := func(lifeSpan VMLifeSpanRaw) float64 {
+		return float64(lifeSpan.Duration)
+	}
+	hists, counts, sums := tools.Histogram(lifeSpansRaw, buckets, keysFunc, valueFunc)
+	var features []VMLifeSpanHistogramBucket
+	for key, hist := range hists {
+		labels := strings.Split(key, ",")
+		if len(labels) != 1 {
+			slog.Warn("vm_life_span: unexpected comma in flavor name")
+			continue
+		}
+		for bucket, value := range hist {
+			// Create a feature for each bucket.
+			features = append(features, VMLifeSpanHistogramBucket{
+				FlavorName: labels[0],
+				Bucket:     bucket,
+				Value:      value,
+				Count:      counts[key],
+				Sum:        sums[key],
+			})
+		}
+	}
+	return e.Extracted(features)
 }

--- a/internal/extractor/plugins/shared/vm_life_span.sql
+++ b/internal/extractor/plugins/shared/vm_life_span.sql
@@ -2,8 +2,7 @@ SELECT
     CAST(EXTRACT(EPOCH FROM (
         servers.updated::timestamp - servers.created::timestamp
     )) AS BIGINT) AS duration,
-    COALESCE(flavors.name, 'unknown') AS flavor_name,
-    servers.id AS instance_uuid
+    COALESCE(flavors.name, 'unknown') AS flavor_name
 FROM openstack_servers servers
 LEFT JOIN openstack_flavors flavors ON flavors.name = servers.flavor_name
 WHERE servers.status = 'DELETED';

--- a/internal/kpis/plugins/shared/host_utilization.go
+++ b/internal/kpis/plugins/shared/host_utilization.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/kpis/plugins"
 	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/nova"
+	"github.com/cobaltcore-dev/cortex/internal/tools"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -101,7 +102,7 @@ func (k *HostUtilizationKPI) Collect(ch chan<- prometheus.Metric) {
 		}
 		return 100 * float64(hypervisor.VCPUsUsed) / float64(hypervisor.VCPUs)
 	}
-	hists, counts, sums := plugins.Histogram(hypervisors, buckets, keysFunc, valueFunc)
+	hists, counts, sums := tools.Histogram(hypervisors, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.hostResourceUsedHist, counts[key], sums[key], hist, key)
 	}
@@ -114,7 +115,7 @@ func (k *HostUtilizationKPI) Collect(ch chan<- prometheus.Metric) {
 		}
 		return 100 * float64(hypervisor.MemoryMBUsed) / float64(hypervisor.MemoryMB)
 	}
-	hists, counts, sums = plugins.Histogram(hypervisors, buckets, keysFunc, valueFunc)
+	hists, counts, sums = tools.Histogram(hypervisors, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.hostResourceUsedHist, counts[key], sums[key], hist, key)
 	}
@@ -127,7 +128,7 @@ func (k *HostUtilizationKPI) Collect(ch chan<- prometheus.Metric) {
 		}
 		return 100 * float64(hypervisor.LocalGBUsed) / float64(hypervisor.LocalGB)
 	}
-	hists, counts, sums = plugins.Histogram(hypervisors, buckets, keysFunc, valueFunc)
+	hists, counts, sums = tools.Histogram(hypervisors, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.hostResourceUsedHist, counts[key], sums[key], hist, key)
 	}

--- a/internal/kpis/plugins/shared/vm_life_span.go
+++ b/internal/kpis/plugins/shared/vm_life_span.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/extractor/plugins/shared"
 	"github.com/cobaltcore-dev/cortex/internal/kpis/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/tools"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -58,7 +59,7 @@ func (k *VMLifeSpanKPI) Collect(ch chan<- prometheus.Metric) {
 	valueFunc := func(lifeSpan shared.VMLifeSpan) float64 {
 		return float64(lifeSpan.Duration)
 	}
-	hists, counts, sums := plugins.Histogram(vmLifeSpans, buckets, keysFunc, valueFunc)
+	hists, counts, sums := tools.Histogram(vmLifeSpans, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		labels := strings.Split(key, ",")
 		if len(labels) != 1 {

--- a/internal/kpis/plugins/shared/vm_life_span.go
+++ b/internal/kpis/plugins/shared/vm_life_span.go
@@ -5,13 +5,11 @@ package shared
 
 import (
 	"log/slog"
-	"strings"
 
 	"github.com/cobaltcore-dev/cortex/internal/conf"
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/extractor/plugins/shared"
 	"github.com/cobaltcore-dev/cortex/internal/kpis/plugins"
-	"github.com/cobaltcore-dev/cortex/internal/tools"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -46,26 +44,37 @@ func (k *VMLifeSpanKPI) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (k *VMLifeSpanKPI) Collect(ch chan<- prometheus.Metric) {
-	var vmLifeSpans []shared.VMLifeSpan
-	tableName := shared.VMLifeSpan{}.TableName()
-	if _, err := k.DB.Select(&vmLifeSpans, "SELECT * FROM "+tableName); err != nil {
+	// The buckets are already aggregated in the database, so we can just select them.
+	var buckets []shared.VMLifeSpanHistogramBucket
+	tableName := shared.VMLifeSpanHistogramBucket{}.TableName()
+	if _, err := k.DB.Select(&buckets, "SELECT * FROM "+tableName); err != nil {
 		slog.Error("failed to select vm life spans", "err", err)
 		return
 	}
-	buckets := prometheus.ExponentialBucketsRange(5, 365*24*60*60, 30)
-	keysFunc := func(lifeSpan shared.VMLifeSpan) []string {
-		return []string{lifeSpan.FlavorName, "all"}
-	}
-	valueFunc := func(lifeSpan shared.VMLifeSpan) float64 {
-		return float64(lifeSpan.Duration)
-	}
-	hists, counts, sums := tools.Histogram(vmLifeSpans, buckets, keysFunc, valueFunc)
-	for key, hist := range hists {
-		labels := strings.Split(key, ",")
-		if len(labels) != 1 {
-			slog.Warn("vm_life_span: unexpected comma in flavor name")
+	bucketsByFlavor := make(map[string][]shared.VMLifeSpanHistogramBucket)
+	for _, bucket := range buckets {
+		if bucket.FlavorName == "" {
+			slog.Warn("vm_life_span: empty flavor name in bucket", "bucket", bucket)
 			continue
 		}
-		ch <- prometheus.MustNewConstHistogram(k.lifeSpanDesc, counts[key], sums[key], hist, labels...)
+		bucketsByFlavor[bucket.FlavorName] = append(bucketsByFlavor[bucket.FlavorName], bucket)
+	}
+	for flavor, buckets := range bucketsByFlavor {
+		if len(buckets) == 0 {
+			slog.Warn("vm_life_span: no buckets for flavor", "flavor", flavor)
+			continue
+		}
+		var count uint64
+		var sum float64
+		hist := make(map[float64]uint64, len(buckets))
+		for _, bucket := range buckets {
+			hist[bucket.Bucket] = bucket.Value
+			count = bucket.Count // Same for all bucket objects.
+			sum = bucket.Sum     // Same for all bucket objects.
+		}
+		ch <- prometheus.MustNewConstHistogram(
+			k.lifeSpanDesc,
+			count, sum, hist, flavor,
+		)
 	}
 }

--- a/internal/kpis/plugins/shared/vm_life_span_test.go
+++ b/internal/kpis/plugins/shared/vm_life_span_test.go
@@ -33,19 +33,20 @@ func TestVMLifeSpanKPI_Collect(t *testing.T) {
 
 	// Create dependency tables
 	if err := testDB.CreateTable(
-		testDB.AddTable(shared.VMLifeSpan{}),
+		testDB.AddTable(shared.VMLifeSpanHistogramBucket{}),
 	); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the vm_life_span table
+	// Insert mock data into the table
 	_, err := testDB.Exec(`
-        INSERT INTO feature_vm_life_span (
-            duration, flavor_name, instance_uuid
+        INSERT INTO feature_vm_life_span_histogram_bucket (
+            flavor_name, bucket, value, count, sum
         )
         VALUES
-            (3600, 'flavor1', 'uuid1'),
-            (7200, 'flavor2', 'uuid2')
+		    ('small', 60, 100, 10, 600),
+		    ('medium', 120, 200, 20, 2400),
+		    ('large', 180, 300, 30, 5400)
     `)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/internal/kpis/plugins/shared/vm_migration_statistics.go
+++ b/internal/kpis/plugins/shared/vm_migration_statistics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/extractor/plugins/shared"
 	"github.com/cobaltcore-dev/cortex/internal/kpis/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/tools"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -72,7 +73,7 @@ func (k *VMMigrationStatisticsKPI) Collect(ch chan<- prometheus.Metric) {
 	valueFunc := func(residency shared.VMHostResidency) float64 {
 		return float64(residency.Duration)
 	}
-	hists, counts, sums := plugins.Histogram(hostResidencies, buckets, keysFunc, valueFunc)
+	hists, counts, sums := tools.Histogram(hostResidencies, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		labels := strings.Split(key, ",")
 		if len(labels) != 2 {

--- a/internal/kpis/plugins/vmware/host_contention.go
+++ b/internal/kpis/plugins/vmware/host_contention.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/extractor/plugins/vmware"
 	"github.com/cobaltcore-dev/cortex/internal/kpis/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/tools"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -61,7 +62,7 @@ func (k *VMwareHostContentionKPI) Collect(ch chan<- prometheus.Metric) {
 	valueFunc := func(contention vmware.VROpsHostsystemContentionLongTerm) float64 {
 		return contention.MaxCPUContention
 	}
-	hists, counts, sums := plugins.Histogram(contentions, buckets, keysFunc, valueFunc)
+	hists, counts, sums := tools.Histogram(contentions, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.hostCPUContentionMax, counts[key], sums[key], hist)
 	}
@@ -71,7 +72,7 @@ func (k *VMwareHostContentionKPI) Collect(ch chan<- prometheus.Metric) {
 	valueFunc = func(contention vmware.VROpsHostsystemContentionLongTerm) float64 {
 		return float64(contention.AvgCPUContention)
 	}
-	hists, counts, sums = plugins.Histogram(contentions, buckets, keysFunc, valueFunc)
+	hists, counts, sums = tools.Histogram(contentions, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.hostCPUContentionAvg, counts[key], sums[key], hist)
 	}

--- a/internal/kpis/plugins/vmware/project_noisiness.go
+++ b/internal/kpis/plugins/vmware/project_noisiness.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/extractor/plugins/vmware"
 	"github.com/cobaltcore-dev/cortex/internal/kpis/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/tools"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -54,7 +55,7 @@ func (k *VMwareProjectNoisinessKPI) Collect(ch chan<- prometheus.Metric) {
 	valueFunc := func(noisiness vmware.VROpsProjectNoisiness) float64 {
 		return float64(noisiness.AvgCPUOfProject)
 	}
-	hists, counts, sums := plugins.Histogram(features, buckets, keysFunc, valueFunc)
+	hists, counts, sums := tools.Histogram(features, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.projectNoisinessDesc, counts[key], sums[key], hist)
 	}

--- a/internal/tools/histogram.go
+++ b/internal/tools/histogram.go
@@ -1,12 +1,10 @@
 // Copyright 2025 SAP SE
 // SPDX-License-Identifier: Apache-2.0
 
-package plugins
-
-import "github.com/cobaltcore-dev/cortex/internal/extractor/plugins"
+package tools
 
 // Create a histogram from features.
-func Histogram[O plugins.Feature](
+func Histogram[O any](
 	features []O,
 	buckets []float64,
 	keysFunc func(O) []string,

--- a/internal/tools/histogram_test.go
+++ b/internal/tools/histogram_test.go
@@ -1,7 +1,7 @@
 // Copyright 2025 SAP SE
 // SPDX-License-Identifier: Apache-2.0
 
-package plugins
+package tools
 
 import (
 	"reflect"


### PR DESCRIPTION
This PR moves the histogram logic of the vm_life_span kpi to the corresponding extractor, reducing the number of DB rows from n_servers (incl. deleted ones) to n_flavors * n_buckets.