### PR TITLE
Added host_total_capacity_kpi

### DIFF
--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -347,10 +347,26 @@ conf:
           extractors:
             - vrops_project_noisiness_extractor
       # Shared KPIs.
+      - name: host_total_capacity_kpi
+        dependencies:
+          extractors:
+            - host_utilization_extractor
+          sync:
+            openstack:
+              nova:
+                types:
+                  - hypervisors
+                  - aggregates
       - name: host_utilization_kpi
         dependencies:
           extractors:
             - host_utilization_extractor
+          sync:
+            openstack:
+              nova:
+                types:
+                  - hypervisors
+                  - aggregates
       - name: vm_migration_statistics_kpi
         dependencies:
           extractors:

--- a/internal/kpis/pipeline.go
+++ b/internal/kpis/pipeline.go
@@ -22,6 +22,7 @@ var SupportedKPIs = []plugins.KPI{
 	&vmware.VMwareProjectNoisinessKPI{},
 	// Shared kpis.
 	&shared.HostUtilizationKPI{},
+	&shared.HostTotalCapacityKPI{},
 	&shared.VMMigrationStatisticsKPI{},
 	&shared.VMLifeSpanKPI{},
 }

--- a/internal/kpis/plugins/shared/host_total_capacity.go
+++ b/internal/kpis/plugins/shared/host_total_capacity.go
@@ -73,7 +73,6 @@ func (k *HostTotalCapacityKPI) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	for _, hs := range hostTotalCapacity {
-
 		ch <- prometheus.MustNewConstMetric(
 			k.hostTotalCapacityPerHost,
 			prometheus.GaugeValue,
@@ -99,5 +98,4 @@ func (k *HostTotalCapacityKPI) Collect(ch chan<- prometheus.Metric) {
 			hs.AvailabilityZone,
 		)
 	}
-
 }

--- a/internal/kpis/plugins/shared/host_total_capacity.go
+++ b/internal/kpis/plugins/shared/host_total_capacity.go
@@ -1,0 +1,103 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"log/slog"
+
+	"github.com/cobaltcore-dev/cortex/internal/extractor/plugins/shared"
+	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/nova"
+
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	"github.com/cobaltcore-dev/cortex/internal/kpis/plugins"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type HostTotalCapacityKPI struct {
+	// Common base for all KPIs that provides standard functionality.
+	plugins.BaseKPI[struct{}] // No options passed through yaml config
+
+	hostTotalCapacityPerHost *prometheus.Desc
+}
+
+func (HostTotalCapacityKPI) GetName() string {
+	return "host_total_capacity_kpi"
+}
+
+func (k *HostTotalCapacityKPI) Init(db db.DB, opts conf.RawOpts) error {
+	if err := k.BaseKPI.Init(db, opts); err != nil {
+		return err
+	}
+	k.hostTotalCapacityPerHost = prometheus.NewDesc(
+		"cortex_host_total_capacity_per_host",
+		"Total resources available on the hosts currently (individually by host).",
+		[]string{"compute_host_name", "resource", "availability_zone"},
+		nil,
+	)
+	return nil
+}
+
+func (k *HostTotalCapacityKPI) Describe(ch chan<- *prometheus.Desc) {
+	ch <- k.hostTotalCapacityPerHost
+}
+
+func (k *HostTotalCapacityKPI) Collect(ch chan<- prometheus.Metric) {
+	type HostTotalCapacityWithAvailabilityZone struct {
+		shared.HostUtilization
+		AvailabilityZone string `db:"availability_zone"`
+	}
+
+	var hostTotalCapacity []HostTotalCapacityWithAvailabilityZone
+
+	aggregatesTableName := nova.Aggregate{}.TableName()
+	hostUtilizationTableName := shared.HostUtilization{}.TableName()
+
+	query := `
+        SELECT
+            f.*,
+            a.availability_zone
+        FROM ` + hostUtilizationTableName + ` AS f
+        JOIN (
+            SELECT DISTINCT compute_host, availability_zone
+            FROM ` + aggregatesTableName + `
+            WHERE availability_zone IS NOT NULL
+        ) AS a
+            ON f.compute_host = a.compute_host
+    `
+
+	if _, err := k.DB.Select(&hostTotalCapacity, query); err != nil {
+		slog.Error("failed to select host utilization", "err", err)
+		return
+	}
+
+	for _, hs := range hostTotalCapacity {
+
+		ch <- prometheus.MustNewConstMetric(
+			k.hostTotalCapacityPerHost,
+			prometheus.GaugeValue,
+			hs.TotalVCPUsAllocatable,
+			hs.ComputeHost,
+			"cpu",
+			hs.AvailabilityZone,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			k.hostTotalCapacityPerHost,
+			prometheus.GaugeValue,
+			hs.TotalDiskAllocatableGB,
+			hs.ComputeHost,
+			"disk",
+			hs.AvailabilityZone,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			k.hostTotalCapacityPerHost,
+			prometheus.GaugeValue,
+			hs.TotalMemoryAllocatableMB,
+			hs.ComputeHost,
+			"memory",
+			hs.AvailabilityZone,
+		)
+	}
+
+}

