### PR TITLE
Add descheduler for virtual machines

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -58,6 +58,11 @@ k8s_resource('cortex-kpis', port_forwards=[
 ], links=[
     link('localhost:8007/metrics', '/metrics'),
 ], labels=['Core-Services'])
+k8s_resource('cortex-descheduler-nova', port_forwards=[
+    port_forward(8008, 2112),
+], links=[
+    link('localhost:8008/metrics', '/metrics'),
+], labels=['Core-Services'])
 
 ########### Cortex Commands
 k8s_resource('cortex-cli', labels=['Commands'])
@@ -76,7 +81,7 @@ local('sh helm/sync.sh helm/cortex-mqtt')
 k8s_yaml(helm('./helm/cortex-mqtt', name='cortex-mqtt'))
 k8s_resource('cortex-mqtt', port_forwards=[
     port_forward(1883, 1883), # Direct TCP connection
-    port_forward(8008, 15675), # Websocket connection
+    port_forward(8009, 15675), # Websocket connection
 ], labels=['Core-Services'])
 
 ########### Postgres DB for Cortex Core Service

--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -63,6 +63,11 @@ modes:
     args: ["scheduler-manila"]
     replicas: 1
 
+  # Descheduler for Nova.
+  - name: descheduler-nova
+    args: ["descheduler-nova"]
+    replicas: 1
+
   # Service that extracts and exposes KPIs.
   - name: kpis
     args: ["kpis"]
@@ -594,6 +599,25 @@ conf:
             diskUtilizedActivationUpperBound: 0.0
           dependencies:
             extractors: [host_utilization_extractor]
+
+  descheduler:
+    nova:
+      disableDryRun: false
+      # Configuration of the descheduler that runs periodically to de-schedule
+      # VMs based on the configured plugins.
+      # Each plugin can specify its own dependencies on extractors and synced data.
+      #
+      # The `name` should correspond to a known descheduler plugin.
+      plugins:
+        - name: demo
+          options:
+            vmName: "cortex-demo-vm"
+          dependencies:
+            sync:
+              openstack:
+                nova:
+                  types:
+                    - servers
 
 # Generic modifiers added on the initial creation of this helm chart.
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -276,6 +276,28 @@ type SchedulerAPIConfig struct {
 	LogRequestBodies bool `json:"logRequestBodies"`
 }
 
