### PR TITLE
Fix multiple aliases for same step overriding config

### DIFF
--- a/internal/scheduler/manila/pipeline.go
+++ b/internal/scheduler/manila/pipeline.go
@@ -16,8 +16,8 @@ type ManilaStep = scheduler.Step[api.ExternalSchedulerRequest]
 
 // Configuration of steps supported by the scheduler.
 // The steps actually used by the scheduler are defined through the configuration file.
-var supportedSteps = []ManilaStep{
-	&netapp.CPUUsageBalancingStep{},
+var supportedSteps = map[string]func() ManilaStep{
+	(&netapp.CPUUsageBalancingStep{}).GetName(): func() ManilaStep { return &netapp.CPUUsageBalancingStep{} },
 }
 
 // Create a new Manila scheduler pipeline.

--- a/internal/scheduler/manila/pipeline.go
+++ b/internal/scheduler/manila/pipeline.go
@@ -41,7 +41,7 @@ func NewPipeline(
 	}
 	topicFinished := "cortex/scheduler/manila/pipeline/finished"
 	return scheduler.NewPipeline(
-		supportedSteps, config.Manila.Plugins, wrappers, config,
+		supportedSteps, config.Manila.Plugins, wrappers,
 		db, monitor, mqttClient, topicFinished,
 	)
 }

--- a/internal/scheduler/nova/pipeline.go
+++ b/internal/scheduler/nova/pipeline.go
@@ -58,7 +58,7 @@ func NewPipeline(
 	}
 	topicFinished := "cortex/scheduler/nova/pipeline/finished"
 	return scheduler.NewPipeline(
-		supportedSteps, config.Nova.Plugins, wrappers, config,
+		supportedSteps, config.Nova.Plugins, wrappers,
 		db, monitor, mqttClient, topicFinished,
 	)
 }

--- a/internal/scheduler/nova/pipeline.go
+++ b/internal/scheduler/nova/pipeline.go
@@ -18,16 +18,16 @@ type NovaStep = scheduler.Step[api.ExternalSchedulerRequest]
 
 // Configuration of steps supported by the scheduler.
 // The steps actually used by the scheduler are defined through the configuration file.
-var supportedSteps = []NovaStep{
+var supportedSteps = map[string]func() NovaStep{
 	// VMware-specific steps
-	&vmware.AntiAffinityNoisyProjectsStep{},
-	&vmware.AvoidLongTermContendedHostsStep{},
-	&vmware.AvoidShortTermContendedHostsStep{},
+	(&vmware.AntiAffinityNoisyProjectsStep{}).GetName():    func() NovaStep { return &vmware.AntiAffinityNoisyProjectsStep{} },
+	(&vmware.AvoidLongTermContendedHostsStep{}).GetName():  func() NovaStep { return &vmware.AvoidLongTermContendedHostsStep{} },
+	(&vmware.AvoidShortTermContendedHostsStep{}).GetName(): func() NovaStep { return &vmware.AvoidShortTermContendedHostsStep{} },
 	// KVM-specific steps
-	&kvm.AvoidOverloadedHostsCPUStep{},
-	&kvm.AvoidOverloadedHostsMemoryStep{},
+	(&kvm.AvoidOverloadedHostsCPUStep{}).GetName():    func() NovaStep { return &kvm.AvoidOverloadedHostsCPUStep{} },
+	(&kvm.AvoidOverloadedHostsMemoryStep{}).GetName(): func() NovaStep { return &kvm.AvoidOverloadedHostsMemoryStep{} },
 	// Shared steps
-	&shared.ResourceBalancingStep{},
+	(&shared.ResourceBalancingStep{}).GetName(): func() NovaStep { return &shared.ResourceBalancingStep{} },
 }
 
 // Create a new Nova scheduler pipeline.

--- a/internal/scheduler/pipeline.go
+++ b/internal/scheduler/pipeline.go
@@ -60,7 +60,6 @@ func NewPipeline[RequestType PipelineRequest](
 	supportedSteps []Step[RequestType],
 	confedSteps []conf.SchedulerStepConfig,
 	stepWrappers []StepWrapper[RequestType],
-	config conf.SchedulerConfig,
 	database db.DB,
 	monitor PipelineMonitor,
 	mqttClient mqtt.Client,

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -227,12 +227,16 @@ func TestNewPipeline(t *testing.T) {
 	database := db.DB{}          // Mock or initialize as needed
 	monitor := PipelineMonitor{} // Replace with an actual mock implementation if available
 	mqttClient := &mqtt.MockClient{}
+	supportedSteps := map[string]func() Step[mockPipelineRequest]{
+		"mock_pipeline_step": func() Step[mockPipelineRequest] {
+			return &mockPipelineStep{
+				name: "mock_pipeline_step",
+			}
+		},
+	}
 
 	pipeline := NewPipeline(
-		[]Step[mockPipelineRequest]{&mockPipelineStep{
-			name:  "mock_pipeline_step",
-			alias: "", // Set by Init
-		}},
+		supportedSteps,
 		[]conf.SchedulerStepConfig{{Name: "mock_pipeline_step", Options: conf.RawOpts{}}},
 		[]StepWrapper[mockPipelineRequest]{},
 		database, monitor, mqttClient, "test/topic",
@@ -253,12 +257,17 @@ func TestNewPipeline_SameStepMultipleAliases(t *testing.T) {
 	database := db.DB{}          // Mock or initialize as needed
 	monitor := PipelineMonitor{} // Replace with an actual mock implementation if available
 	mqttClient := &mqtt.MockClient{}
+	supportedSteps := map[string]func() Step[mockPipelineRequest]{
+		"mock_pipeline_step": func() Step[mockPipelineRequest] {
+			return &mockPipelineStep{
+				name:  "mock_pipeline_step",
+				alias: "", // Set by Init
+			}
+		},
+	}
 
 	pipeline := NewPipeline(
-		[]Step[mockPipelineRequest]{&mockPipelineStep{
-			name:  "mock_pipeline_step",
-			alias: "", // Set by Init
-		}},
+		supportedSteps,
 		[]conf.SchedulerStepConfig{
 			{Name: "mock_pipeline_step", Alias: "mock_step_1", Options: conf.RawOpts{}},
 			{Name: "mock_pipeline_step", Alias: "mock_step_2", Options: conf.RawOpts{}},


### PR DESCRIPTION
Currently if we pass multiple steps with the same name but different steps, the init function will be called twice on the same step, leading to only one being initialized and executed. This PR adds a test for this specific condition and fixes the issue.