### PR TITLE
Load secrets through kubernetes secret instead of configmap

### DIFF
--- a/cortex.secrets.example.yaml
+++ b/cortex.secrets.example.yaml
@@ -20,7 +20,7 @@ sharedSSOCert: &sharedSSOCert
   # If true, the certificate is not verified.
   selfSigned: false
 
-conf:
+secrets:
   sync:
     # Override the endpoints to your Prometheus instances.
     prometheus:

--- a/helm/cortex/templates/cli.yaml
+++ b/helm/cortex/templates/cli.yaml
@@ -40,6 +40,9 @@ spec:
           volumeMounts:
             - name: {{ include "cortex.fullname" $ }}-config-volume
               mountPath: /etc/config
+            - name: {{ $.Chart.Name }}-secrets-volume
+              mountPath: /etc/secrets
+              readOnly: true
             {{- with $.Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -47,6 +50,9 @@ spec:
         - name: {{ include "cortex.fullname" $ }}-config-volume
           configMap:
             name: {{ include "cortex.fullname" $ }}-config
+        - name: {{ $.Chart.Name }}-secrets-volume
+          secret:
+            secretName: {{ include "cortex.fullname" $ }}-secrets
         {{- with $.Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/cortex/templates/deployment.yaml
+++ b/helm/cortex/templates/deployment.yaml
@@ -10,6 +10,8 @@ metadata:
   annotations:
     # Roll the service when its configmap changes.
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
+    # Roll the service when its secret changes.
+    checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") $ | sha256sum }}
     kubectl.kubernetes.io/default-container: {{ $.Chart.Name }}-{{ .name }}
     checksum/image: "{{ $.Values.image.tag }}"
   labels:
@@ -62,6 +64,9 @@ spec:
           volumeMounts:
             - name: {{ include "cortex.fullname" $ }}-config-volume
               mountPath: /etc/config
+            - name: {{ $.Chart.Name }}-secrets-volume
+              mountPath: /etc/secrets
+              readOnly: true
           {{- with $.Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -69,6 +74,9 @@ spec:
         - name: {{ include "cortex.fullname" $ }}-config-volume
           configMap:
             name: {{ include "cortex.fullname" $ }}-config
+        - name: {{ $.Chart.Name }}-secrets-volume
+          secret:
+            secretName: {{ include "cortex.fullname" $ }}-secrets
       {{- with $.Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/cortex/templates/migrations.yaml
+++ b/helm/cortex/templates/migrations.yaml
@@ -39,7 +39,13 @@ spec:
             # Custom config that can override some values, e.g. conf validation.
             - name: {{ include "cortex.fullname" $ }}-pre-upgrade-config-volume
               mountPath: /etc/config
+            - name: {{ $.Chart.Name }}-secrets-volume
+              mountPath: /etc/secrets
+              readOnly: true
       volumes:
         - name: {{ include "cortex.fullname" $ }}-pre-upgrade-config-volume
           configMap:
             name: {{ include "cortex.fullname" $ }}-pre-upgrade-config
+        - name: {{ $.Chart.Name }}-secrets-volume
+          secret:
+            secretName: {{ include "cortex.fullname" $ }}-secrets

--- a/helm/cortex/templates/secret.yaml
+++ b/helm/cortex/templates/secret.yaml
@@ -1,0 +1,43 @@
+# Copyright 2025 SAP SE
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cortex.fullname" . }}-secrets
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+type: Opaque
+data:
+  secrets.json: |-
+    {{- if .Values.secrets }}
+    {{ toJson .Values.secrets | b64enc }}
+    {{- else }}
+    {{ "{}" | b64enc }}
+    {{- end }}
+---
+# Secret for pre-upgrade resources.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cortex.fullname" . }}-pre-upgrade-secrets
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+type: Opaque
+data:
+  secrets.json: |-
+    {{- if .Values.secrets }}
+    {{ toJson .Values.secrets | b64enc }}
+    {{- else }}
+    {{ "{}" | b64enc }}
+    {{- end }}

--- a/helm/cortex/values.yaml
+++ b/helm/cortex/values.yaml
@@ -84,7 +84,7 @@ sharedSSOCert: &sharedSSOCert
   # If true, the certificate is not verified.
   selfSigned: false
 
-# Values passed to the service by conf.yaml
+# Values passed to the service through a configmap.
 conf:
   logging:
     # The log level to use (debug, info, warn, error).
@@ -109,8 +109,6 @@ conf:
   mqtt:
     # Must match rabbitmq settings from the cortex-mqtt chart.
     url: "tcp://cortex-mqtt:1883"
-    username: "cortex"
-    password: "secret"
     # Configure how Cortex should handle lost connections to the MQTT broker.
     reconnect:
       maxRetries: 20
@@ -124,8 +122,6 @@ conf:
   db:
     host: cortex-postgresql
     port: 5432
-    user: postgres
-    password: secret
     database: postgres
     reconnect:
       maxRetries: 20
@@ -135,37 +131,10 @@ conf:
   keystone:
     # Authentication/identity service URL for openstack.
     url: https://path-to-keystone/v3
-    # Optional, only required if OpenStack is configured with SSO.
-    # Note: the certificate will be used for all other OpenStack services.
-    sso: *sharedSSOCert
-
-    # OpenStack login credentials also used by the OpenStack CLI.
-    username: openstack-user-with-all-project-read-access
-    password: openstack-user-password
-    projectName: openstack-project-of-user
-    userDomainName: openstack-domain-of-user
-    projectDomainName: openstack-domain-of-project-scoped-to
 
   # Sync plugins config.
   sync:
     prometheus:
-      # Prometheus hosts to consider when syncing the metrics.
-      hosts:
-        - name: vmware_prometheus
-          url: https://path-to-vrops-prometheus
-          provides: [vrops_vm_metric, vrops_host_metric]
-          # Optional, only required if Prometheus is configured with SSO.
-          sso: *sharedSSOCert
-        - name: kvm_prometheus
-          url: https://path-to-node-exporter
-          provides: [node_exporter_metric]
-          # Optional, only required if Prometheus is configured with SSO.
-          sso: *sharedSSOCert
-        - name: netapp_prometheus
-          url: https://path-to-netapp-harvest-exporter
-          provides: [netapp_aggregate_labels_metric, netapp_node_metric]
-          # Optional, only required if Prometheus is configured with SSO.
-          sso: *sharedSSOCert
       # Prometheus metrics to sync into the database.
       # Each metric can be synced from a different Prometheus instance.
       # The `type` parameter should map to a known metric model in the database.
@@ -657,6 +626,47 @@ conf:
                 nova:
                   types:
                     - servers
+
+# Values passed to the service through a kubernetes secret.
+# The keys of these values should correspond to the keys used above in the conf.
+secrets:
+  # MQTT broker connection credentials.
+  mqtt:
+    username: cortex
+    password: secret
+  # Database connection credentials.
+  db:
+    user: postgres
+    password: secret
+  keystone:
+    # OpenStack login credentials also used by the OpenStack CLI.
+    projectName: openstack-project-of-user
+    userDomainName: openstack-domain-of-user
+    projectDomainName: openstack-domain-of-project-scoped-to
+    username: openstack-user-with-all-project-read-access
+    password: openstack-user-password
+    # Optional, only required if OpenStack is configured with SSO.
+    # Note: the certificate will be used for all other OpenStack services.
+    sso: *sharedSSOCert
+  sync:
+    prometheus:
+      # Prometheus hosts to consider when syncing the metrics.
+      hosts:
+        - name: vmware_prometheus
+          url: https://path-to-vrops-prometheus
+          provides: [vrops_vm_metric, vrops_host_metric]
+          # Optional, only required if Prometheus is configured with SSO.
+          sso: *sharedSSOCert
+        - name: kvm_prometheus
+          url: https://path-to-node-exporter
+          provides: [node_exporter_metric]
+          # Optional, only required if Prometheus is configured with SSO.
+          sso: *sharedSSOCert
+        - name: netapp_prometheus
+          url: https://path-to-netapp-harvest-exporter
+          provides: [netapp_aggregate_labels_metric, netapp_node_metric]
+          # Optional, only required if Prometheus is configured with SSO.
+          sso: *sharedSSOCert
 
 # Generic modifiers added on the initial creation of this helm chart.
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -41,8 +41,8 @@ type DBConfig struct {
 	Host      string            `json:"host"`
 	Port      int               `json:"port"`
 	Database  string            `json:"database"`
-	User      string            `json:"user" env:"inject"`
-	Password  string            `json:"password" env:"inject"`
+	User      string            `json:"user"`
+	Password  string            `json:"password"`
 	Reconnect DBReconnectConfig `json:"reconnect"`
 }
 
@@ -336,8 +336,8 @@ type MQTTConfig struct {
 	// The URL of the MQTT broker to use for mqtt.
 	URL string `json:"url"`
 	// Credentials for the MQTT broker.
-	Username  string              `json:"username" env:"inject"`
-	Password  string              `json:"password" env:"inject"`
+	Username  string              `json:"username"`
+	Password  string              `json:"password"`
 	Reconnect MQTTReconnectConfig `json:"reconnect"`
 }
 
@@ -355,9 +355,9 @@ type KeystoneConfig struct {
 	// use SSO to connect to the openstack services.
 	SSO SSOConfig `json:"sso,omitempty"`
 	// The OpenStack username (OS_USERNAME in openstack cli).
-	OSUsername string `json:"username" env:"inject"`
+	OSUsername string `json:"username"`
 	// The OpenStack password (OS_PASSWORD in openstack cli).
-	OSPassword string `json:"password" env:"inject"`
+	OSPassword string `json:"password"`
 	// The OpenStack project name (OS_PROJECT_NAME in openstack cli).
 	OSProjectName string `json:"projectName"`
 	// The OpenStack user domain name (OS_USER_DOMAIN_NAME in openstack cli).

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -122,7 +122,11 @@ func TestNewConfig(t *testing.T) {
 }`
 	filepath := createTempConfigFile(t, content)
 
-	config := newConfigFromFile(filepath)
+	rawConfig, err := readRawConfig(filepath)
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+	config := newConfigFromMaps(rawConfig, nil)
 
 	// Test SyncConfig
 	syncConfig := config.GetSyncConfig()
@@ -218,5 +222,63 @@ func TestNewConfig(t *testing.T) {
 	apiConfig := config.GetAPIConfig()
 	if apiConfig.Port == 0 {
 		t.Errorf("Expected non-zero API port, got 0")
+	}
+}
+
+func TestMergeMaps(t *testing.T) {
+	// Test basic merge
+	dst := map[string]any{
+		"a": "original",
+		"b": map[string]any{"nested": "value"},
+	}
+	src := map[string]any{
+		"a": "overridden",
+		"c": "new",
+	}
+
+	mergeMaps(dst, src)
+
+	if dst["a"] != "overridden" {
+		t.Errorf("Expected 'a' to be 'overridden', got %v", dst["a"])
+	}
+	if dst["c"] != "new" {
+		t.Errorf("Expected 'c' to be 'new', got %v", dst["c"])
+	}
+
+	// Test nested merge
+	dst = map[string]any{
+		"nested": map[string]any{
+			"keep":     "original",
+			"override": "old",
+		},
+	}
+	src = map[string]any{
+		"nested": map[string]any{
+			"override": "new",
+			"add":      "added",
+		},
+	}
+
+	mergeMaps(dst, src)
+
+	nested := dst["nested"].(map[string]any)
+	if nested["keep"] != "original" {
+		t.Errorf("Expected nested 'keep' to be 'original', got %v", nested["keep"])
+	}
+	if nested["override"] != "new" {
+		t.Errorf("Expected nested 'override' to be 'new', got %v", nested["override"])
+	}
+	if nested["add"] != "added" {
+		t.Errorf("Expected nested 'add' to be 'added', got %v", nested["add"])
+	}
+
+	// Test nil value handling
+	dst = map[string]any{"key": "value"}
+	src = map[string]any{"key": nil}
+
+	mergeMaps(dst, src)
+
+	if dst["key"] != "value" {
+		t.Errorf("Expected 'key' to remain 'value' when src is nil, got %v", dst["key"])
 	}
 }

--- a/internal/conf/validation_test.go
+++ b/internal/conf/validation_test.go
@@ -83,7 +83,11 @@ func TestValidConf(t *testing.T) {
   }
 }
 `
-	conf := newConfigFromBytes([]byte(content))
+	rawConf, err := readRawConfigFromBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+	conf := newConfigFromMaps(rawConf, nil)
 	if err := conf.Validate(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -130,7 +134,11 @@ func TestInvalidConf_MissingNovaDependency(t *testing.T) {
   }
 }
 `
-	conf := newConfigFromBytes([]byte(content))
+	rawConf, err := readRawConfigFromBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+	conf := newConfigFromMaps(rawConf, nil)
 	if err := conf.Validate(); err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -150,7 +158,11 @@ func TestInvalidConf_MissingResourceProviders(t *testing.T) {
   }
 }
 `
-	conf := newConfigFromBytes([]byte(content))
+	rawConf, err := readRawConfigFromBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+	conf := newConfigFromMaps(rawConf, nil)
 	if err := conf.Validate(); err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -168,7 +180,11 @@ func TestInvalidConf_InvalidServiceAvailability(t *testing.T) {
   }
 }
 `
-	conf := newConfigFromBytes([]byte(content))
+	rawConf, err := readRawConfigFromBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+	conf := newConfigFromMaps(rawConf, nil)
 	if err := conf.Validate(); err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -190,7 +206,11 @@ func TestInvalidConf_MissingHost(t *testing.T) {
   }
 }
 `
-	conf := newConfigFromBytes([]byte(content))
+	rawConf, err := readRawConfigFromBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+	conf := newConfigFromMaps(rawConf, nil)
 	if err := conf.Validate(); err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -213,7 +233,11 @@ func TestInvalidConf_MissingFeatureForKPI(t *testing.T) {
   }
 }
 `
-	conf := newConfigFromBytes([]byte(content))
+	rawConf, err := readRawConfigFromBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+	conf := newConfigFromMaps(rawConf, nil)
 	if len(conf.GetKPIsConfig().Plugins) == 0 {
 		t.Fatalf("expected plugins, got none")
 	}
@@ -238,7 +262,11 @@ func TestInvalidConf_NovaSchedulerDependency(t *testing.T) {
   }
 }
 `
-	conf := newConfigFromBytes([]byte(content))
+	rawConf, err := readRawConfigFromBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+	conf := newConfigFromMaps(rawConf, nil)
 	if err := conf.Validate(); err == nil {
 		t.Fatalf("expected error, got nil")
 	}


### PR DESCRIPTION
Improve access control to passwords -> people without access to kubernetes secrets can still see configmap using RBAC.