+// Configuration for the descheduler module.
+type DeschedulerConfig struct {
+	Nova NovaDeschedulerConfig `json:"nova"`
+}
+
+// Configuration for the nova descheduler.
+type NovaDeschedulerConfig struct {
+	// The steps to execute in the descheduler.
+	Plugins []DeschedulerStepConfig `json:"plugins"`
+	// If dry-run is disabled (by default its enabled).
+	DisableDryRun bool `json:"disableDryRun,omitempty"`
+}
+
+type DeschedulerStepConfig struct {
+	// The name of the step.
+	Name string `json:"name"`
+	// Custom options for the step, as a raw yaml map.
+	Options RawOpts `json:"options,omitempty"`
+	// The dependencies this step needs.
+	DependencyConfig `json:"dependencies,omitempty"`
+}
+
 // Configuration for the kpis module.
 type KPIsConfig struct {
 	// KPI plugins to use.
@@ -333,6 +355,7 @@ type Config interface {
 	GetSyncConfig() SyncConfig
 	GetExtractorConfig() ExtractorConfig
 	GetSchedulerConfig() SchedulerConfig
+	GetDeschedulerConfig() DeschedulerConfig
 	GetKPIsConfig() KPIsConfig
 	GetMonitoringConfig() MonitoringConfig
 	GetMQTTConfig() MQTTConfig
@@ -345,15 +368,16 @@ type config struct {
 	// The checks to run, in this particular order.
 	Checks []string `json:"checks"`
 
-	LoggingConfig    `json:"logging"`
-	DBConfig         `json:"db"`
-	SyncConfig       `json:"sync"`
-	ExtractorConfig  `json:"extractor"`
-	SchedulerConfig  `json:"scheduler"`
-	MonitoringConfig `json:"monitoring"`
-	KPIsConfig       `json:"kpis"`
-	MQTTConfig       `json:"mqtt"`
-	APIConfig        `json:"api"`
+	LoggingConfig     `json:"logging"`
+	DBConfig          `json:"db"`
+	SyncConfig        `json:"sync"`
+	ExtractorConfig   `json:"extractor"`
+	SchedulerConfig   `json:"scheduler"`
+	DeschedulerConfig `json:"descheduler"`
+	MonitoringConfig  `json:"monitoring"`
+	KPIsConfig        `json:"kpis"`
+	MQTTConfig        `json:"mqtt"`
+	APIConfig         `json:"api"`
 }
 
 // Create a new configuration from the default config json file.
@@ -384,13 +408,14 @@ func newConfigFromBytes(bytes []byte) Config {
 	return &c
 }
 
-func (c *config) GetChecks() []string                   { return c.Checks }
-func (c *config) GetLoggingConfig() LoggingConfig       { return c.LoggingConfig }
-func (c *config) GetDBConfig() DBConfig                 { return c.DBConfig }
-func (c *config) GetSyncConfig() SyncConfig             { return c.SyncConfig }
-func (c *config) GetExtractorConfig() ExtractorConfig   { return c.ExtractorConfig }
-func (c *config) GetSchedulerConfig() SchedulerConfig   { return c.SchedulerConfig }
-func (c *config) GetKPIsConfig() KPIsConfig             { return c.KPIsConfig }
-func (c *config) GetMonitoringConfig() MonitoringConfig { return c.MonitoringConfig }
-func (c *config) GetMQTTConfig() MQTTConfig             { return c.MQTTConfig }
-func (c *config) GetAPIConfig() APIConfig               { return c.APIConfig }
+func (c *config) GetChecks() []string                     { return c.Checks }
+func (c *config) GetLoggingConfig() LoggingConfig         { return c.LoggingConfig }
+func (c *config) GetDBConfig() DBConfig                   { return c.DBConfig }
+func (c *config) GetSyncConfig() SyncConfig               { return c.SyncConfig }
+func (c *config) GetExtractorConfig() ExtractorConfig     { return c.ExtractorConfig }
+func (c *config) GetSchedulerConfig() SchedulerConfig     { return c.SchedulerConfig }
+func (c *config) GetDeschedulerConfig() DeschedulerConfig { return c.DeschedulerConfig }
+func (c *config) GetKPIsConfig() KPIsConfig               { return c.KPIsConfig }
+func (c *config) GetMonitoringConfig() MonitoringConfig   { return c.MonitoringConfig }
+func (c *config) GetMQTTConfig() MQTTConfig               { return c.MQTTConfig }
+func (c *config) GetAPIConfig() APIConfig                 { return c.APIConfig }

--- a/internal/conf/validation.go
+++ b/internal/conf/validation.go
@@ -99,13 +99,18 @@ func (c *config) Validate() error {
 			return err
 		}
 	}
-	for _, step := range c.Nova.Plugins {
+	for _, step := range c.SchedulerConfig.Nova.Plugins {
+		if err := step.validate(*c); err != nil {
+			return err
+		}
+	}
+	for _, step := range c.DeschedulerConfig.Nova.Plugins {
 		if err := step.validate(*c); err != nil {
 			return err
 		}
 	}
 	// Check general dependencies needed by all scheduler steps.
-	if err := c.Nova.validate(*c); err != nil {
+	if err := c.SchedulerConfig.Nova.validate(*c); err != nil {
 		return err
 	}
 	if c.API.LogRequestBodies {

--- a/internal/descheduler/nova/descheduler.go
+++ b/internal/descheduler/nova/descheduler.go
@@ -1,0 +1,174 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package nova
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	"github.com/cobaltcore-dev/cortex/internal/descheduler/nova/plugins"
+	"github.com/sapcc/go-bits/jobloop"
+)
+
+// Configuration of steps supported by the descheduler.
+// The steps actually used by the scheduler are defined through the configuration file.
+var supportedSteps = []Step{
+	&plugins.DemoStep{}, // Example step, replace with actual steps.
+}
+
+type Descheduler struct {
+	// Steps to execute in the descheduler.
+	steps []Step
+	// Configuration for the descheduler.
+	config conf.DeschedulerConfig
+}
+
+func NewDescheduler(config conf.DeschedulerConfig, db db.DB) *Descheduler {
+	// Initialize the descheduler with the provided configuration and database.
+	descheduler := &Descheduler{
+		config: config,
+	}
+	// Initialize the steps based on the configuration.
+	descheduler.Init(context.Background(), db, config)
+	return descheduler
+}
+
+func (d *Descheduler) Init(ctx context.Context, db db.DB, config conf.DeschedulerConfig) {
+	supportedStepsByName := make(map[string]Step)
+	for _, step := range supportedSteps {
+		supportedStepsByName[step.GetName()] = step
+	}
+
+	// Load all steps from the configuration.
+	d.steps = make([]Step, 0, len(config.Nova.Plugins))
+	for _, stepConf := range config.Nova.Plugins {
+		step, ok := supportedStepsByName[stepConf.Name]
+		if !ok {
+			slog.Error("descheduler: step not supported", "name", stepConf.Name)
+			continue
+		}
+		if err := step.Init(db, stepConf.Options); err != nil {
+			slog.Error("descheduler: failed to initialize step", "name", stepConf.Name, "error", err)
+			continue
+		}
+		d.steps = append(d.steps, step)
+		slog.Info(
+			"descheduler: added step",
+			"name", stepConf.Name,
+			"options", stepConf.Options,
+		)
+	}
+
+	d.config = config
+}
+
+// Execute the descheduler steps in parallel and collect the decisions made by
+// each step.
+func (d *Descheduler) run() map[string]map[string][]string {
+	var lock sync.Mutex
+	decisionsByStep := map[string]map[string][]string{}
+	var wg sync.WaitGroup
+	for _, step := range d.steps {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			slog.Info("descheduler: running step", "name", step.GetName())
+			decisions, err := step.Run()
+			if errors.Is(err, ErrStepSkipped) {
+				slog.Info("descheduler: step skipped", "name", step.GetName())
+				return
+			}
+			if err != nil {
+				slog.Error("descheduler: failed to run step", "name", step.GetName(), "error", err)
+				return
+			}
+			slog.Info("descheduler: finished step", "name", step.GetName())
+			lock.Lock()
+			defer lock.Unlock()
+			decisionsByStep[step.GetName()] = decisions
+		}()
+	}
+	wg.Wait()
+	return decisionsByStep
+}
+
+// Descheduler steps may make decisions that overlap, meaning that multiple
+// steps may decide to move the same VM to a potentially different set of hosts.
+// This function deduplicates those decisions by intersecting the hosts for each
+// VM ID across all steps.
+func (d *Descheduler) deduplicate(decisionsByStep map[string]map[string][]string) map[string][]string {
+	uniqueDecisions := map[string][]string{}
+	for _, decisions := range decisionsByStep {
+		for vmId, nextHosts := range decisions {
+			// If this VM ID is not already in the uniqueDecisions map, add it.
+			prevHosts, exists := uniqueDecisions[vmId]
+			if !exists {
+				uniqueDecisions[vmId] = nextHosts
+				continue
+			}
+			// If it exists, intersect the hosts with the existing ones.
+			hostsInBoth := []string{}
+			for _, nextHost := range nextHosts {
+				if !slices.Contains(prevHosts, nextHost) {
+					continue
+				}
+				hostsInBoth = append(hostsInBoth, nextHost)
+			}
+			uniqueDecisions[vmId] = hostsInBoth
+		}
+	}
+
+	return uniqueDecisions
+}
+
+// Execute the virtual machine live-migrations using the Nova API.
+func (d *Descheduler) execute(decisions map[string][]string) {
+	for stepName, decisionList := range decisions {
+		for _, decision := range decisionList {
+			slog.Info("descheduler: executing decision", "step", stepName, "decision", decision)
+			if !d.config.Nova.DisableDryRun {
+				slog.Info("descheduler: dry-run enabled, skipping execution", "decision", decision)
+				continue
+			}
+			// Here you would call the Nova API to execute the decision.
+			// For example, if the decision is to migrate a VM, you would call:
+			// novaClient.MigrateVM(decision)
+			// This is a placeholder for the actual execution logic.
+			slog.Info("descheduler: executing migration for VM", "vmId", decision)
+		}
+	}
+}
+
+func (d *Descheduler) DeschedulePeriodically(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("descheduler shutting down")
+			return
+		default:
+			decisionsByStep := d.run()
+			if len(decisionsByStep) == 0 {
+				slog.Info("descheduler: no decisions made in this run")
+				time.Sleep(jobloop.DefaultJitter(time.Minute))
+				continue
+			}
+			slog.Info("descheduler: decisions made", "decisionsByStep", decisionsByStep)
+			decisions := d.deduplicate(decisionsByStep)
+			if len(decisions) == 0 {
+				slog.Info("descheduler: no unique decisions made in this run")
+				time.Sleep(jobloop.DefaultJitter(time.Minute))
+				continue
+			}
+			slog.Info("descheduler: unique decisions made", "decisions", decisions)
+			d.execute(decisions)
+			time.Sleep(jobloop.DefaultJitter(time.Minute))
+		}
+	}
+}

