### PR TITLE
Extend bitnami postgres chart to support major version upgrades

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -84,7 +84,13 @@ local('sh helm/sync.sh helm/cortex-postgres')
 k8s_yaml(helm('./helm/cortex-postgres', name='cortex-postgres'))
 k8s_resource('cortex-postgresql', port_forwards=[
     port_forward(5432, 5432),
-], labels=['Core-Services'])
+], labels=['Database'])
+# Get the version from the chart.
+cmd = "helm show chart ./helm/cortex-postgres | grep -E '^version:' | awk '{print $2}'"
+chart_version = str(local(cmd)).strip()
+# Use the chart version to name the pre-upgrade job.
+k8s_resource('cortex-postgresql-pre-upgrade-'+chart_version, labels=['Database'])
+k8s_resource('cortex-postgresql-post-upgrade-'+chart_version, labels=['Database'])
 
 ########### Monitoring
 local('sh helm/sync.sh helm/cortex-prometheus-operator')

--- a/helm/cortex-postgres/Chart.lock
+++ b/helm/cortex-postgres/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.5.27
+  version: 16.7.15
 - name: owner-info
   repository: oci://ghcr.io/sapcc/helm-charts
   version: 1.0.0
-digest: sha256:26cb9c33b10bfaec7d04e718c321935eb031c3d0e426902afc12b99541a20ad7
-generated: "2025-04-23T08:52:04.316499+02:00"
+digest: sha256:d2030d29edf68d5b813bff67335253cba60b69f8d350fef8f80255e8ac4e0c9e
+generated: "2025-07-02T12:15:27.653053+02:00"

--- a/helm/cortex-postgres/Chart.yaml
+++ b/helm/cortex-postgres/Chart.yaml
@@ -5,12 +5,12 @@ apiVersion: v2
 name: cortex-postgres
 description: Postgres setup for Cortex.
 type: application
-version: 0.1.3
+version: 0.2.0
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
     # Use a specific version of this chart which contains compliant images.
-    version: 15.5.27
+    version: 16.7.15
   # Owner info adds a configmap to the kubernetes cluster with information on
   # the service owner. This makes it easier to find out who to contact in case
   # of issues. See: https://github.com/sapcc/helm-charts/pkgs/container/helm-charts%2Fowner-info

--- a/helm/cortex-postgres/Chart.yaml
+++ b/helm/cortex-postgres/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cortex-postgres
 description: Postgres setup for Cortex.
 type: application
-version: 0.1.2
+version: 0.1.3
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/helm/cortex-postgres/files/post-upgrade.sh
+++ b/helm/cortex-postgres/files/post-upgrade.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+# Parse the cmd line args.
+pg_password="$1"
+
+# Wait until postgres is available.
+until PGPASSWORD=$pg_password psql -U postgres -c '\q'; do
+  echo "PostgreSQL is not yet available. Retrying in 1 second..."
+  sleep 1
+done
+
+# Restore from the backup created during pre-upgrade.
+gunzip -c /bitnami/postgresql/pre-upgrade-dump.gz | PGPASSWORD=$pg_password psql -U postgres
+
+echo "The following data was loaded during the upgrade:"
+PGPASSWORD=$pg_password psql -U postgres -d postgres -c "
+SELECT table_schema, table_name
+FROM information_schema.tables
+WHERE
+  table_type = 'BASE TABLE'
+  AND table_schema NOT IN ('pg_catalog', 'information_schema')
+GROUP BY table_schema, table_name
+ORDER BY table_schema, table_name;"

--- a/helm/cortex-postgres/files/pre-upgrade.sh
+++ b/helm/cortex-postgres/files/pre-upgrade.sh
@@ -20,6 +20,10 @@ ORDER BY table_schema, table_name;"
 # Create a PostgreSQL dump of the database and save it to the persistent directory.
 PGPASSWORD=$pg_password pg_dumpall -U postgres \
   | gzip > /bitnami/postgresql/pre-upgrade-dump.gz
