### PR TITLE
Don't place ironic flavors

### DIFF
--- a/internal/scheduler/nova/api/http/api.go
+++ b/internal/scheduler/nova/api/http/api.go
@@ -61,6 +61,7 @@ func (httpAPI *httpAPI) canRunScheduler(requestData api.ExternalSchedulerRequest
 	}
 	// Cortex doesn't support baremetal flavors.
 	// See: https://github.com/sapcc/nova/blob/5fcb125/nova/utils.py#L1234
+	// And: https://github.com/sapcc/nova/pull/570/files
 	extraSpecs := requestData.Spec.Data.Flavor.Data.ExtraSpecs
 	if _, ok := extraSpecs["capabilities:cpu_arch"]; ok {
 		return false, "baremetal flavors are not supported"

--- a/internal/scheduler/nova/api/http/api.go
+++ b/internal/scheduler/nova/api/http/api.go
@@ -59,6 +59,12 @@ func (httpAPI *httpAPI) canRunScheduler(requestData api.ExternalSchedulerRequest
 			return false, "weight assigned to unknown host"
 		}
 	}
+	// Cortex doesn't support baremetal flavors.
+	// See: https://github.com/sapcc/nova/blob/5fcb125/nova/utils.py#L1234
+	extraSpecs := requestData.Spec.Data.Flavor.Data.ExtraSpecs
+	if _, ok := extraSpecs["capabilities:cpu_arch"]; ok {
+		return false, "baremetal flavors are not supported"
+	}
 	return true, ""
 }
 

--- a/internal/scheduler/nova/api/http/api_test.go
+++ b/internal/scheduler/nova/api/http/api_test.go
@@ -53,6 +53,29 @@ func TestCanRunScheduler(t *testing.T) {
 			wantOk: false,
 		},
 		{
+			name: "Unsupported baremetal flavor",
+			request: api.ExternalSchedulerRequest{
+				Hosts: []api.ExternalSchedulerHost{
+					{ComputeHost: "host1", HypervisorHostname: "hypervisor1"},
+				},
+				Weights: map[string]float64{
+					"unknown_host": 1.0,
+				},
+				Spec: api.NovaObject[api.NovaSpec]{
+					Data: api.NovaSpec{
+						Flavor: api.NovaObject[api.NovaFlavor]{
+							Data: api.NovaFlavor{
+								ExtraSpecs: map[string]string{
+									"capabilities:cpu_arch": "x86_64",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantOk: false,
+		},
+		{
 			name: "Valid request",
 			request: api.ExternalSchedulerRequest{
 				Hosts: []api.ExternalSchedulerHost{


### PR DESCRIPTION
See https://github.com/sapcc/nova/pull/570
This is to have a 2nd safety in place, and so we don't forget that it's unsupported.