--- a/internal/descheduler/nova/plugins/base.go
+++ b/internal/descheduler/nova/plugins/base.go
@@ -1,0 +1,27 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package plugins
+
+import (
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+)
+
+// Common base for all steps that provides some functionality
+// that would otherwise be duplicated across all steps.
+type BaseStep[Opts any] struct {
+	// Options to pass via yaml to this step.
+	conf.JsonOpts[Opts]
+	// Database connection.
+	DB db.DB
+}
+
+// Init the step with the database and options.
+func (s *BaseStep[Opts]) Init(db db.DB, opts conf.RawOpts) error {
+	if err := s.Load(opts); err != nil {
+		return err
+	}
+	s.DB = db
+	return nil
+}

--- a/internal/descheduler/nova/plugins/demo.go
+++ b/internal/descheduler/nova/plugins/demo.go
@@ -1,0 +1,42 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package plugins
+
+import (
+	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/nova"
+)
+
+type DemoStepOpts struct {
+	// A name of a virtual machine to de-schedule.
+	VMName string `json:"vmName"`
+}
+
+type DemoStep struct {
+	// BaseStep is a helper struct that provides common functionality for all steps.
+	BaseStep[DemoStepOpts]
+}
+
+// Get the name of this step, used for identification in config, logs, metrics, etc.
+func (s *DemoStep) GetName() string {
+	return "demo"
+}
+
+// Run the step to de-schedule the VM.
+func (s *DemoStep) Run() (map[string][]string, error) {
+	decisions := make(map[string][]string)
+	// Get VMs matching the VMName option.
+	var ids []string
+	q := "SELECT id FROM " + nova.Server{}.TableName()
+	q += " WHERE name = :name"
+	if _, err := s.DB.Select(&ids, q, map[string]any{
+		"name": s.Options.VMName,
+	}); err != nil {
+		return nil, err
+	}
+	// For each VM, we decide to de-schedule it.
+	for _, id := range ids {
+		decisions[id] = []string{} // No specific target host.
+	}
+	return decisions, nil
+}