-# Wipe the current PostgreSQL data directory to ensure a clean upgrade.
-echo "Wiping the current PostgreSQL data directory..."
-rm -rf /bitnami/postgresql/data/
+# Rename the current PostgreSQL data directory to ensure it is preserved
+# in case of issues after the upgrade.
+backup_dir="/bitnami/postgresql/data.bak.$(date +%Y%m%d%H%M%S)"
+if [ -d /bitnami/postgresql/data ]; then
+  echo "Backing up current PostgreSQL data directory to $backup_dir"
+  mv /bitnami/postgresql/data "$backup_dir"
+fi

--- a/helm/cortex-postgres/files/pre-upgrade.sh
+++ b/helm/cortex-postgres/files/pre-upgrade.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+# Parse the cmd line args.
+pg_password="$1"
+
+# Print out the number of rows in each table in the PostgreSQL database.
+# This is useful for verifying that the database is not empty before the upgrade.
+echo "The following data should be preserved during the upgrade:"
+PGPASSWORD=$pg_password psql -U postgres -d postgres -c "
+SELECT table_schema, table_name
+FROM information_schema.tables
+WHERE
+  table_type = 'BASE TABLE'
+  AND table_schema NOT IN ('pg_catalog', 'information_schema')
+GROUP BY table_schema, table_name
+ORDER BY table_schema, table_name;"
+
+# Create a PostgreSQL dump of the database and save it to the persistent directory.
+PGPASSWORD=$pg_password pg_dumpall -U postgres \
+  | gzip > /bitnami/postgresql/pre-upgrade-dump.gz
+# Wipe the current PostgreSQL data directory to ensure a clean upgrade.
+echo "Wiping the current PostgreSQL data directory..."
+rm -rf /bitnami/postgresql/data/

--- a/helm/cortex-postgres/templates/.gitkeep
+++ b/helm/cortex-postgres/templates/.gitkeep
@@ -1,4 +1,0 @@
-# Copyright 2025 SAP SE
-# SPDX-License-Identifier: Apache-2.0
-
-In case we want to customize the postgres setup, this would be the place to do that.

