### PR TITLE
Fix 10s cap for timer metrics

### DIFF
--- a/internal/extractor/monitor.go
+++ b/internal/extractor/monitor.go
@@ -32,7 +32,7 @@ func NewPipelineMonitor(registry *monitoring.Registry) Monitor {
 	stepRunTimer := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "cortex_feature_pipeline_step_run_duration_seconds",
 		Help:    "Duration of feature pipeline step run",
-		Buckets: prometheus.DefBuckets,
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 21), // 0.001s to ~1048s in 21 buckets
 	}, []string{"step"})
 	stepFeatureCounter := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "cortex_feature_pipeline_step_features",

--- a/internal/sync/monitor.go
+++ b/internal/sync/monitor.go
@@ -25,7 +25,7 @@ func NewSyncMonitor(registry *monitoring.Registry) Monitor {
 	pipelineRunTimer := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "cortex_sync_run_duration_seconds",
 		Help:    "Duration of sync run",
-		Buckets: prometheus.DefBuckets,
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 21), // 0.001s to ~1048s in 21 buckets,
 	}, []string{"datasource"})
 	pipelineObjectsGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "cortex_sync_objects",


### PR DESCRIPTION
Increase the Prometheus histogram bucket range for sync and extractor step durations from the default (capped at 10s) to exponential buckets spanning 0.001s up to ~1048s.

Applied to:
- `cortex_sync_run_duration_seconds`
- `cortex_feature_pipeline_step_run_duration_seconds`