--- a/internal/descheduler/nova/step.go
+++ b/internal/descheduler/nova/step.go
@@ -1,0 +1,25 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package nova
+
+import (
+	"errors"
+
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+)
+
+var (
+	// This error is returned from the step at any time when the step should be skipped.
+	ErrStepSkipped = errors.New("step skipped")
+)
+
+type Step interface {
+	// Get the VM ids to de-schedule together with potential target hosts.
+	Run() (map[string][]string, error)
+	// Get the name of this step, used for identification in config, logs, metrics, etc.
+	GetName() string
+	// Configure the step with a database and options.
+	Init(db db.DB, opts conf.RawOpts) error
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/commands/checks"
 	"github.com/cobaltcore-dev/cortex/internal/conf"
 	"github.com/cobaltcore-dev/cortex/internal/db"
+	novaDescheduler "github.com/cobaltcore-dev/cortex/internal/descheduler/nova"
 	"github.com/cobaltcore-dev/cortex/internal/extractor"
 	"github.com/cobaltcore-dev/cortex/internal/kpis"
 	"github.com/cobaltcore-dev/cortex/internal/monitoring"
@@ -21,7 +22,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/scheduler"
 	"github.com/cobaltcore-dev/cortex/internal/scheduler/manila"
 	manilaAPIHTTP "github.com/cobaltcore-dev/cortex/internal/scheduler/manila/api/http"
-	"github.com/cobaltcore-dev/cortex/internal/scheduler/nova"
+	novaScheduler "github.com/cobaltcore-dev/cortex/internal/scheduler/nova"
 	novaApiHTTP "github.com/cobaltcore-dev/cortex/internal/scheduler/nova/api/http"
 	"github.com/cobaltcore-dev/cortex/internal/sync"
 	"github.com/cobaltcore-dev/cortex/internal/sync/openstack"
@@ -74,7 +75,7 @@ func runSchedulerNova(mux *http.ServeMux, registry *monitoring.Registry, config 
 		panic("failed to connect to mqtt broker: " + err.Error())
 	}
 	defer mqttClient.Disconnect()
-	schedulerPipeline := nova.NewPipeline(config, db, monitor, mqttClient)
+	schedulerPipeline := novaScheduler.NewPipeline(config, db, monitor, mqttClient)
 	apiMonitor := scheduler.NewSchedulerMonitor(registry)
 	api := novaApiHTTP.NewAPI(config.API, schedulerPipeline, apiMonitor)
 	api.Init(mux) // non-blocking
@@ -102,6 +103,13 @@ func runKPIService(registry *monitoring.Registry, config conf.KPIsConfig, db db.
 	} // non-blocking
 }
 
