### PR TITLE
Add premodifier for pipeline to preselect all nova hosts if needed

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -170,6 +170,11 @@ type NovaSchedulerConfig struct {
 
 	// Dependencies needed by all the Nova scheduler steps.
 	DependencyConfig `json:"dependencies,omitempty"`
+
+	// If all available hosts should be selected in the request,
+	// regardless of what nova sends us in the request.
+	// By default, this is false (use the hosts nova gives us).
+	PreselectAllHosts bool `json:"preselectAllHosts,omitempty"`
 }
 
 type SchedulerStepConfig struct {

--- a/internal/scheduler/manila/pipeline.go
+++ b/internal/scheduler/manila/pipeline.go
@@ -45,6 +45,6 @@ func NewPipeline(
 	}
 	return scheduler.NewPipeline(
 		supportedSteps, config.Manila.Plugins, wrappers,
-		db, monitor, mqttClient, TopicFinished,
+		db, monitor, mqttClient, TopicFinished, nil,
 	)
 }

--- a/internal/scheduler/nova/pipeline_test.go
+++ b/internal/scheduler/nova/pipeline_test.go
@@ -28,31 +28,87 @@ func setupTestDBWithHypervisors(t *testing.T) db.DB {
 	}
 
 	// Insert mock hypervisor data
-	_, err = testDB.Exec(`
-		INSERT INTO openstack_hypervisors (
-			id, hostname, state, status, hypervisor_type, hypervisor_version,
-			host_ip, service_id, service_host, service_disabled_reason,
-			vcpus, memory_mb, local_gb, vcpus_used, memory_mb_used, local_gb_used,
-			free_ram_mb, free_disk_gb, current_workload, running_vms,
-			disk_available_least, cpu_info
-		)
-		VALUES
-			('1', 'hypervisor-1.example.com', 'up', 'enabled', 'kvm', 2011,
-			 '192.168.1.10', 'service-1', 'nova-compute-1', NULL,
-			 16, 32768, 1000, 4, 8192, 200,
-			 24576, 800, 2, 5,
-			 750, '{"arch": "x86_64", "model": "Intel"}'),
-			('2', 'hypervisor-2.example.com', 'up', 'enabled', 'vmware', 6070,
-			 '192.168.1.11', 'service-2', 'nova-compute-2', NULL,
-			 32, 65536, 2000, 8, 16384, 400,
-			 49152, 1600, 4, 10,
-			 1500, '{"arch": "x86_64", "model": "AMD"}'),
-			('3', 'hypervisor-3.example.com', 'down', 'disabled', 'kvm', 2011,
-			 '192.168.1.12', 'service-3', 'nova-compute-3', 'maintenance',
-			 24, 49152, 1500, 0, 0, 0,
-			 49152, 1500, 0, 0,
-			 1450, '{"arch": "x86_64", "model": "Intel"}')
-	`)
+	h1Disk := 750
+	h2Disk := 1500
+	h3SDA := "maintenance"
+	h3Disk := 1450
+	hypervisors := []any{
+		&nova.Hypervisor{
+			ID:                    "1",
+			Hostname:              "hypervisor-1.example.com",
+			State:                 "up",
+			Status:                "enabled",
+			HypervisorType:        "kvm",
+			HypervisorVersion:     2011,
+			HostIP:                "192.168.1.10",
+			ServiceID:             "service-1",
+			ServiceHost:           "nova-compute-1",
+			ServiceDisabledReason: nil,
+			VCPUs:                 16,
+			MemoryMB:              32768,
+			LocalGB:               1000,
+			VCPUsUsed:             4,
+			MemoryMBUsed:          8192,
+			LocalGBUsed:           200,
+			FreeRAMMB:             24576,
+			FreeDiskGB:            800,
+			CurrentWorkload:       2,
+			RunningVMs:            5,
+			DiskAvailableLeast:    &h1Disk,
+			CPUInfo:               `{"arch": "x86_64", "model": "Intel"}`,
+		},
+		&nova.Hypervisor{
+			ID:                    "2",
+			Hostname:              "hypervisor-2.example.com",
+			State:                 "up",
+			Status:                "enabled",
+			HypervisorType:        "vmware",
+			HypervisorVersion:     6070,
+			HostIP:                "192.168.1.11",
+			ServiceID:             "service-2",
+			ServiceHost:           "nova-compute-2",
+			ServiceDisabledReason: nil,
+			VCPUs:                 32,
+			MemoryMB:              65536,
+			LocalGB:               2000,
+			VCPUsUsed:             8,
+			MemoryMBUsed:          16384,
+			LocalGBUsed:           400,
+			FreeRAMMB:             49152,
+			FreeDiskGB:            1600,
+			CurrentWorkload:       4,
+			RunningVMs:            10,
+			DiskAvailableLeast:    &h2Disk,
+			CPUInfo:               `{"arch": "x86_64", "model": "AMD"}`,
+		},
+		&nova.Hypervisor{
+			ID:                    "3",
+			Hostname:              "hypervisor-3.example.com",
+			State:                 "down",
+			Status:                "disabled",
+			HypervisorType:        "kvm",
+			HypervisorVersion:     2011,
+			HostIP:                "192.168.1.12",
+			ServiceID:             "service-3",
+			ServiceHost:           "nova-compute-3",
+			ServiceDisabledReason: &h3SDA,
+			VCPUs:                 24,
+			MemoryMB:              49152,
+			LocalGB:               1500,
+			VCPUsUsed:             0,
+			MemoryMBUsed:          0,
+			LocalGBUsed:           0,
+			FreeRAMMB:             49152,
+			FreeDiskGB:            1500,
+			CurrentWorkload:       0,
+			RunningVMs:            0,
+			DiskAvailableLeast:    &h3Disk,
+			CPUInfo:               `{"arch": "x86_64", "model": "Intel"}`,
+		},
+	}
+	if err := testDB.Insert(hypervisors...); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	if err != nil {
 		t.Fatalf("expected no error inserting hypervisor data, got %v", err)
 	}