--- a/internal/kpis/plugins/shared/host_total_capacity_test.go
+++ b/internal/kpis/plugins/shared/host_total_capacity_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cobaltcore-dev/cortex/internal/extractor/plugins/shared"
+	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/nova"
+
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	testlibDB "github.com/cobaltcore-dev/cortex/testlib/db"
+	"github.com/prometheus/client_golang/prometheus"
+	prometheusgo "github.com/prometheus/client_model/go"
+)
+
+func TestHostTotalCapacityKPI_Init(t *testing.T) {
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	kpi := &HostTotalCapacityKPI{}
+	if err := kpi.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestHostTotalCapacityKPI_Collect(t *testing.T) {
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	// Create dependency tables
+	if err := testDB.CreateTable(
+		testDB.AddTable(shared.HostUtilization{}),
+		testDB.AddTable(nova.Aggregate{}),
+		testDB.AddTable(nova.Hypervisor{}),
+	); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Insert mock data into the hypervisor table
+	hypervisors := []any{
+		&nova.Hypervisor{ID: "1", ServiceHost: "host1"},
+		&nova.Hypervisor{ID: "2", ServiceHost: "host2"},
+	}
+	if err := testDB.Insert(hypervisors...); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Insert mock data into the host space table
+	hostUtilizations := []any{
+		&shared.HostUtilization{ComputeHost: "host1", RAMUtilizedPct: 50, VCPUsUtilizedPct: 50, DiskUtilizedPct: 50, TotalMemoryAllocatableMB: 1000, TotalVCPUsAllocatable: 100, TotalDiskAllocatableGB: 100},
+		&shared.HostUtilization{ComputeHost: "host2", RAMUtilizedPct: 80, VCPUsUtilizedPct: 75, DiskUtilizedPct: 80, TotalMemoryAllocatableMB: 1000, TotalVCPUsAllocatable: 100, TotalDiskAllocatableGB: 100},
+	}
+	if err := testDB.Insert(hostUtilizations...); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Insert mock data into the aggregates table
+	availabilityZone1 := "zone1"
+	availabilityZone2 := "zone2"
+	aggregates := []any{
+		&nova.Aggregate{Name: "zone1", AvailabilityZone: &availabilityZone1, ComputeHost: "host1"},
+		&nova.Aggregate{Name: "zone2", AvailabilityZone: &availabilityZone2, ComputeHost: "host2"},
+		&nova.Aggregate{Name: "something-else", AvailabilityZone: &availabilityZone2, ComputeHost: "host2"},
+	}
+	if err := testDB.Insert(aggregates...); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	kpi := &HostTotalCapacityKPI{}
+	if err := kpi.Init(testDB, conf.NewRawOpts("{}")); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	ch := make(chan prometheus.Metric, 10)
+	kpi.Collect(ch)
+	close(ch)
+
+	metricsCount := 0
+
+	// Used to track the number of metrics related to each host
+	metricsHost := make(map[string][]string)
+
+	metricsHost["host1"] = make([]string, 0)
+	metricsHost["host2"] = make([]string, 0)
+
+	for metric := range ch {
+		metricsCount++
+
+		var m prometheusgo.Metric
+		if err := metric.Write(&m); err != nil {
+			t.Fatalf("failed to write metric: %v", err)
+		}
+
+		labels := make(map[string]string)
+		for _, label := range m.Label {
+			labels[label.GetName()] = label.GetValue()
+		}
+
+		availabilityZone := labels["availability_zone"]
+		computeHostName := labels["compute_host_name"]
+
+		switch computeHostName {
+		case "host1":
+			if availabilityZone != "zone1" {
+				t.Errorf("expected availability zone for host1 to be zone1, got %s", availabilityZone)
+			}
+		case "host2":
+			if availabilityZone != "zone2" {
+				t.Errorf("expected availability zone for host2 to be zone2, got %s", availabilityZone)
+			}
+		default:
+			t.Errorf("unexpected compute host name: %s", computeHostName)
+		}
+		metricsHost[computeHostName] = append(metricsHost[computeHostName], labels["resource"])
+	}
+
+	for host, resources := range metricsHost {
+		// Since we store cpu, disk and memory utilization for each host we expect 3 metrics per host
+		if len(resources) != 3 {
+			t.Errorf("expected 3 metrics for host %s, got %d", host, len(resources))
+		}
+		joinedResources := strings.Join(resources, ", ")
+
+		if !strings.Contains(joinedResources, "memory") ||
+			!strings.Contains(joinedResources, "disk") ||
+			!strings.Contains(joinedResources, "cpu") {
+			t.Errorf("expected resources for host %s to include memory, disk, and cpu, got %s", host, joinedResources)
+		}
+	}
+
+	if metricsCount == 0 {
+		t.Errorf("expected metrics to be collected, got %d", metricsCount)
+	}
+}


### PR DESCRIPTION
This PR introduces the KPI `cortex_host_total_capacity_per_host` to visualize the total capacity (CPU, RAM, Disk) of each host over time. This enhancement addresses an issue observed when a hypervisor server was physically shut down, causing the cluster’s total RAM capacity to be halved. Since neither Nova nor Placement performs automatic balancing, the VMs remain assigned to the cluster—even when they are in the `SHUTOFF` state. In OpenStack, VMs in `SHUTOFF` status continue to consume resources. As a result, Placement may report an inflated utilization value in such scenarios.