+// Run a descheduler for Nova virtual machines.
+func runDeschedulerNova(ctx context.Context, config conf.DeschedulerConfig, db db.DB) {
+	descheduler := novaDescheduler.NewDescheduler(config, db)
+	descheduler.Init(ctx, db, config)          // non-blocking
+	go descheduler.DeschedulePeriodically(ctx) // blocking
+}
+
 // Run the prometheus metrics server for monitoring.
 func runMonitoringServer(ctx context.Context, registry *monitoring.Registry, config conf.MonitoringConfig) {
 	mux := http.NewServeMux()
@@ -125,6 +133,7 @@ const usage = `
   -scheduler-nova   Serve Nova scheduling requests with a http API.
   -scheduler-manila Serve Manila scheduling requests with a http API.
   -kpis      Expose KPIs extracted from the database.
+  -descheduler-nova Run a Nova descheduler that periodically de-schedules VMs.
 `
 
 func main() {
@@ -214,6 +223,8 @@ func main() {
 		runSchedulerManila(mux, registry, config.GetSchedulerConfig(), database)
 	case "kpis":
 		runKPIService(registry, config.GetKPIsConfig(), database)
+	case "descheduler-nova":
+		runDeschedulerNova(ctx, config.GetDeschedulerConfig(), database)
 	default:
 		panic("unknown task")
 	}

--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -272,7 +272,7 @@
   </section>
 
   <section class="mqtt-url-input">
-    <input type="text" id="mqtt-url" placeholder="Enter MQTT URL" value="ws://localhost:8008/ws" />
+    <input type="text" id="mqtt-url" placeholder="Enter MQTT URL" value="ws://localhost:8009/ws" />
     <button onclick="reconnect()">Reconnect MQTT</button>
   </section>
 


### PR DESCRIPTION
Descheduler steps can detect VMs that should be moved away from a host. The decisions of the individual steps are combined and the migrations triggered + monitoring until completion.