--- a/helm/cortex-postgres/templates/job.yaml
+++ b/helm/cortex-postgres/templates/job.yaml
@@ -1,0 +1,221 @@
+# Copyright 2025 SAP SE
+# SPDX-License-Identifier: Apache-2.0
+
+# These will always be mounted into the postgres container since the mount
+# is done unconditionally through the helm values of the bitnami postgresql chart.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cortex-postgresql-pre-upgrade-script
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+data:
+  pre-upgrade.sh: |
+  {{- range .Files.Lines "files/pre-upgrade.sh" }}
+    {{ . }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cortex-postgresql-post-upgrade-script
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+data:
+  post-upgrade.sh: |
+  {{- range .Files.Lines "files/post-upgrade.sh" }}
+    {{ . }}
+  {{- end }}
+
+{{- if .Values.upgradeJob.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cortex-postgresql-pre-upgrade-{{ .Chart.Version }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # Run this job before Helm upgrades are applied.
+    # Note: since we use pre-upgrade here, it is assumed that the old postgres
+    # is already present in the cluster.
+    "helm.sh/hook": pre-upgrade
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+        {{- with $.Values.upgradeJob.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: cortex-postgresql-job-sa
+      restartPolicy: Never
+      containers:
+        - name: kubectl
+          image: "{{ $.Values.upgradeJob.image.repository }}:{{ $.Values.upgradeJob.image.tag }}"
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cortex-postgresql
+                  key: postgres-password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              # Get the /bitnami/postgresql/pre-upgrade.chart file from inside the
+              # cortex-postgresql-0 pod (if exists) and check if $.Chart.Version
+              # is already deployed, or needs an upgrade.
+              if kubectl exec cortex-postgresql-0 -c postgresql \
+                -n {{ .Release.Namespace }} -- /bin/sh \
+                -c "test -f /bitnami/postgresql/pre-upgrade.chart"; then
+                current_version=$(kubectl exec cortex-postgresql-0 -c postgresql \
+                  -n {{ .Release.Namespace }} -- /bin/sh \
+                  -c "cat /bitnami/postgresql/pre-upgrade.chart")
+                if [ "${current_version}" = "{{ .Chart.Version }}" ]; then
+                  echo "Chart version {{ .Chart.Version }} already deployed, skipping pre-upgrade steps."
+                  exit 0
+                else
+                  echo "Chart version {{ .Chart.Version }} is a new version, proceeding with pre-upgrade steps."
+                fi
+              else
+                echo "No pre-upgrade chart file found, proceeding with pre-upgrade steps."
+              fi
+
+              echo "Making cortex-postgresql service unavailable by merging selector cortex=currently-upgrading..."
+              kubectl patch service cortex-postgresql \
+                -n {{ .Release.Namespace }} \
+                --type=merge \
+                -p '{"spec": {"selector": {"cortex": "currently-upgrading"}}}'
+
+              echo "Executing pre-upgrade script in cortex-postgresql-0 pod..."
+              kubectl exec cortex-postgresql-0 -c postgresql \
+                -n {{ .Release.Namespace }} -- /bin/sh \
+                /opt/pre-upgrade/pre-upgrade.sh ${POSTGRES_PASSWORD}
+              kubectl exec cortex-postgresql-0 -c postgresql \
+                -n {{ .Release.Namespace }} -- /bin/sh \
+                -c "echo '{{ .Chart.Version }}' > /bitnami/postgresql/pre-upgrade.chart"
+
+              echo "Scaling down the cortex-postgresql StatefulSet to enforce a restart..."
+              kubectl scale statefulset cortex-postgresql \
+                -n {{ .Release.Namespace }} --replicas=0
+              while [ "$(kubectl get statefulset cortex-postgresql \
+                -n {{ .Release.Namespace }} -o jsonpath='{.status.replicas}')" != "0" ]; do
+                echo "Waiting for cortex-postgresql StatefulSet to scale down..."
+                sleep 1
+              done
+
+              echo "Ready to upgrade and execute post-upgrade script."
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cortex-postgresql-post-upgrade-{{ .Chart.Version }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # Run this job after Helm upgrades are applied.
+    # Note: since we use post-upgrade here, it is assumed that the new postgres
+    # is already present in the cluster.
+    "helm.sh/hook": post-upgrade
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+        {{- with $.Values.upgradeJob.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: cortex-postgresql-job-sa
+      restartPolicy: Never
+      containers:
+        - name: kubectl
+          image: "{{ $.Values.upgradeJob.image.repository }}:{{ $.Values.upgradeJob.image.tag }}"
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cortex-postgresql
+                  key: postgres-password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              # Get the /bitnami/postgresql/post-upgrade.chart file from inside the
+              # cortex-postgresql-0 pod (if exists) and check if $.Chart.Version
+              # is already deployed, or needs an upgrade.
+              if kubectl exec cortex-postgresql-0 -c postgresql \
+                -n {{ .Release.Namespace }} -- /bin/sh \
+                -c "test -f /bitnami/postgresql/post-upgrade.chart"; then
+                current_version=$(kubectl exec cortex-postgresql-0 -c postgresql \
+                  -n {{ .Release.Namespace }} -- /bin/sh \
+                  -c "cat /bitnami/postgresql/post-upgrade.chart")
+                if [ "${current_version}" = "{{ .Chart.Version }}" ]; then
+                  echo "Chart version {{ .Chart.Version }} already deployed, skipping post-upgrade steps."
+                  exit 0
+                else
+                  echo "Chart version {{ .Chart.Version }} is a new version, proceeding with post-upgrade steps."
+                fi
+              else
+                echo "No post-upgrade chart file found, proceeding with post-upgrade steps."
+              fi
+
+              while [ "$(kubectl get job cortex-postgresql-pre-upgrade-{{ .Chart.Version }} \
+                -n {{ .Release.Namespace }} -o jsonpath='{.status.succeeded}')" != "1" ]; do
+                echo "Waiting for pre-upgrade job to complete..."
+                sleep 1
+              done
+
+              # Scale up the cortex-postgresql StatefulSet again.
+              echo "Scaling up the cortex-postgresql StatefulSet..."
+              kubectl scale statefulset cortex-postgresql \
+                -n {{ .Release.Namespace }} --replicas=1
+              # Wait until the pod is healthy, by checking the readinessProbe's status.
+              while [ "$(kubectl get pod cortex-postgresql-0 \
+                -n {{ .Release.Namespace }} \
+                -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" != "True" ]; do
+                echo "Waiting for cortex-postgresql-0 pod to become ready..."
+                sleep 1
+              done
+
+              echo "Executing post-upgrade script in cortex-postgresql-0 pod..."
+              kubectl exec cortex-postgresql-0 -c postgresql \
+                -n {{ .Release.Namespace }} -- /bin/sh \
+                /opt/post-upgrade/post-upgrade.sh ${POSTGRES_PASSWORD}
+              kubectl exec cortex-postgresql-0 -c postgresql \
+                -n {{ .Release.Namespace }} -- /bin/sh \
+                -c "echo '{{ .Chart.Version }}' > /bitnami/postgresql/post-upgrade.chart"
+
+              echo "Restoring original cortex-postgresql service selectors..."
+              # Patch service with selector minus cortex=currently-upgrading
+              kubectl patch service cortex-postgresql \
+                -n {{ .Release.Namespace }} \
+                --type='json' \
+                -p='[{"op": "remove", "path": "/spec/selector/cortex"}]'
+
+              echo "Successfully upgraded to chart version {{ .Chart.Version }}."
+{{- end }}

--- a/helm/cortex-postgres/templates/rbac.yaml
+++ b/helm/cortex-postgres/templates/rbac.yaml
@@ -1,0 +1,59 @@
+# Copyright 2025 SAP SE
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.upgradeJob.enabled }}
+# ServiceAccount used by the upgrade job to manage the Postgres StatefulSet
+# and execute commands in the Postgres pod.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cortex-postgresql-job-sa
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cortex-postgresql-job-role
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "update"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets/scale"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cortex-postgresql-job-rb
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cortex-postgresql-job-role
+subjects:
+  - kind: ServiceAccount
+    name: cortex-postgresql-job-sa
+{{- end }}

--- a/helm/cortex-postgres/values.yaml
+++ b/helm/cortex-postgres/values.yaml
@@ -21,3 +21,32 @@ postgresql:
       postgresql: 5432
   metrics:
     enabled: true
+  primary:
+    # Add a pre-upgrade script and a post-upgrade script to the primary pod.
+    #
+    # In case of a major version upgrade:
+    # - The pre-upgrade script will disable the service and dump the database.
+    # - The post-upgrade script will load the database dump and re-enable the service.
+    extraVolumes:
+      - {name: pre-upgrade-script, configMap: {name: cortex-postgresql-pre-upgrade-script}}
+      - {name: post-upgrade-script, configMap: {name: cortex-postgresql-post-upgrade-script}}
+    extraVolumeMounts:
+      - {name: pre-upgrade-script, mountPath: /opt/pre-upgrade, readOnly: true}
+      - {name: post-upgrade-script, mountPath: /opt/post-upgrade, readOnly: true}
+
+# Job that performs upgrade tasks on the Cortex Postgres StatefulSet.
+#
+# If postgres needs a major version upgrade, this job will scale down the
+# StatefulSet, wait for the pod to terminate, run upgrade commands, and scale
+# it back up.
+upgradeJob:
+  enabled: true
+  image:
+    repository: "bitnami/kubectl"
+    tag: "latest"
+  # Additional annotations for the created database upgrade job.
+  podAnnotations:
+    # If you use linkerd, this will disable injection for the upgrade job.
+    # Otherwise, the linkerd-proxy container will hang around forever and
+    # block the job from completing.
+    "linkerd.io/inject": disabled


### PR DESCRIPTION
By default, the bitnami postgres chart doesn't support major version upgrades without manual intervention. This PR automates the process. 

**Note: helm reinstall is needed to make this work initially, as the volume mounts of the scripts into the postgres container are initially not present.**