### PR TITLE
Feature extractor for pinned projects

### DIFF
--- a/helm/bundles/cortex-nova/values.yaml
+++ b/helm/bundles/cortex-nova/values.yaml
@@ -219,6 +219,7 @@ cortex-core:
                 nova:
                   types:
                     - aggregates
+                    - hypervisors
         - name: host_domain_project_extractor
           recencySeconds: 60 # 1 minute
           dependencies:

--- a/helm/bundles/cortex-nova/values.yaml
+++ b/helm/bundles/cortex-nova/values.yaml
@@ -211,6 +211,14 @@ cortex-core:
                   - alias: node_exporter_memory_active_pct
 
         # Shared extractors.
+        - name: host_pinned_projects_extractor
+          recencySeconds: 300
+          dependencies:
+            sync:
+              openstack:
+                nova:
+                  types:
+                    - aggregates
         - name: host_domain_project_extractor
           recencySeconds: 60 # 1 minute
           dependencies:

--- a/internal/extractor/pipeline.go
+++ b/internal/extractor/pipeline.go
@@ -40,6 +40,7 @@ var SupportedExtractors = []plugins.FeatureExtractor{
 	&shared.VMLifeSpanHistogramExtractor{},
 	&shared.HostDomainProjectExtractor{},
 	&shared.HostAZExtractor{},
+	&shared.HostPinnedProjectsExtractor{},
 	// SAP-specific extractors
 	&sap.HostDetailsExtractor{},
 }

--- a/internal/extractor/plugins/shared/host_pinned_project_test.go
+++ b/internal/extractor/plugins/shared/host_pinned_project_test.go
@@ -1,0 +1,4 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package shared

--- a/internal/extractor/plugins/shared/host_pinned_project_test.go
+++ b/internal/extractor/plugins/shared/host_pinned_project_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/conf"
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/nova"
+	"github.com/cobaltcore-dev/cortex/testlib"
 	testlibDB "github.com/cobaltcore-dev/cortex/testlib/db"
 )
 
@@ -49,20 +50,17 @@ func TestHostPinnedProjectsExtractor_Extract_FindComputeHostProjectMapping(t *te
 		t.Fatalf("failed to create table: %v", err)
 	}
 
-	computeHost1 := "host-1"
-	computeHost2 := "host-2"
-
 	aggregates := []any{
 		&nova.Aggregate{
 			Name:        "agg1",
 			UUID:        "agg1",
-			ComputeHost: &computeHost1,
+			ComputeHost: testlib.Ptr("host1"),
 			Metadata:    "{\"filter_tenant_id\":\"project_id_1, project_id_2\"}",
 		},
 		&nova.Aggregate{
 			Name:        "agg1",
 			UUID:        "agg1",
-			ComputeHost: &computeHost2,
+			ComputeHost: testlib.Ptr("host2"),
 			Metadata:    "{\"filter_tenant_id\":\"project_id_1, project_id_2\"}",
 		},
 	}
@@ -96,25 +94,25 @@ func TestHostPinnedProjectsExtractor_Extract_FindComputeHostProjectMapping(t *te
 		{
 			AggregateName: "agg1",
 			AggregateUUID: "agg1",
-			ComputeHost:   &computeHost1,
+			ComputeHost:   testlib.Ptr("host1"),
 			ProjectID:     "project_id_1",
 		},
 		{
 			AggregateName: "agg1",
 			AggregateUUID: "agg1",
-			ComputeHost:   &computeHost1,
+			ComputeHost:   testlib.Ptr("host1"),
 			ProjectID:     "project_id_2",
 		},
 		{
 			AggregateName: "agg1",
 			AggregateUUID: "agg1",
-			ComputeHost:   &computeHost2,
+			ComputeHost:   testlib.Ptr("host2"),
 			ProjectID:     "project_id_1",
 		},
 		{
 			AggregateName: "agg1",
 			AggregateUUID: "agg1",
-			ComputeHost:   &computeHost2,
+			ComputeHost:   testlib.Ptr("host2"),
 			ProjectID:     "project_id_2",
 		},
 	}
@@ -144,13 +142,11 @@ func TestHostPinnedProjectsExtractor_Extract_SkipAggregatesWithNoFilterTenant(t 
 		t.Fatalf("failed to create table: %v", err)
 	}
 
-	computeHost1 := "host-1"
-
 	aggregates := []any{
 		&nova.Aggregate{
 			Name:        "ignore-no-filter-tenant",
 			UUID:        "ignore",
-			ComputeHost: &computeHost1,
+			ComputeHost: testlib.Ptr("host1"),
 			Metadata:    "{\"something_different\":\"project_id_1, project_id_2\"}",
 		},
 	}
@@ -199,8 +195,6 @@ func TestHostPinnedProjectsExtractor_Extract_SupportEmptyComputeHost(t *testing.
 		t.Fatalf("failed to create table: %v", err)
 	}
 
