### PR TITLE
Replace plain table names usage in sql queries

### DIFF
--- a/internal/extractor/plugins/kvm/node_exporter_host_cpu_usage_test.go
+++ b/internal/extractor/plugins/kvm/node_exporter_host_cpu_usage_test.go
@@ -48,14 +48,13 @@ func TestNodeExporterHostCPUUsageExtractor_Extract(t *testing.T) {
 	}
 
 	// Insert mock data into the node_exporter_metrics table
-	_, err := testDB.Exec(`
-        INSERT INTO node_exporter_metrics (node, name, value)
-        VALUES
-            ('node1', 'node_exporter_cpu_usage_pct', 20.0),
-            ('node2', 'node_exporter_cpu_usage_pct', 30.0),
-            ('node1', 'node_exporter_cpu_usage_pct', 40.0)
-    `)
-	if err != nil {
+	nodeExporterMetrics := []any{
+		&prometheus.NodeExporterMetric{Node: "node1", Name: "node_exporter_cpu_usage_pct", Value: 20.0},
+		&prometheus.NodeExporterMetric{Node: "node2", Name: "node_exporter_cpu_usage_pct", Value: 30.0},
+		&prometheus.NodeExporterMetric{Node: "node1", Name: "node_exporter_cpu_usage_pct", Value: 40.0},
+	}
+
+	if err := testDB.Insert(nodeExporterMetrics...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -69,14 +68,13 @@ func TestNodeExporterHostCPUUsageExtractor_Extract(t *testing.T) {
 	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if _, err = extractor.Extract(); err != nil {
+	if _, err := extractor.Extract(); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	// Verify the data was inserted into the feature_host_cpu_usage table
 	var usages []NodeExporterHostCPUUsage
-	table := NodeExporterHostCPUUsage{}.TableName()
-	_, err = testDB.Select(&usages, "SELECT * FROM "+table)
+	_, err := testDB.Select(&usages, "SELECT * FROM "+NodeExporterHostCPUUsage{}.TableName())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/extractor/plugins/kvm/node_exporter_host_cpu_usage_test.go
+++ b/internal/extractor/plugins/kvm/node_exporter_host_cpu_usage_test.go
@@ -74,7 +74,8 @@ func TestNodeExporterHostCPUUsageExtractor_Extract(t *testing.T) {
 
 	// Verify the data was inserted into the feature_host_cpu_usage table
 	var usages []NodeExporterHostCPUUsage
-	_, err := testDB.Select(&usages, "SELECT * FROM "+NodeExporterHostCPUUsage{}.TableName())
+	table := NodeExporterHostCPUUsage{}.TableName()
+	_, err := testDB.Select(&usages, "SELECT * FROM "+table)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/extractor/plugins/kvm/node_exporter_host_memory_active_test.go
+++ b/internal/extractor/plugins/kvm/node_exporter_host_memory_active_test.go
@@ -49,9 +49,9 @@ func TestNodeExporterHostMemoryActiveExtractor_Extract(t *testing.T) {
 	// Insert mock data into the node_exporter_metrics table
 
 	nodeExporterMetrics := []any{
-		&prometheus.NodeExporterMetric{Node: "node1", Name: "node_exporter_cpu_usage_pct", Value: 20.0},
-		&prometheus.NodeExporterMetric{Node: "node2", Name: "node_exporter_cpu_usage_pct", Value: 30.0},
-		&prometheus.NodeExporterMetric{Node: "node1", Name: "node_exporter_cpu_usage_pct", Value: 40.0},
+		&prometheus.NodeExporterMetric{Node: "node1", Name: "node_exporter_memory_active_pct", Value: 20.0},
+		&prometheus.NodeExporterMetric{Node: "node2", Name: "node_exporter_memory_active_pct", Value: 30.0},
+		&prometheus.NodeExporterMetric{Node: "node1", Name: "node_exporter_memory_active_pct", Value: 40.0},
 	}
 
 	if err := testDB.Insert(nodeExporterMetrics...); err != nil {

--- a/internal/extractor/plugins/kvm/node_exporter_host_memory_active_test.go
+++ b/internal/extractor/plugins/kvm/node_exporter_host_memory_active_test.go
@@ -73,7 +73,8 @@ func TestNodeExporterHostMemoryActiveExtractor_Extract(t *testing.T) {
 
 	// Verify the data was inserted into the feature_host_memory_active table
 	var usages []NodeExporterHostMemoryActive
-	_, err := testDB.Select(&usages, "SELECT * FROM "+NodeExporterHostMemoryActive{}.TableName())
+	table := NodeExporterHostMemoryActive{}.TableName()
+	_, err := testDB.Select(&usages, "SELECT * FROM "+table)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/extractor/plugins/kvm/node_exporter_host_memory_active_test.go
+++ b/internal/extractor/plugins/kvm/node_exporter_host_memory_active_test.go
@@ -47,14 +47,14 @@ func TestNodeExporterHostMemoryActiveExtractor_Extract(t *testing.T) {
 	}
 
 	// Insert mock data into the node_exporter_metrics table
-	_, err := testDB.Exec(`
-        INSERT INTO node_exporter_metrics (node, name, value)
-        VALUES
-            ('node1', 'node_exporter_memory_active_pct', 20.0),
-            ('node2', 'node_exporter_memory_active_pct', 30.0),
-            ('node1', 'node_exporter_memory_active_pct', 40.0)
-    `)
-	if err != nil {
+
+	nodeExporterMetrics := []any{
+		&prometheus.NodeExporterMetric{Node: "node1", Name: "node_exporter_cpu_usage_pct", Value: 20.0},
+		&prometheus.NodeExporterMetric{Node: "node2", Name: "node_exporter_cpu_usage_pct", Value: 30.0},
+		&prometheus.NodeExporterMetric{Node: "node1", Name: "node_exporter_cpu_usage_pct", Value: 40.0},
+	}
+
+	if err := testDB.Insert(nodeExporterMetrics...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -67,14 +67,13 @@ func TestNodeExporterHostMemoryActiveExtractor_Extract(t *testing.T) {
 	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if _, err = extractor.Extract(); err != nil {
+	if _, err := extractor.Extract(); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	// Verify the data was inserted into the feature_host_memory_active table
 	var usages []NodeExporterHostMemoryActive
-	table := NodeExporterHostMemoryActive{}.TableName()
-	_, err = testDB.Select(&usages, "SELECT * FROM "+table)
+	_, err := testDB.Select(&usages, "SELECT * FROM "+NodeExporterHostMemoryActive{}.TableName())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/extractor/plugins/sap/host_details_test.go
+++ b/internal/extractor/plugins/sap/host_details_test.go
@@ -87,14 +87,14 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 	availabilityZone1 := "az1"
 	availabilityZone2 := "az2"
 
-	host_availability_zones := []any{
+	hostAvailabilityZones := []any{
 		&shared.HostAZ{AvailabilityZone: &availabilityZone1, ComputeHost: "nova-compute-bb01"},
 		&shared.HostAZ{AvailabilityZone: nil, ComputeHost: "node001-bb02"},
 		&shared.HostAZ{AvailabilityZone: &availabilityZone2, ComputeHost: "node002-bb03"},
 		&shared.HostAZ{AvailabilityZone: &availabilityZone2, ComputeHost: "ironic-host-01"},
 	}
 
-	if err := testDB.Insert(host_availability_zones...); err != nil {
+	if err := testDB.Insert(hostAvailabilityZones...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 

--- a/internal/extractor/plugins/shared/vm_host_residency_test.go
+++ b/internal/extractor/plugins/shared/vm_host_residency_test.go
@@ -54,13 +54,11 @@ func TestVMHostResidencyExtractor_Extract(t *testing.T) {
 		t.Fatalf("failed to create dependency tables: %v", err)
 	}
 
-	// Insert mock data into the servers, migrations, and flavors tables
-	if _, err := testDB.Exec(`
-		INSERT INTO openstack_servers (id, flavor_name, created)
-		VALUES
-			('server1', 'small', '2025-01-01T00:00:00Z'),
-			('server2', 'medium', '2025-01-02T00:00:00Z')
-	`); err != nil {
+	servers := []any{
+		&nova.Server{ID: "server1", FlavorName: "small", Created: "2025-01-01T00:00:00Z"},
+		&nova.Server{ID: "server2", FlavorName: "medium", Created: "2025-01-02T00:00:00Z"},
+	}
+	if err := testDB.Insert(servers...); err != nil {
 		t.Fatalf("failed to insert servers: %v", err)
 	}
 

--- a/internal/extractor/plugins/shared/vm_life_span_test.go
+++ b/internal/extractor/plugins/shared/vm_life_span_test.go
@@ -56,13 +56,11 @@ func TestVMLifeSpanExtractor_Extract(t *testing.T) {
 		t.Fatalf("failed to create dependency tables: %v", err)
 	}
 
-	// Insert mock data into the servers and flavors tables
-	if _, err := testDB.Exec(`
-        INSERT INTO openstack_servers (id, flavor_name, created, updated, status)
-        VALUES
-            ('server1', 'small', '2025-01-01T00:00:00Z', '2025-01-03T00:00:00Z', 'DELETED'),
-            ('server2', 'medium', '2025-01-02T00:00:00Z', '2025-01-04T00:00:00Z', 'DELETED')
-    `); err != nil {
+	servers := []any{
+		&nova.Server{ID: "server1", FlavorName: "small", Created: "2025-01-01T00:00:00Z", Status: "DELETED", Updated: "2025-01-03T00:00:00Z"},
+		&nova.Server{ID: "server2", FlavorName: "medium", Created: "2025-01-02T00:00:00Z", Status: "DELETED", Updated: "2025-01-04T00:00:00Z"},
+	}
+	if err := testDB.Insert(servers...); err != nil {
 		t.Fatalf("failed to insert servers: %v", err)
 	}
 

--- a/internal/extractor/plugins/vmware/vrops_hostsystem_contention_short_term_test.go
+++ b/internal/extractor/plugins/vmware/vrops_hostsystem_contention_short_term_test.go
@@ -48,26 +48,20 @@ func TestVROpsHostsystemContentionShortTermExtractor_Extract(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the vrops_host_metrics table
-	_, err := testDB.Exec(`
-        INSERT INTO vrops_host_metrics (hostsystem, name, value)
-        VALUES
-            ('hostsystem1', 'vrops_hostsystem_cpu_contention_short_term_percentage', 30.0),
-            ('hostsystem2', 'vrops_hostsystem_cpu_contention_short_term_percentage', 40.0),
-            ('hostsystem1', 'vrops_hostsystem_cpu_contention_short_term_percentage', 50.0)
-    `)
-	if err != nil {
+	vropsHostMetrics := []any{
+		&prometheus.VROpsHostMetric{HostSystem: "hostsystem1", Name: "vrops_hostsystem_cpu_contention_short_term_percentage", Value: 30.0},
+		&prometheus.VROpsHostMetric{HostSystem: "hostsystem2", Name: "vrops_hostsystem_cpu_contention_short_term_percentage", Value: 40.0},
+		&prometheus.VROpsHostMetric{HostSystem: "hostsystem1", Name: "vrops_hostsystem_cpu_contention_short_term_percentage", Value: 50.0},
+	}
+	if err := testDB.Insert(vropsHostMetrics...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the feature_vrops_resolved_hostsystem table
-	_, err = testDB.Exec(`
-        INSERT INTO feature_vrops_resolved_hostsystem (vrops_hostsystem, nova_compute_host)
-        VALUES
-            ('hostsystem1', 'compute_host1'),
-            ('hostsystem2', 'compute_host2')
-    `)
-	if err != nil {
+	vropsResolvedHostsystems := []any{
+		&ResolvedVROpsHostsystem{VROpsHostsystem: "hostsystem1", NovaComputeHost: "compute_host1"},
+		&ResolvedVROpsHostsystem{VROpsHostsystem: "hostsystem2", NovaComputeHost: "compute_host2"},
+	}
+	if err := testDB.Insert(vropsResolvedHostsystems...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -80,14 +74,14 @@ func TestVROpsHostsystemContentionShortTermExtractor_Extract(t *testing.T) {
 	if err := extractor.Init(testDB, config); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if _, err = extractor.Extract(); err != nil {
+	if _, err := extractor.Extract(); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	// Verify the data was inserted into the feature_vrops_hostsystem_contention table
 	var contentions []VROpsHostsystemContentionShortTerm
 	table := VROpsHostsystemContentionShortTerm{}.TableName()
-	_, err = testDB.Select(&contentions, "SELECT * FROM "+table)
+	_, err := testDB.Select(&contentions, "SELECT * FROM "+table)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/extractor/plugins/vmware/vrops_hostsystem_resolver_test.go
+++ b/internal/extractor/plugins/vmware/vrops_hostsystem_resolver_test.go
@@ -50,25 +50,19 @@ func TestVROpsHostsystemResolver_Extract(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the metrics table
-	_, err := testDB.Exec(`
-        INSERT INTO vrops_vm_metrics (hostsystem, instance_uuid)
-        VALUES
-            ('hostsystem1', 'uuid1'),
-            ('hostsystem2', 'uuid2')
-    `)
-	if err != nil {
+	vropsVMMetrics := []any{
+		&prometheus.VROpsVMMetric{HostSystem: "hostsystem1", InstanceUUID: "uuid1"},
+		&prometheus.VROpsVMMetric{HostSystem: "hostsystem2", InstanceUUID: "uuid2"},
+	}
+	if err := testDB.Insert(vropsVMMetrics...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the openstack_servers table
-	_, err = testDB.Exec(`
-        INSERT INTO openstack_servers (id, os_ext_srv_attr_host)
-        VALUES
-            ('uuid1', 'service_host1'),
-            ('uuid2', 'service_host2')
-    `)
-	if err != nil {
+	servers := []any{
+		&nova.Server{ID: "uuid1", OSEXTSRVATTRHost: "service_host1"},
+		&nova.Server{ID: "uuid2", OSEXTSRVATTRHost: "service_host2"},
+	}
+	if err := testDB.Insert(servers...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -88,7 +82,7 @@ func TestVROpsHostsystemResolver_Extract(t *testing.T) {
 	// Verify the data was inserted into the feature_vrops_resolved_hostsystem table
 	var resolvedHostsystems []ResolvedVROpsHostsystem
 	table := ResolvedVROpsHostsystem{}.TableName()
-	_, err = testDB.Select(&resolvedHostsystems, "SELECT * FROM "+table)
+	_, err := testDB.Select(&resolvedHostsystems, "SELECT * FROM "+table)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/extractor/plugins/vmware/vrops_project_noisiness_test.go
+++ b/internal/extractor/plugins/vmware/vrops_project_noisiness_test.go
@@ -53,42 +53,36 @@ func TestVROpsProjectNoisinessExtractor_Extract(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the metrics table
-	if _, err := testDB.Exec(`
-	INSERT INTO vrops_vm_metrics (name, project, value, instance_uuid)
-	VALUES
-		('vrops_virtualmachine_cpu_demand_ratio', 'project1', 50, 'uuid1'),
-		('vrops_virtualmachine_cpu_demand_ratio', 'project1', 60, 'uuid2'),
-		('vrops_virtualmachine_cpu_demand_ratio', 'project2', 70, 'uuid3')
-	`); err != nil {
+	vropsVMMetrics := []any{
+		&prometheus.VROpsVMMetric{Name: "vrops_virtualmachine_cpu_demand_ratio", Project: "project1", Value: 50, InstanceUUID: "uuid1"},
+		&prometheus.VROpsVMMetric{Name: "vrops_virtualmachine_cpu_demand_ratio", Project: "project1", Value: 60, InstanceUUID: "uuid2"},
+		&prometheus.VROpsVMMetric{Name: "vrops_virtualmachine_cpu_demand_ratio", Project: "project2", Value: 70, InstanceUUID: "uuid3"},
+	}
+	if err := testDB.Insert(vropsVMMetrics...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the openstack_servers table
-	if _, err := testDB.Exec(`
-	INSERT INTO openstack_servers (id, tenant_id, os_ext_srv_attr_hypervisor_hostname)
-	VALUES
-		('uuid1', 'project1', 'host1'),
-		('uuid2', 'project1', 'host2'),
-		('uuid3', 'project2', 'host1')
-	`); err != nil {
+	servers := []any{
+		&nova.Server{ID: "uuid1", TenantID: "project1", OSEXTSRVATTRHypervisorHostname: "host1"},
+		&nova.Server{ID: "uuid2", TenantID: "project1", OSEXTSRVATTRHypervisorHostname: "host2"},
+		&nova.Server{ID: "uuid3", TenantID: "project2", OSEXTSRVATTRHypervisorHostname: "host1"},
+	}
+	if err := testDB.Insert(servers...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the openstack_hypervisors table
-	if _, err := testDB.Exec(`
-	INSERT INTO openstack_hypervisors (id, hostname, service_host)
-	VALUES
-		(1, 'host1', 'service_host1'),
-		(2, 'host2', 'service_host2')
-	`); err != nil {
+	hypervisors := []any{
+		&nova.Hypervisor{ID: "1", Hostname: "host1", ServiceHost: "service_host1"},
+		&nova.Hypervisor{ID: "2", Hostname: "host2", ServiceHost: "service_host2"},
+	}
+	if err := testDB.Insert(hypervisors...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	extractor := &VROpsProjectNoisinessExtractor{}
 
 	config := conf.FeatureExtractorConfig{
-		Name:           "vrops_project_noisines_extractor",
+		Name:           "vrops_project_noisiness_extractor",
 		Options:        conf.NewRawOpts("{}"),
 		RecencySeconds: nil,
 	}

--- a/internal/kpis/plugins/netapp/storage_pool_cpu_test.go
+++ b/internal/kpis/plugins/netapp/storage_pool_cpu_test.go
@@ -38,9 +38,11 @@ func TestNetAppStoragePoolCPUUsageKPI_Collect(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the storage pool cpu usage table
-	_, err := testDB.Exec(`INSERT INTO feature_storage_pool_cpu_usage (storage_pool_name, max_cpu_usage_pct, avg_cpu_usage_pct) VALUES ('pool1', 80.5, 60.0), ('pool2', 90.0, 70.0)`)
-	if err != nil {
+	storagePoolCPUUsage := []any{
+		&netapp.StoragePoolCPUUsage{StoragePoolName: "pool1", MaxCPUUsagePct: 80.5, AvgCPUUsagePct: 60.0},
+		&netapp.StoragePoolCPUUsage{StoragePoolName: "pool2", MaxCPUUsagePct: 90.0, AvgCPUUsagePct: 70.0},
+	}
+	if err := testDB.Insert(storagePoolCPUUsage...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 

--- a/internal/kpis/plugins/shared/vm_life_span_test.go
+++ b/internal/kpis/plugins/shared/vm_life_span_test.go
@@ -38,17 +38,12 @@ func TestVMLifeSpanKPI_Collect(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the table
-	_, err := testDB.Exec(`
-        INSERT INTO feature_vm_life_span_histogram_bucket (
-            flavor_name, bucket, value, count, sum
-        )
-        VALUES
-		    ('small', 60, 100, 10, 600),
-		    ('medium', 120, 200, 20, 2400),
-		    ('large', 180, 300, 30, 5400)
-    `)
-	if err != nil {
+	vmLifeSpan := []any{
+		&shared.VMLifeSpanHistogramBucket{FlavorName: "small", Bucket: 60, Value: 100, Count: 10, Sum: 600},
+		&shared.VMLifeSpanHistogramBucket{FlavorName: "medium", Bucket: 120, Value: 200, Count: 20, Sum: 2400},
+		&shared.VMLifeSpanHistogramBucket{FlavorName: "large", Bucket: 180, Value: 300, Count: 30, Sum: 5400},
+	}
+	if err := testDB.Insert(vmLifeSpan...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 

--- a/internal/kpis/plugins/shared/vm_migration_statistics_test.go
+++ b/internal/kpis/plugins/shared/vm_migration_statistics_test.go
@@ -37,15 +37,12 @@ func TestVMMigrationStatisticsKPI_Collect(t *testing.T) {
 	); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	_, err := testDB.Exec(`
-        INSERT INTO feature_vm_host_residency (
-            duration, flavor_name, instance_uuid, migration_uuid, source_host, target_host, source_node, target_node, user_id, project_id, type, time
-        )
-        VALUES
-            (120, 'small', 'uuid1', 'migration1', 'host1', 'host2', 'node1', 'node2', 'user1', 'project1', 'live-migration', 1620000000),
-            (300, 'medium', 'uuid2', 'migration2', 'host3', 'host4', 'node3', 'node4', 'user2', 'project2', 'resize', 1620000300)
-    `)
-	if err != nil {
+
+	vmHostResidency := []any{
+		&shared.VMHostResidency{Duration: 120, FlavorName: "small", InstanceUUID: "uuid1", MigrationUUID: "migration1", SourceHost: "host1", TargetHost: "host2", SourceNode: "node1", TargetNode: "node2", UserID: "user1", ProjectID: "project1", Type: "live-migration", Time: 1620000000},
+		&shared.VMHostResidency{Duration: 300, FlavorName: "medium", InstanceUUID: "uuid2", MigrationUUID: "migration2", SourceHost: "host3", TargetHost: "host4", SourceNode: "node3", TargetNode: "node4", UserID: "user2", ProjectID: "project2", Type: "resize", Time: 1620000300},
+	}
+	if err := testDB.Insert(vmHostResidency...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 

--- a/internal/kpis/plugins/vmware/host_contention_test.go
+++ b/internal/kpis/plugins/vmware/host_contention_test.go
@@ -38,16 +38,11 @@ func TestVMwareHostContentionKPI_Collect(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the feature_vrops_hostsystem_contention table
-	_, err := testDB.Exec(`
-        INSERT INTO feature_vrops_hostsystem_contention_long_term (
-            compute_host, avg_cpu_contention, max_cpu_contention
-        )
-        VALUES
-            ('host1', 10.5, 20.0),
-            ('host2', 15.0, 25.0)
-    `)
-	if err != nil {
+	vropsHostsystemContentionLongTerm := []any{
+		&vmware.VROpsHostsystemContentionLongTerm{ComputeHost: "host1", AvgCPUContention: 10.5, MaxCPUContention: 20.0},
+		&vmware.VROpsHostsystemContentionLongTerm{ComputeHost: "host2", AvgCPUContention: 15.0, MaxCPUContention: 25.0},
+	}
+	if err := testDB.Insert(vropsHostsystemContentionLongTerm...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 

--- a/internal/kpis/plugins/vmware/project_noisiness_test.go
+++ b/internal/kpis/plugins/vmware/project_noisiness_test.go
@@ -38,16 +38,11 @@ func TestVMwareProjectNoisinessKPI_Collect(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the feature_vrops_project_noisiness table
-	_, err := testDB.Exec(`
-        INSERT INTO feature_vrops_project_noisiness (
-            project, compute_host, avg_cpu_of_project
-        )
-        VALUES
-            ('project1', 'host1', 10.5),
-            ('project2', 'host2', 15.0)
-    `)
-	if err != nil {
+	vropsProjectNoisiness := []any{
+		&vmware.VROpsProjectNoisiness{Project: "project1", ComputeHost: "host1", AvgCPUOfProject: 10.5},
+		&vmware.VROpsProjectNoisiness{Project: "project2", ComputeHost: "host2", AvgCPUOfProject: 15.0},
+	}
+	if err := testDB.Insert(vropsProjectNoisiness...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 

--- a/internal/scheduler/manila/plugins/netapp/cpu_usage_balancing_test.go
+++ b/internal/scheduler/manila/plugins/netapp/cpu_usage_balancing_test.go
@@ -26,16 +26,14 @@ func TestCPUUsageBalancingStep_Run(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the feature_storage_pool_cpu_usage table
-	_, err = testDB.Exec(`
-        INSERT INTO feature_storage_pool_cpu_usage (storage_pool_name, avg_cpu_usage_pct, max_cpu_usage_pct)
-        VALUES
-            ('pool1', 0.0, 0.0),
-            ('pool2', 100.0, 0.0),
-            ('pool3', 0.0, 100.0),
-            ('pool4', 100.0, 100.0)
-    `)
-	if err != nil {
+	storagePoolCPUUsage := []any{
+		&netapp.StoragePoolCPUUsage{StoragePoolName: "pool1", AvgCPUUsagePct: 0.0, MaxCPUUsagePct: 0.0},
+		&netapp.StoragePoolCPUUsage{StoragePoolName: "pool2", AvgCPUUsagePct: 100.0, MaxCPUUsagePct: 0.0},
+		&netapp.StoragePoolCPUUsage{StoragePoolName: "pool3", AvgCPUUsagePct: 0.0, MaxCPUUsagePct: 100.0},
+		&netapp.StoragePoolCPUUsage{StoragePoolName: "pool4", AvgCPUUsagePct: 100.0, MaxCPUUsagePct: 100.0},
+	}
+
+	if err := testDB.Insert(storagePoolCPUUsage...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 

--- a/internal/scheduler/nova/plugins/kvm/avoid_overloaded_hosts_cpu_test.go
+++ b/internal/scheduler/nova/plugins/kvm/avoid_overloaded_hosts_cpu_test.go
@@ -26,14 +26,15 @@ func TestAvoidOverloadedHostsCPUStep_Run(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the feature_host_cpu_usage table
-	_, err = testDB.Exec(`
-        INSERT INTO feature_host_cpu_usage (compute_host, avg_cpu_usage, max_cpu_usage)
-        VALUES
-            ('host1', 15.0, 25.0),
-            ('host2', 5.0, 10.0),
-            ('host3', 20.0, 30.0)
-    `)
+	hostCPUUsage := []any{
+		&kvm.NodeExporterHostCPUUsage{ComputeHost: "host1", AvgCPUUsage: 15.0, MaxCPUUsage: 25.0},
+		&kvm.NodeExporterHostCPUUsage{ComputeHost: "host2", AvgCPUUsage: 5.0, MaxCPUUsage: 10.0},
+		&kvm.NodeExporterHostCPUUsage{ComputeHost: "host3", AvgCPUUsage: 20.0, MaxCPUUsage: 30.0},
+	}
+	if err := testDB.Insert(hostCPUUsage...); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/scheduler/nova/plugins/kvm/avoid_overloaded_hosts_memory_test.go
+++ b/internal/scheduler/nova/plugins/kvm/avoid_overloaded_hosts_memory_test.go
@@ -26,16 +26,12 @@ func TestAvoidOverloadedHostsMemoryStep_Run(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the feature_host_memory_active table
-	_, err = testDB.Exec(`
-        INSERT INTO feature_host_memory_active
-			(compute_host, avg_memory_active, max_memory_active)
-        VALUES
-            ('host1', 15.0, 25.0),
-            ('host2', 5.0, 10.0),
-            ('host3', 20.0, 30.0)
-    `)
-	if err != nil {
+	hostMemoryActive := []any{
+		&kvm.NodeExporterHostMemoryActive{ComputeHost: "host1", AvgMemoryActive: 15.0, MaxMemoryActive: 25.0},
+		&kvm.NodeExporterHostMemoryActive{ComputeHost: "host2", AvgMemoryActive: 5.0, MaxMemoryActive: 10.0},
+		&kvm.NodeExporterHostMemoryActive{ComputeHost: "host3", AvgMemoryActive: 20.0, MaxMemoryActive: 30.0},
+	}
+	if err := testDB.Insert(hostMemoryActive...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 

--- a/internal/scheduler/nova/plugins/vmware/anti_affinity_noisy_projects_test.go
+++ b/internal/scheduler/nova/plugins/vmware/anti_affinity_noisy_projects_test.go
@@ -26,17 +26,15 @@ func TestAntiAffinityNoisyProjectsStep_Run(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the feature_vrops_project_noisiness table
-	_, err = testDB.Exec(`
-        INSERT INTO feature_vrops_project_noisiness (project, compute_host, avg_cpu_of_project)
-        VALUES
-            ('project1', 'host1', 25.0),
-            ('project1', 'host2', 30.0),
-            ('project2', 'host3', 15.0)
-    `)
-	if err != nil {
+	vropsProjectNoisiness := []any{
+		&vmware.VROpsProjectNoisiness{Project: "project1", ComputeHost: "host1", AvgCPUOfProject: 25.0},
+		&vmware.VROpsProjectNoisiness{Project: "project1", ComputeHost: "host2", AvgCPUOfProject: 30.0},
+		&vmware.VROpsProjectNoisiness{Project: "project2", ComputeHost: "host3", AvgCPUOfProject: 15.0},
+	}
+	if err := testDB.Insert(vropsProjectNoisiness...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
+
 	opts := conf.NewRawOpts(`{
         "avgCPUUsageLowerBound": 20,
         "avgCPUUsageUpperBound": 100,

--- a/internal/scheduler/nova/plugins/vmware/avoid_long_term_contended_hosts_test.go
+++ b/internal/scheduler/nova/plugins/vmware/avoid_long_term_contended_hosts_test.go
@@ -26,16 +26,13 @@ func TestAvoidLongTermContendedHostsStep_Run(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the feature_vrops_hostsystem_contention table
-	_, err = testDB.Exec(`
-        INSERT INTO feature_vrops_hostsystem_contention_long_term (compute_host, avg_cpu_contention, max_cpu_contention)
-        VALUES
-            ('host1', 0.0, 0.0),
-            ('host2', 100.0, 0.0),
-            ('host3', 0.0, 100.0),
-			('host4', 100.0, 100.0)
-    `)
-	if err != nil {
+	vropsHostsystemContentionLongTerm := []any{
+		&vmware.VROpsHostsystemContentionLongTerm{ComputeHost: "host1", AvgCPUContention: 0.0, MaxCPUContention: 0.0},
+		&vmware.VROpsHostsystemContentionLongTerm{ComputeHost: "host2", AvgCPUContention: 100.0, MaxCPUContention: 0.0},
+		&vmware.VROpsHostsystemContentionLongTerm{ComputeHost: "host3", AvgCPUContention: 0.0, MaxCPUContention: 100.0},
+		&vmware.VROpsHostsystemContentionLongTerm{ComputeHost: "host4", AvgCPUContention: 100.0, MaxCPUContention: 100.0},
+	}
+	if err := testDB.Insert(vropsHostsystemContentionLongTerm...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 

--- a/internal/scheduler/nova/plugins/vmware/avoid_short_term_contended_hosts_test.go
+++ b/internal/scheduler/nova/plugins/vmware/avoid_short_term_contended_hosts_test.go
@@ -26,16 +26,13 @@ func TestAvoidShortTermContendedHostsStep_Run(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Insert mock data into the feature_vrops_hostsystem_contention table
-	_, err = testDB.Exec(`
-        INSERT INTO feature_vrops_hostsystem_contention_short_term (compute_host, avg_cpu_contention, max_cpu_contention)
-        VALUES
-            ('host1', 0.0, 0.0),
-            ('host2', 100.0, 0.0),
-            ('host3', 0.0, 100.0),
-			('host4', 100.0, 100.0)
-    `)
-	if err != nil {
+	vropsHostsystemContentionShortTerm := []any{
+		&vmware.VROpsHostsystemContentionShortTerm{ComputeHost: "host1", AvgCPUContention: 0.0, MaxCPUContention: 0.0},
+		&vmware.VROpsHostsystemContentionShortTerm{ComputeHost: "host2", AvgCPUContention: 100.0, MaxCPUContention: 0.0},
+		&vmware.VROpsHostsystemContentionShortTerm{ComputeHost: "host3", AvgCPUContention: 0.0, MaxCPUContention: 100.0},
+		&vmware.VROpsHostsystemContentionShortTerm{ComputeHost: "host4", AvgCPUContention: 100.0, MaxCPUContention: 100.0},
+	}
+	if err := testDB.Insert(vropsHostsystemContentionShortTerm...); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 


### PR DESCRIPTION
This PR replaces all occurrences of plain table names in test cases with proper `Insert()` calls or `TableName()` method calls in SQL query strings. This ensures better maintainability and consistency across the codebase. This will help catch cases where SQL queries use outdated table names when table structures are modified

> [!NOTE]
> The Manila storage pool CPU usage test was fixed in PR #240 to avoid merge conflicts.