### PR TITLE
Release cortex-postgres v0.3.1 to re-introduce postgres upgrade

### DIFF
--- a/helm/cortex-postgres/Chart.lock
+++ b/helm/cortex-postgres/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.5.27
+  version: 16.7.15
 - name: owner-info
   repository: oci://ghcr.io/sapcc/helm-charts
   version: 1.0.0
-digest: sha256:26cb9c33b10bfaec7d04e718c321935eb031c3d0e426902afc12b99541a20ad7
-generated: "2025-04-23T08:52:04.316499+02:00"
+digest: sha256:d2030d29edf68d5b813bff67335253cba60b69f8d350fef8f80255e8ac4e0c9e
+generated: "2025-07-02T11:13:19.202697+02:00"

--- a/helm/cortex-postgres/Chart.yaml
+++ b/helm/cortex-postgres/Chart.yaml
@@ -5,12 +5,12 @@ apiVersion: v2
 name: cortex-postgres
 description: Postgres setup for Cortex.
 type: application
-version: 0.3.0
+version: 0.3.1
 dependencies:
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
     # Use a specific version of this chart which contains compliant images.
-    version: 15.5.27
+    version: 16.7.15
   # Owner info adds a configmap to the kubernetes cluster with information on
   # the service owner. This makes it easier to find out who to contact in case
   # of issues. See: https://github.com/sapcc/helm-charts/pkgs/container/helm-charts%2Fowner-info


### PR DESCRIPTION
After the temporary downgrade, the deployments now support upgrading.