### PR TITLE
Release cortex-postgres 0.3.0 to roll jobs into deployments

### DIFF
--- a/helm/cortex-postgres/Chart.lock
+++ b/helm/cortex-postgres/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.7.15
+  version: 15.5.27
 - name: owner-info
   repository: oci://ghcr.io/sapcc/helm-charts
   version: 1.0.0
-digest: sha256:d2030d29edf68d5b813bff67335253cba60b69f8d350fef8f80255e8ac4e0c9e
-generated: "2025-07-02T12:15:27.653053+02:00"
+digest: sha256:26cb9c33b10bfaec7d04e718c321935eb031c3d0e426902afc12b99541a20ad7
+generated: "2025-04-23T08:52:04.316499+02:00"

--- a/helm/cortex-postgres/Chart.yaml
+++ b/helm/cortex-postgres/Chart.yaml
@@ -5,12 +5,12 @@ apiVersion: v2
 name: cortex-postgres
 description: Postgres setup for Cortex.
 type: application
-version: 0.2.0
+version: 0.3.0
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
     # Use a specific version of this chart which contains compliant images.
-    version: 16.7.15
+    version: 15.5.27
   # Owner info adds a configmap to the kubernetes cluster with information on
   # the service owner. This makes it easier to find out who to contact in case
   # of issues. See: https://github.com/sapcc/helm-charts/pkgs/container/helm-charts%2Fowner-info

--- a/helm/cortex/Chart.yaml
+++ b/helm/cortex/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cortex
 description: A Helm chart for deploying Cortex.
 type: application
-version: 0.22.2
+version: 0.22.3
 appVersion: 0.1.0
 dependencies:
   # Owner info adds a configmap to the kubernetes cluster with information on


### PR DESCRIPTION
This is required since our services are currently running 15.5.27 in prod regions. We need to rollout the new jobs with this version *once* and can then upgrade. I missed that in the last release.