-	computeHost1 := "host-1"
-
 	aggregates := []any{
 		// This aggregate doesn't have a compute host so project_3 and 4 should have an empty entry for the compute host
 		&nova.Aggregate{
@@ -213,7 +207,7 @@ func TestHostPinnedProjectsExtractor_Extract_SupportEmptyComputeHost(t *testing.
 		&nova.Aggregate{
 			Name:        "agg3",
 			UUID:        "agg3",
-			ComputeHost: &computeHost1,
+			ComputeHost: testlib.Ptr("host1"),
 			Metadata:    "{\"filter_tenant_id\":\"project_id_3, project_id_4\"}",
 		},
 	}
@@ -259,13 +253,13 @@ func TestHostPinnedProjectsExtractor_Extract_SupportEmptyComputeHost(t *testing.
 		{
 			AggregateName: "agg3",
 			AggregateUUID: "agg3",
-			ComputeHost:   &computeHost1,
+			ComputeHost:   testlib.Ptr("host1"),
 			ProjectID:     "project_id_3",
 		},
 		{
 			AggregateName: "agg3",
 			AggregateUUID: "agg3",
-			ComputeHost:   &computeHost1,
+			ComputeHost:   testlib.Ptr("host1"),
 			ProjectID:     "project_id_4",
 		},
 	}

--- a/internal/extractor/plugins/shared/host_pinned_project_test.go
+++ b/internal/extractor/plugins/shared/host_pinned_project_test.go
@@ -2,3 +2,341 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package shared
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/cobaltcore-dev/cortex/internal/conf"
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/nova"
+	testlibDB "github.com/cobaltcore-dev/cortex/testlib/db"
+)
+
+func TestHostPinnedProjectsExtractor_Init(t *testing.T) {
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	extractor := &HostPinnedProjectsExtractor{}
+	config := conf.FeatureExtractorConfig{
+		Name:           "host_pinned_projects_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+	if err := extractor.Init(testDB, config); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !testDB.TableExists(HostPinnedProjects{}) {
+		t.Error("expected table to be created")
+	}
+}
+
+func TestHostPinnedProjectsExtractor_Extract_FindComputeHostProjectMapping(t *testing.T) {
+	if os.Getenv("POSTGRES_CONTAINER") != "1" {
+		t.Skip("skipping test; set POSTGRES_CONTAINER=1 to run")
+	}
+
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	if err := testDB.CreateTable(testDB.AddTable(nova.Aggregate{})); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	computeHost1 := "host-1"
+	computeHost2 := "host-2"
+
+	aggregates := []any{
+		&nova.Aggregate{
+			Name:        "agg1",
+			UUID:        "agg1",
+			ComputeHost: &computeHost1,
+			Metadata:    "{\"filter_tenant_id\":\"project_id_1, project_id_2\"}",
+		},
+		&nova.Aggregate{
+			Name:        "agg1",
+			UUID:        "agg1",
+			ComputeHost: &computeHost2,
+			Metadata:    "{\"filter_tenant_id\":\"project_id_1, project_id_2\"}",
+		},
+	}
+
+	if err := testDB.Insert(aggregates...); err != nil {
+		t.Fatalf("failed to insert aggregates: %v", err)
+	}
+
+	extractor := &HostPinnedProjectsExtractor{}
+	config := conf.FeatureExtractorConfig{
+		Name:           "host_pinned_projects_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+
+	if err := extractor.Init(testDB, config); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if _, err := extractor.Extract(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var results []HostPinnedProjects
+	table := HostPinnedProjects{}.TableName()
+	if _, err := testDB.Select(&results, "SELECT * FROM "+table); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	expectedFeatures := []HostPinnedProjects{
+		{
+			AggregateName: "agg1",
+			AggregateUUID: "agg1",
+			ComputeHost:   &computeHost1,
+			ProjectID:     "project_id_1",
+		},
+		{
+			AggregateName: "agg1",
+			AggregateUUID: "agg1",
+			ComputeHost:   &computeHost1,
+			ProjectID:     "project_id_2",
+		},
+		{
+			AggregateName: "agg1",
+			AggregateUUID: "agg1",
+			ComputeHost:   &computeHost2,
+			ProjectID:     "project_id_1",
+		},
+		{
+			AggregateName: "agg1",
+			AggregateUUID: "agg1",
+			ComputeHost:   &computeHost2,
+			ProjectID:     "project_id_2",
+		},
+	}
+
+	if len(results) != len(expectedFeatures) {
+		t.Errorf("expected %d results, got %d", len(expectedFeatures), len(results))
+	}
+
+	for i := range results {
+		if !reflect.DeepEqual(results[i], expectedFeatures[i]) {
+			t.Errorf("expected %v, got %v", expectedFeatures[i], results[i])
+		}
+	}
+}
+
+func TestHostPinnedProjectsExtractor_Extract_SkipAggregatesWithNoFilterTenant(t *testing.T) {
+	if os.Getenv("POSTGRES_CONTAINER") != "1" {
+		t.Skip("skipping test; set POSTGRES_CONTAINER=1 to run")
+	}
+
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	if err := testDB.CreateTable(testDB.AddTable(nova.Aggregate{})); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	computeHost1 := "host-1"
+
+	aggregates := []any{
+		&nova.Aggregate{
+			Name:        "ignore-no-filter-tenant",
+			UUID:        "ignore",
+			ComputeHost: &computeHost1,
+			Metadata:    "{\"something_different\":\"project_id_1, project_id_2\"}",
+		},
+	}
+
+	if err := testDB.Insert(aggregates...); err != nil {
+		t.Fatalf("failed to insert aggregates: %v", err)
+	}
+
+	extractor := &HostPinnedProjectsExtractor{}
+	config := conf.FeatureExtractorConfig{
+		Name:           "host_pinned_projects_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+
+	if err := extractor.Init(testDB, config); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if _, err := extractor.Extract(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var results []HostPinnedProjects
+	table := HostPinnedProjects{}.TableName()
+	if _, err := testDB.Select(&results, "SELECT * FROM "+table); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(results) > 0 {
+		t.Errorf("expected no results, got %d", len(results))
+	}
+}
+
+func TestHostPinnedProjectsExtractor_Extract_SupportEmptyComputeHost(t *testing.T) {
+	if os.Getenv("POSTGRES_CONTAINER") != "1" {
+		t.Skip("skipping test; set POSTGRES_CONTAINER=1 to run")
+	}
+
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	if err := testDB.CreateTable(testDB.AddTable(nova.Aggregate{})); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	computeHost1 := "host-1"
+
+	aggregates := []any{
+		// This aggregate doesn't have a compute host so project_3 and 4 should have an empty entry for the compute host
+		&nova.Aggregate{
+			Name:        "agg2",
+			UUID:        "agg2",
+			ComputeHost: nil,
+			Metadata:    "{\"filter_tenant_id\":\"project_id_3, project_id_4\"}",
+		},
+		// Because of this aggregate project 3 and 4 should additionally have a host-4 as pinned
+		&nova.Aggregate{
+			Name:        "agg3",
+			UUID:        "agg3",
+			ComputeHost: &computeHost1,
+			Metadata:    "{\"filter_tenant_id\":\"project_id_3, project_id_4\"}",
+		},
+	}
+
+	if err := testDB.Insert(aggregates...); err != nil {
+		t.Fatalf("failed to insert aggregates: %v", err)
+	}
+
+	extractor := &HostPinnedProjectsExtractor{}
+	config := conf.FeatureExtractorConfig{
+		Name:           "host_pinned_projects_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+
+	if err := extractor.Init(testDB, config); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if _, err := extractor.Extract(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var results []HostPinnedProjects
+	table := HostPinnedProjects{}.TableName()
+	if _, err := testDB.Select(&results, "SELECT * FROM "+table); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	expectedFeatures := []HostPinnedProjects{
+		{
+			AggregateName: "agg2",
+			AggregateUUID: "agg2",
+			ComputeHost:   nil,
+			ProjectID:     "project_id_3",
+		},
+		{
+			AggregateName: "agg2",
+			AggregateUUID: "agg2",
+			ComputeHost:   nil,
+			ProjectID:     "project_id_4",
+		},
+		{
+			AggregateName: "agg3",
+			AggregateUUID: "agg3",
+			ComputeHost:   &computeHost1,
+			ProjectID:     "project_id_3",
+		},
+		{
+			AggregateName: "agg3",
+			AggregateUUID: "agg3",
+			ComputeHost:   &computeHost1,
+			ProjectID:     "project_id_4",
+		},
+	}
+
+	if len(results) != len(expectedFeatures) {
+		t.Errorf("expected %d results, got %d", len(expectedFeatures), len(results))
+	}
+
+	for i := range results {
+		if !reflect.DeepEqual(results[i], expectedFeatures[i]) {
+			t.Errorf("expected %v, got %v", expectedFeatures[i], results[i])
+		}
+	}
+}
+
+func TestHostPinnedProjectsExtractor_Extract_FilterOutEmptyFilterTenantLists(t *testing.T) {
+	if os.Getenv("POSTGRES_CONTAINER") != "1" {
+		t.Skip("skipping test; set POSTGRES_CONTAINER=1 to run")
+	}
+
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	if err := testDB.CreateTable(testDB.AddTable(nova.Aggregate{})); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	aggregates := []any{
+		// Doesn't have any filter_tenant_id set, so this aggregate is supposed to be ignored
+		&nova.Aggregate{
+			Name:        "agg1",
+			UUID:        "agg1",
+			ComputeHost: nil,
+			Metadata:    "{\"filter_tenant_id\":\"\"}",
+		},
+		&nova.Aggregate{
+			Name:        "agg2",
+			UUID:        "agg2",
+			ComputeHost: nil,
+			Metadata:    "{\"filter_tenant_id\":\"[]\"}",
+		},
+	}
+
+	if err := testDB.Insert(aggregates...); err != nil {
+		t.Fatalf("failed to insert aggregates: %v", err)
+	}
+
+	extractor := &HostPinnedProjectsExtractor{}
+	config := conf.FeatureExtractorConfig{
+		Name:           "host_pinned_projects_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+
+	if err := extractor.Init(testDB, config); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if _, err := extractor.Extract(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var results []HostPinnedProjects
+	table := HostPinnedProjects{}.TableName()
+	if _, err := testDB.Select(&results, "SELECT * FROM "+table); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(results) > 0 {
+		t.Errorf("expected no results, got %d", len(results))
+	}
+}

--- a/internal/extractor/plugins/shared/host_pinned_project_test.go
+++ b/internal/extractor/plugins/shared/host_pinned_project_test.go
@@ -46,7 +46,10 @@ func TestHostPinnedProjectsExtractor_Extract_FindComputeHostProjectMapping(t *te
 	defer testDB.Close()
 	defer dbEnv.Close()
 
-	if err := testDB.CreateTable(testDB.AddTable(nova.Aggregate{})); err != nil {
+	if err := testDB.CreateTable(
+		testDB.AddTable(nova.Aggregate{}),
+		testDB.AddTable(nova.Hypervisor{}),
+	); err != nil {
 		t.Fatalf("failed to create table: %v", err)
 	}
 
@@ -55,13 +58,13 @@ func TestHostPinnedProjectsExtractor_Extract_FindComputeHostProjectMapping(t *te
 			Name:        "agg1",
 			UUID:        "agg1",
 			ComputeHost: testlib.Ptr("host1"),
-			Metadata:    "{\"filter_tenant_id\":\"project_id_1, project_id_2\"}",
+			Metadata:    `{"filter_tenant_id":"project_id_1, project_id_2"}`,
 		},
 		&nova.Aggregate{
 			Name:        "agg1",
 			UUID:        "agg1",
 			ComputeHost: testlib.Ptr("host2"),
-			Metadata:    "{\"filter_tenant_id\":\"project_id_1, project_id_2\"}",
+			Metadata:    `{"filter_tenant_id":"project_id_1, project_id_2"}`,
 		},
 	}
 
@@ -92,28 +95,28 @@ func TestHostPinnedProjectsExtractor_Extract_FindComputeHostProjectMapping(t *te
 
 	expectedFeatures := []HostPinnedProjects{
 		{
-			AggregateName: "agg1",
-			AggregateUUID: "agg1",
+			AggregateName: testlib.Ptr("agg1"),
+			AggregateUUID: testlib.Ptr("agg1"),
 			ComputeHost:   testlib.Ptr("host1"),
-			ProjectID:     "project_id_1",
+			ProjectID:     testlib.Ptr("project_id_1"),
 		},
 		{
-			AggregateName: "agg1",
-			AggregateUUID: "agg1",
+			AggregateName: testlib.Ptr("agg1"),
+			AggregateUUID: testlib.Ptr("agg1"),
 			ComputeHost:   testlib.Ptr("host1"),
-			ProjectID:     "project_id_2",
+			ProjectID:     testlib.Ptr("project_id_2"),
 		},
 		{
-			AggregateName: "agg1",
-			AggregateUUID: "agg1",
+			AggregateName: testlib.Ptr("agg1"),
+			AggregateUUID: testlib.Ptr("agg1"),
 			ComputeHost:   testlib.Ptr("host2"),
-			ProjectID:     "project_id_1",
+			ProjectID:     testlib.Ptr("project_id_1"),
 		},
 		{
-			AggregateName: "agg1",
-			AggregateUUID: "agg1",
+			AggregateName: testlib.Ptr("agg1"),
+			AggregateUUID: testlib.Ptr("agg1"),
 			ComputeHost:   testlib.Ptr("host2"),
-			ProjectID:     "project_id_2",
+			ProjectID:     testlib.Ptr("project_id_2"),
 		},
 	}
 
@@ -138,7 +141,10 @@ func TestHostPinnedProjectsExtractor_Extract_SkipAggregatesWithNoFilterTenant(t 
 	defer testDB.Close()
 	defer dbEnv.Close()
 
-	if err := testDB.CreateTable(testDB.AddTable(nova.Aggregate{})); err != nil {
+	if err := testDB.CreateTable(
+		testDB.AddTable(nova.Aggregate{}),
+		testDB.AddTable(nova.Hypervisor{}),
+	); err != nil {
 		t.Fatalf("failed to create table: %v", err)
 	}
 
@@ -147,7 +153,7 @@ func TestHostPinnedProjectsExtractor_Extract_SkipAggregatesWithNoFilterTenant(t 
 			Name:        "ignore-no-filter-tenant",
 			UUID:        "ignore",
 			ComputeHost: testlib.Ptr("host1"),
-			Metadata:    "{\"something_different\":\"project_id_1, project_id_2\"}",
+			Metadata:    `{"something_different":"project_id_1, project_id_2"}`,
 		},
 	}
 
@@ -191,7 +197,10 @@ func TestHostPinnedProjectsExtractor_Extract_SupportEmptyComputeHost(t *testing.
 	defer testDB.Close()
 	defer dbEnv.Close()
 
-	if err := testDB.CreateTable(testDB.AddTable(nova.Aggregate{})); err != nil {
+	if err := testDB.CreateTable(
+		testDB.AddTable(nova.Aggregate{}),
+		testDB.AddTable(nova.Hypervisor{}),
+	); err != nil {
 		t.Fatalf("failed to create table: %v", err)
 	}
 
@@ -201,14 +210,14 @@ func TestHostPinnedProjectsExtractor_Extract_SupportEmptyComputeHost(t *testing.
 			Name:        "agg2",
 			UUID:        "agg2",
 			ComputeHost: nil,
-			Metadata:    "{\"filter_tenant_id\":\"project_id_3, project_id_4\"}",
+			Metadata:    `{"filter_tenant_id":"project_id_3, project_id_4"}`,
 		},
 		// Because of this aggregate project 3 and 4 should additionally have a host-4 as pinned
 		&nova.Aggregate{
 			Name:        "agg3",
 			UUID:        "agg3",
 			ComputeHost: testlib.Ptr("host1"),
-			Metadata:    "{\"filter_tenant_id\":\"project_id_3, project_id_4\"}",
+			Metadata:    `{"filter_tenant_id":"project_id_3, project_id_4"}`,
 		},
 	}
 
@@ -239,28 +248,28 @@ func TestHostPinnedProjectsExtractor_Extract_SupportEmptyComputeHost(t *testing.
 
 	expectedFeatures := []HostPinnedProjects{
 		{
-			AggregateName: "agg2",
-			AggregateUUID: "agg2",
+			AggregateName: testlib.Ptr("agg2"),
+			AggregateUUID: testlib.Ptr("agg2"),
 			ComputeHost:   nil,
-			ProjectID:     "project_id_3",
+			ProjectID:     testlib.Ptr("project_id_3"),
 		},
 		{
-			AggregateName: "agg2",
-			AggregateUUID: "agg2",
+			AggregateName: testlib.Ptr("agg2"),
+			AggregateUUID: testlib.Ptr("agg2"),
 			ComputeHost:   nil,
-			ProjectID:     "project_id_4",
+			ProjectID:     testlib.Ptr("project_id_4"),
 		},
 		{
-			AggregateName: "agg3",
-			AggregateUUID: "agg3",
+			AggregateName: testlib.Ptr("agg3"),
+			AggregateUUID: testlib.Ptr("agg3"),
 			ComputeHost:   testlib.Ptr("host1"),
-			ProjectID:     "project_id_3",
+			ProjectID:     testlib.Ptr("project_id_3"),
 		},
 		{
-			AggregateName: "agg3",
-			AggregateUUID: "agg3",
+			AggregateName: testlib.Ptr("agg3"),
+			AggregateUUID: testlib.Ptr("agg3"),
 			ComputeHost:   testlib.Ptr("host1"),
-			ProjectID:     "project_id_4",
+			ProjectID:     testlib.Ptr("project_id_4"),
 		},
 	}
 
@@ -285,7 +294,10 @@ func TestHostPinnedProjectsExtractor_Extract_FilterOutEmptyFilterTenantLists(t *
 	defer testDB.Close()
 	defer dbEnv.Close()
 
-	if err := testDB.CreateTable(testDB.AddTable(nova.Aggregate{})); err != nil {
+	if err := testDB.CreateTable(
+		testDB.AddTable(nova.Aggregate{}),
+		testDB.AddTable(nova.Hypervisor{}),
+	); err != nil {
 		t.Fatalf("failed to create table: %v", err)
 	}
 
@@ -295,13 +307,13 @@ func TestHostPinnedProjectsExtractor_Extract_FilterOutEmptyFilterTenantLists(t *
 			Name:        "agg1",
 			UUID:        "agg1",
 			ComputeHost: nil,
-			Metadata:    "{\"filter_tenant_id\":\"\"}",
+			Metadata:    `{"filter_tenant_id":""}`,
 		},
 		&nova.Aggregate{
 			Name:        "agg2",
 			UUID:        "agg2",
 			ComputeHost: nil,
-			Metadata:    "{\"filter_tenant_id\":\"[]\"}",
+			Metadata:    `{"filter_tenant_id":[]}`,
 		},
 	}
 
@@ -332,5 +344,222 @@ func TestHostPinnedProjectsExtractor_Extract_FilterOutEmptyFilterTenantLists(t *
 
 	if len(results) > 0 {
 		t.Errorf("expected no results, got %d", len(results))
+	}
+}
+
+func TestHostPinnedProjectsExtractor_Extract_FindAllHypervisorsIfNoAggregateIsProvided(t *testing.T) {
+	if os.Getenv("POSTGRES_CONTAINER") != "1" {
+		t.Skip("skipping test; set POSTGRES_CONTAINER=1 to run")
+	}
+
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	if err := testDB.CreateTable(
+		testDB.AddTable(nova.Aggregate{}),
+		testDB.AddTable(nova.Hypervisor{}),
+	); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	hypervisors := []any{
+		// Ironic hypervisor should be filtered out
+		&nova.Hypervisor{
+			ID:             "1",
+			ServiceHost:    "host1",
+			HypervisorType: "ironic",
+		},
+		&nova.Hypervisor{
+			ID:             "2",
+			ServiceHost:    "host2",
+			HypervisorType: "not-ironic",
+		},
+		&nova.Hypervisor{
+			ID:             "3",
+			ServiceHost:    "host3",
+			HypervisorType: "other-not-ironic",
+		},
+	}
+
+	if err := testDB.Insert(hypervisors...); err != nil {
+		t.Fatalf("failed to insert hypervisors: %v", err)
+	}
+
+	extractor := &HostPinnedProjectsExtractor{}
+	config := conf.FeatureExtractorConfig{
+		Name:           "host_pinned_projects_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+
+	if err := extractor.Init(testDB, config); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if _, err := extractor.Extract(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var results []HostPinnedProjects
+	table := HostPinnedProjects{}.TableName()
+	if _, err := testDB.Select(&results, "SELECT * FROM "+table); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	expectedFeatures := []HostPinnedProjects{
+		{
+			AggregateName: nil,
+			AggregateUUID: nil,
+			ComputeHost:   testlib.Ptr("host2"),
+			ProjectID:     nil,
+		},
+		{
+			AggregateName: nil,
+			AggregateUUID: nil,
+			ComputeHost:   testlib.Ptr("host3"),
+			ProjectID:     nil,
+		},
+	}
+
+	if len(results) != len(expectedFeatures) {
+		t.Errorf("expected %d results, got %d", len(expectedFeatures), len(results))
+	}
+
+	for i := range results {
+		if !reflect.DeepEqual(results[i], expectedFeatures[i]) {
+			t.Errorf("expected %v, got %v", expectedFeatures[i], results[i])
+		}
+	}
+}
+
+func TestHostPinnedProjectsExtractor_Extract_FindAllHypervisorsWithNoFilterIfAggregatesExist(t *testing.T) {
+	if os.Getenv("POSTGRES_CONTAINER") != "1" {
+		t.Skip("skipping test; set POSTGRES_CONTAINER=1 to run")
+	}
+
+	dbEnv := testlibDB.SetupDBEnv(t)
+	testDB := db.DB{DbMap: dbEnv.DbMap}
+	defer testDB.Close()
+	defer dbEnv.Close()
+
+	if err := testDB.CreateTable(
+		testDB.AddTable(nova.Aggregate{}),
+		testDB.AddTable(nova.Hypervisor{}),
+	); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	hypervisors := []any{
+		&nova.Hypervisor{
+			ID:             "1",
+			ServiceHost:    "host1",
+			HypervisorType: "not-ironic",
+		},
+		&nova.Hypervisor{
+			ID:             "2",
+			ServiceHost:    "host2",
+			HypervisorType: "other-not-ironic",
+		},
+		&nova.Hypervisor{
+			ID:             "3",
+			ServiceHost:    "host3",
+			HypervisorType: "non-filter-host",
+		},
+	}
+
+	aggregates := []any{
+		&nova.Aggregate{
+			Name:        "agg1",
+			UUID:        "agg1",
+			ComputeHost: testlib.Ptr("host1"),
+			Metadata:    `{"filter_tenant_id":"project_id_1"}`,
+		},
+		&nova.Aggregate{
+			Name:        "agg1",
+			UUID:        "agg1",
+			ComputeHost: testlib.Ptr("host2"),
+			Metadata:    `{"filter_tenant_id":"project_id_1"}`,
+		},
+		&nova.Aggregate{
+			Name:        "az1",
+			UUID:        "az1",
+			ComputeHost: testlib.Ptr("host1"),
+			Metadata:    `{"type":"az"}`,
+		},
+		&nova.Aggregate{
+			Name:        "az1",
+			UUID:        "az1",
+			ComputeHost: testlib.Ptr("host2"),
+			Metadata:    `{"type":"az"}`,
+		},
+		// Host 3 is part of an availability zone aggregate, but has no filter_tenant_id
+		&nova.Aggregate{
+			Name:        "az1",
+			UUID:        "az1",
+			ComputeHost: testlib.Ptr("host3"),
+			Metadata:    `{"type":"az"}`,
+		},
+	}
+
+	if err := testDB.Insert(hypervisors...); err != nil {
+		t.Fatalf("failed to insert hypervisors: %v", err)
+	}
+
+	if err := testDB.Insert(aggregates...); err != nil {
+		t.Fatalf("failed to insert aggregates: %v", err)
+	}
+
+	extractor := &HostPinnedProjectsExtractor{}
+	config := conf.FeatureExtractorConfig{
+		Name:           "host_pinned_projects_extractor",
+		Options:        conf.NewRawOpts("{}"),
+		RecencySeconds: nil,
+	}
+
+	if err := extractor.Init(testDB, config); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if _, err := extractor.Extract(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var results []HostPinnedProjects
+	table := HostPinnedProjects{}.TableName()
+	if _, err := testDB.Select(&results, "SELECT * FROM "+table); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	expectedFeatures := []HostPinnedProjects{
+		{
+			AggregateName: testlib.Ptr("agg1"),
+			AggregateUUID: testlib.Ptr("agg1"),
+			ComputeHost:   testlib.Ptr("host1"),
+			ProjectID:     testlib.Ptr("project_id_1"),
+		},
+		{
+			AggregateName: testlib.Ptr("agg1"),
+			AggregateUUID: testlib.Ptr("agg1"),
+			ComputeHost:   testlib.Ptr("host2"),
+			ProjectID:     testlib.Ptr("project_id_1"),
+		},
+		{
+			AggregateName: nil,
+			AggregateUUID: nil,
+			ComputeHost:   testlib.Ptr("host3"),
+			ProjectID:     nil,
+		},
+	}
+
+	if len(results) != len(expectedFeatures) {
+		t.Errorf("expected %d results, got %d", len(expectedFeatures), len(results))
+	}
+
+	for i := range results {
+		if !reflect.DeepEqual(results[i], expectedFeatures[i]) {
+			t.Errorf("expected %v, got %v", expectedFeatures[i], results[i])
+		}
 	}
 }

--- a/internal/extractor/plugins/shared/host_pinned_projects.go
+++ b/internal/extractor/plugins/shared/host_pinned_projects.go
@@ -8,17 +8,20 @@ import (
 
 	"github.com/cobaltcore-dev/cortex/internal/db"
 	"github.com/cobaltcore-dev/cortex/internal/extractor/plugins"
-	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/identity"
 	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/nova"
-	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/placement"
 )
 
-// Feature that maps how many resources are utilized on a compute host.
+// Feature that maps hosts that are pinned to projects.
+// See the docs: https://docs.openstack.org/nova/latest/admin/scheduling.html#aggregatemultitenancyisolation
 type HostPinnedProjects struct {
-	// Name of the OpenStack compute host.
-	ComputeHost string `db:"compute_host"`
-	// Project ID
+	// The name of the aggregate where the filter is defined
+	AggregateName string `db:"aggregate_name"`
+	// UUID of the aggregate where the filter is defined
+	AggregateUUID string `db:"aggregate_uuid"`
+	// Tenant ID that belongs to the filter
 	ProjectID string `db:"project_id"`
+	// Name of the OpenStack compute host.
+	ComputeHost *string `db:"compute_host"`
 }
 
 // Table under which the feature is stored.
@@ -47,9 +50,6 @@ func (*HostPinnedProjectsExtractor) GetName() string {
 func (HostPinnedProjectsExtractor) Triggers() []string {
 	return []string{
 		nova.TriggerNovaHypervisorsSynced,
-		placement.TriggerPlacementInventoryUsagesSynced,
-		identity.TriggerIdentityDomainsSynced,
-		identity.TriggerIdentityProjectsSynced,
 	}
 }
 

--- a/internal/extractor/plugins/shared/host_pinned_projects.go
+++ b/internal/extractor/plugins/shared/host_pinned_projects.go
@@ -15,11 +15,11 @@ import (
 // See the docs: https://docs.openstack.org/nova/latest/admin/scheduling.html#aggregatemultitenancyisolation
 type HostPinnedProjects struct {
 	// The name of the aggregate where the filter is defined
-	AggregateName string `db:"aggregate_name"`
+	AggregateName *string `db:"aggregate_name"`
 	// UUID of the aggregate where the filter is defined
-	AggregateUUID string `db:"aggregate_uuid"`
+	AggregateUUID *string `db:"aggregate_uuid"`
 	// Tenant ID that belongs to the filter
-	ProjectID string `db:"project_id"`
+	ProjectID *string `db:"project_id"`
 	// Name of the OpenStack compute host.
 	ComputeHost *string `db:"compute_host"`
 }
@@ -50,6 +50,7 @@ func (*HostPinnedProjectsExtractor) GetName() string {
 func (HostPinnedProjectsExtractor) Triggers() []string {
 	return []string{
 		nova.TriggerNovaHypervisorsSynced,
+		nova.TriggerNovaAggregatesSynced,
 	}
 }
 

--- a/internal/extractor/plugins/shared/host_pinned_projects.go
+++ b/internal/extractor/plugins/shared/host_pinned_projects.go
@@ -1,0 +1,62 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	_ "embed"
+
+	"github.com/cobaltcore-dev/cortex/internal/db"
+	"github.com/cobaltcore-dev/cortex/internal/extractor/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/identity"
+	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/nova"
+	"github.com/cobaltcore-dev/cortex/internal/sync/openstack/placement"
+)
+
+// Feature that maps how many resources are utilized on a compute host.
+type HostPinnedProjects struct {
+	// Name of the OpenStack compute host.
+	ComputeHost string `db:"compute_host"`
+	// Project ID
+	ProjectID string `db:"project_id"`
+}
+
+// Table under which the feature is stored.
+func (HostPinnedProjects) TableName() string {
+	return "feature_host_pinned_projects"
+}
+
+// Indexes for the feature.
+func (HostPinnedProjects) Indexes() []db.Index { return nil }
+
+// Extractor that extracts the utilization on a compute host.
+type HostPinnedProjectsExtractor struct {
+	// Common base for all extractors that provides standard functionality.
+	plugins.BaseExtractor[
+		struct{},           // No options passed through yaml config
+		HostPinnedProjects, // Feature model
+	]
+}
+
+// Name of this feature extractor that is used in the yaml config, for logging etc.
+func (*HostPinnedProjectsExtractor) GetName() string {
+	return "host_pinned_projects_extractor"
+}
+
+// Get message topics that trigger a re-execution of this extractor.
+func (HostPinnedProjectsExtractor) Triggers() []string {
+	return []string{
+		nova.TriggerNovaHypervisorsSynced,
+		placement.TriggerPlacementInventoryUsagesSynced,
+		identity.TriggerIdentityDomainsSynced,
+		identity.TriggerIdentityProjectsSynced,
+	}
+}
+
+//go:embed host_pinned_projects.sql
+var hostPinnedProjectsQuery string
+
+// Extract the domains and projects on a compute host.
+func (e *HostPinnedProjectsExtractor) Extract() ([]plugins.Feature, error) {
+	return e.ExtractSQL(hostPinnedProjectsQuery)
+}

--- a/internal/extractor/plugins/shared/host_pinned_projects.sql
+++ b/internal/extractor/plugins/shared/host_pinned_projects.sql
@@ -9,4 +9,22 @@ WHERE agg.metadata::jsonb ? 'filter_tenant_id'
   AND agg.metadata::jsonb ->> 'filter_tenant_id' != ''
   AND agg.metadata::jsonb ->> 'filter_tenant_id' != '[]'
   AND trim(tenant.value) != ''
-  AND trim(tenant.value) IS NOT NULL;
+  AND trim(tenant.value) IS NOT NULL
+
+UNION ALL
+
+--- Get all hypervisors which don't have a filter applied to them
+SELECT
+    NULL as aggregate_uuid,
+    NULL as aggregate_name,
+    h.service_host as compute_host,
+    NULL as project_id
+FROM openstack_hypervisors h
+WHERE h.hypervisor_type != 'ironic' --- Filter out ironic hypervisors
+  AND h.service_host IS NOT NULL
+  AND h.service_host NOT IN (
+      SELECT DISTINCT agg.compute_host
+      FROM openstack_aggregates_v2 agg
+      WHERE agg.metadata::jsonb ? 'filter_tenant_id'
+        AND agg.compute_host IS NOT NULL
+  );

--- a/internal/extractor/plugins/shared/host_pinned_projects.sql
+++ b/internal/extractor/plugins/shared/host_pinned_projects.sql
@@ -1,0 +1,12 @@
+SELECT
+    uuid as aggregate_uuid,
+    name as aggregate_name,
+    compute_host,
+    trim(tenant.value) as project_id
+FROM openstack_aggregates_v2 agg
+CROSS JOIN LATERAL unnest(string_to_array(agg.metadata::jsonb ->> 'filter_tenant_id', ',')) AS tenant(value)
+WHERE agg.metadata::jsonb ? 'filter_tenant_id'
+  AND agg.metadata::jsonb ->> 'filter_tenant_id' != ''
+  AND agg.metadata::jsonb ->> 'filter_tenant_id' != '[]'
+  AND trim(tenant.value) != ''
+  AND trim(tenant.value) IS NOT NULL;


### PR DESCRIPTION
Open questions:

- can we just ignore aggregates with `filter_tenant_id` but without any `hosts` assigned to them