--- a/internal/scheduler/nova/pipeline_test.go
+++ b/internal/scheduler/nova/pipeline_test.go
@@ -1,0 +1,357 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package nova
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	"github.com/cobaltcore-dev/cortex/internal/scheduler/nova/api"
+	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/nova"
+	testlibDB "github.com/cobaltcore-dev/cortex/testlib/db"
+)
+
+// setupTestDBWithHypervisors creates a test database with hypervisor data for premodifier testing.
+func setupTestDBWithHypervisors(t *testing.T) db.DB {
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+
+	// Create table for hypervisors
+	err := testDB.CreateTable(
+		testDB.AddTable(nova.Hypervisor{}),
+	)
+	if err != nil {
+		t.Fatalf("expected no error creating hypervisors table, got %v", err)
+	}
+
+	// Insert mock hypervisor data
+	_, err = testDB.Exec(`
+		INSERT INTO openstack_hypervisors (
+			id, hostname, state, status, hypervisor_type, hypervisor_version,
+			host_ip, service_id, service_host, service_disabled_reason,
+			vcpus, memory_mb, local_gb, vcpus_used, memory_mb_used, local_gb_used,
+			free_ram_mb, free_disk_gb, current_workload, running_vms,
+			disk_available_least, cpu_info
+		)
+		VALUES
+			('1', 'hypervisor-1.example.com', 'up', 'enabled', 'kvm', 2011,
+			 '192.168.1.10', 'service-1', 'nova-compute-1', NULL,
+			 16, 32768, 1000, 4, 8192, 200,
+			 24576, 800, 2, 5,
+			 750, '{"arch": "x86_64", "model": "Intel"}'),
+			('2', 'hypervisor-2.example.com', 'up', 'enabled', 'vmware', 6070,
+			 '192.168.1.11', 'service-2', 'nova-compute-2', NULL,
+			 32, 65536, 2000, 8, 16384, 400,
+			 49152, 1600, 4, 10,
+			 1500, '{"arch": "x86_64", "model": "AMD"}'),
+			('3', 'hypervisor-3.example.com', 'down', 'disabled', 'kvm', 2011,
+			 '192.168.1.12', 'service-3', 'nova-compute-3', 'maintenance',
+			 24, 49152, 1500, 0, 0, 0,
+			 49152, 1500, 0, 0,
+			 1450, '{"arch": "x86_64", "model": "Intel"}')
+	`)
+	if err != nil {
+		t.Fatalf("expected no error inserting hypervisor data, got %v", err)
+	}
+
+	return testDB
+}
+
+func TestPremodifier_ModifyRequest_PreselectAllHostsDisabled(t *testing.T) {
+	testDB := setupTestDBWithHypervisors(t)
+	defer testDB.Close()
+
+	premod := &premodifier{
+		database: testDB,
+		config: conf.NovaSchedulerConfig{
+			PreselectAllHosts: false, // Disabled
+		},
+	}
+
+	// Create a request with some existing hosts
+	request := &api.ExternalSchedulerRequest{
+		Hosts: []api.ExternalSchedulerHost{
+			{ComputeHost: "existing-host-1", HypervisorHostname: "existing-hypervisor-1"},
+		},
+		Weights: map[string]float64{
+			"existing-host-1": 1.5,
+		},
+	}
+
+	err := premod.ModifyRequest(request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Request should remain unchanged when PreselectAllHosts is false
+	expectedHosts := []api.ExternalSchedulerHost{
+		{ComputeHost: "existing-host-1", HypervisorHostname: "existing-hypervisor-1"},
+	}
+	expectedWeights := map[string]float64{
+		"existing-host-1": 1.5,
+	}
+
+	if !reflect.DeepEqual(request.Hosts, expectedHosts) {
+		t.Errorf("hosts = %v, want %v", request.Hosts, expectedHosts)
+	}
+	if !reflect.DeepEqual(request.Weights, expectedWeights) {
+		t.Errorf("weights = %v, want %v", request.Weights, expectedWeights)
+	}
+}
+
+func TestPremodifier_ModifyRequest_PreselectAllHostsEnabled(t *testing.T) {
+	testDB := setupTestDBWithHypervisors(t)
+	defer testDB.Close()
+
+	premod := &premodifier{
+		database: testDB,
+		config: conf.NovaSchedulerConfig{
+			PreselectAllHosts: true, // Enabled
+		},
+	}
+
+	// Create a request with some existing hosts (should be replaced)
+	request := &api.ExternalSchedulerRequest{
+		Hosts: []api.ExternalSchedulerHost{
+			{ComputeHost: "existing-host-1", HypervisorHostname: "existing-hypervisor-1"},
+		},
+		Weights: map[string]float64{
+			"existing-host-1": 1.5,
+		},
+	}
+
+	err := premod.ModifyRequest(request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Request should be modified to include all hypervisors from database
+	expectedHosts := []api.ExternalSchedulerHost{
+		{ComputeHost: "nova-compute-1", HypervisorHostname: "hypervisor-1.example.com"},
+		{ComputeHost: "nova-compute-2", HypervisorHostname: "hypervisor-2.example.com"},
+		{ComputeHost: "nova-compute-3", HypervisorHostname: "hypervisor-3.example.com"},
+	}
+	expectedWeights := map[string]float64{
+		"nova-compute-1": 0.0,
+		"nova-compute-2": 0.0,
+		"nova-compute-3": 0.0,
+	}
+
+	if len(request.Hosts) != 3 {
+		t.Errorf("expected 3 hosts, got %d", len(request.Hosts))
+	}
+	if len(request.Weights) != 3 {
+		t.Errorf("expected 3 weights, got %d", len(request.Weights))
+	}
+
+	// Check that all expected hosts are present (order might vary)
+	hostMap := make(map[string]string)
+	for _, host := range request.Hosts {
+		hostMap[host.ComputeHost] = host.HypervisorHostname
+	}
+
+	for _, expectedHost := range expectedHosts {
+		if hypervisorHostname, exists := hostMap[expectedHost.ComputeHost]; !exists {
+			t.Errorf("expected host %s not found", expectedHost.ComputeHost)
+		} else if hypervisorHostname != expectedHost.HypervisorHostname {
+			t.Errorf("host %s has hypervisor hostname %s, want %s",
+				expectedHost.ComputeHost, hypervisorHostname, expectedHost.HypervisorHostname)
+		}
+	}
+
+	// Check weights
+	for computeHost, expectedWeight := range expectedWeights {
+		if weight, exists := request.Weights[computeHost]; !exists {
+			t.Errorf("expected weight for host %s not found", computeHost)
+		} else if weight != expectedWeight {
+			t.Errorf("weight for host %s = %f, want %f", computeHost, weight, expectedWeight)
+		}
+	}
+}
+
+func TestPremodifier_ModifyRequest_PreselectAllHostsEnabled_EmptyRequest(t *testing.T) {
+	testDB := setupTestDBWithHypervisors(t)
+	defer testDB.Close()
+
+	premod := &premodifier{
+		database: testDB,
+		config: conf.NovaSchedulerConfig{
+			PreselectAllHosts: true,
+		},
+	}
+
+	// Create an empty request
+	request := &api.ExternalSchedulerRequest{
+		Hosts:   []api.ExternalSchedulerHost{},
+		Weights: map[string]float64{},
+	}
+
+	err := premod.ModifyRequest(request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should populate with all hypervisors
+	if len(request.Hosts) != 3 {
+		t.Errorf("expected 3 hosts, got %d", len(request.Hosts))
+	}
+	if len(request.Weights) != 3 {
+		t.Errorf("expected 3 weights, got %d", len(request.Weights))
+	}
+
+	// Verify all weights are 0.0
+	for _, weight := range request.Weights {
+		if weight != 0.0 {
+			t.Errorf("expected weight 0.0, got %f", weight)
+		}
+	}
+}
+
+func TestPremodifier_ModifyRequest_NoHypervisors(t *testing.T) {
+	// Create empty database
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+
+	// Create table but don't insert any data
+	err := testDB.CreateTable(
+		testDB.AddTable(nova.Hypervisor{}),
+	)
+	if err != nil {
+		t.Fatalf("expected no error creating hypervisors table, got %v", err)
+	}
+
+	premod := &premodifier{
+		database: testDB,
+		config: conf.NovaSchedulerConfig{
+			PreselectAllHosts: true,
+		},
+	}
+
+	request := &api.ExternalSchedulerRequest{
+		Hosts:   []api.ExternalSchedulerHost{},
+		Weights: map[string]float64{},
+	}
+
+	err = premod.ModifyRequest(request)
+	if err == nil {
+		t.Fatal("expected error when no hypervisors found, got nil")
+	}
+	if err.Error() != "no hypervisors found" {
+		t.Errorf("expected error 'no hypervisors found', got %v", err)
+	}
+}
+
+func TestPremodifier_ModifyRequest_DatabaseError(t *testing.T) {
+	// Create database but don't create the hypervisors table
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+
+	premod := &premodifier{
+		database: testDB,
+		config: conf.NovaSchedulerConfig{
+			PreselectAllHosts: true,
+		},
+	}
+
+	request := &api.ExternalSchedulerRequest{
+		Hosts:   []api.ExternalSchedulerHost{},
+		Weights: map[string]float64{},
+	}
+
+	err := premod.ModifyRequest(request)
+	if err == nil {
+		t.Fatal("expected database error, got nil")
+	}
+	// The exact error message will depend on the database implementation,
+	// but it should be a database-related error
+}
+
+func TestPremodifier_ModifyRequest_PreservesOtherFields(t *testing.T) {
+	testDB := setupTestDBWithHypervisors(t)
+	defer testDB.Close()
+
+	premod := &premodifier{
+		database: testDB,
+		config: conf.NovaSchedulerConfig{
+			PreselectAllHosts: true,
+		},
+	}
+
+	// Create a request with various fields set
+	originalRequest := &api.ExternalSchedulerRequest{
+		Spec: api.NovaObject[api.NovaSpec]{
+			Data: api.NovaSpec{
+				ProjectID:    "test-project",
+				UserID:       "test-user",
+				InstanceUUID: "test-instance-uuid",
+			},
+		},
+		Context: api.NovaRequestContext{
+			UserID:    "test-user",
+			ProjectID: "test-project",
+			RequestID: "test-request-id",
+		},
+		Rebuild:   true,
+		Resize:    false,
+		Live:      true,
+		VMware:    false,
+		Sandboxed: true,
+		Hosts: []api.ExternalSchedulerHost{
+			{ComputeHost: "original-host", HypervisorHostname: "original-hypervisor"},
+		},
+		Weights: map[string]float64{
+			"original-host": 2.5,
+		},
+	}
+
+	err := premod.ModifyRequest(originalRequest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify that non-host/weight fields are preserved
+	if originalRequest.Spec.Data.ProjectID != "test-project" {
+		t.Errorf("spec.data.project_id = %s, want test-project", originalRequest.Spec.Data.ProjectID)
+	}
+	if originalRequest.Context.UserID != "test-user" {
+		t.Errorf("context.user_id = %s, want test-user", originalRequest.Context.UserID)
+	}
+	if !originalRequest.Rebuild {
+		t.Error("rebuild should be true")
+	}
+	if originalRequest.Resize {
+		t.Error("resize should be false")
+	}
+	if !originalRequest.Live {
+		t.Error("live should be true")
+	}
+	if originalRequest.VMware {
+		t.Error("vmware should be false")
+	}
+	if !originalRequest.Sandboxed {
+		t.Error("sandboxed should be true")
+	}
+
+	// Verify that hosts and weights were replaced
+	if len(originalRequest.Hosts) != 3 {
+		t.Errorf("expected 3 hosts after premodification, got %d", len(originalRequest.Hosts))
+	}
+	if len(originalRequest.Weights) != 3 {
+		t.Errorf("expected 3 weights after premodification, got %d", len(originalRequest.Weights))
+	}
+
+	// Verify original host is no longer present
+	for _, host := range originalRequest.Hosts {
+		if host.ComputeHost == "original-host" {
+			t.Error("original host should have been replaced")
+		}
+	}
+	if _, exists := originalRequest.Weights["original-host"]; exists {
+		t.Error("original host weight should have been replaced")
+	}
+}

--- a/internal/scheduler/pipeline_test.go
+++ b/internal/scheduler/pipeline_test.go
@@ -239,7 +239,7 @@ func TestNewPipeline(t *testing.T) {
 		supportedSteps,
 		[]conf.SchedulerStepConfig{{Name: "mock_pipeline_step", Options: conf.RawOpts{}}},
 		[]StepWrapper[mockPipelineRequest]{},
-		database, monitor, mqttClient, "test/topic",
+		database, monitor, mqttClient, "test/topic", nil,
 	).(*pipeline[mockPipelineRequest])
 
 	if len(pipeline.executionOrder) != 1 {
@@ -273,7 +273,7 @@ func TestNewPipeline_SameStepMultipleAliases(t *testing.T) {
 			{Name: "mock_pipeline_step", Alias: "mock_step_2", Options: conf.RawOpts{}},
 		},
 		[]StepWrapper[mockPipelineRequest]{},
-		database, monitor, mqttClient, "test/topic",
+		database, monitor, mqttClient, "test/topic", nil,
 	).(*pipeline[mockPipelineRequest])
 
 	if len(pipeline.executionOrder[0]) != 2 {


### PR DESCRIPTION
This is useful to compare our own filters with nova filters.

Usage to enable this feature for local debugging:
```
cortex-core:
  conf:
    scheduler:
      nova:
        preselectAllHosts: true
```