### PR TITLE
Consider all unknown cpu_architectures as cascade-lake

### DIFF
--- a/internal/extractor/plugins/sap/host_details.sql
+++ b/internal/extractor/plugins/sap/host_details.sql
@@ -19,8 +19,7 @@ SELECT
     -- CPU Architecture
     CASE
         WHEN ht.traits LIKE '%CUSTOM_HW_SAPPHIRE_RAPIDS%' THEN 'sapphire-rapids'
-        WHEN ht.traits LIKE '%CUSTOM_NUMASIZE_C48_M729%' THEN 'cascade-lake'
-        ELSE 'unknown'
+        ELSE 'cascade-lake'
     END AS cpu_architecture,
     ht.hypervisor_type,
     CASE

--- a/internal/extractor/plugins/sap/host_details_test.go
+++ b/internal/extractor/plugins/sap/host_details_test.go
@@ -128,7 +128,7 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 		{
 			ComputeHost:      "ironic-host-01",
 			AvailabilityZone: "az2",
-			CPUArchitecture:  "unknown",
+			CPUArchitecture:  "cascade-lake",
 			HypervisorType:   "ironic",
 			HypervisorFamily: "unknown",
 			WorkloadType:     "general-purpose",
@@ -150,7 +150,7 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 		{
 			ComputeHost:      "node002-bb03",
 			AvailabilityZone: "az2",
-			CPUArchitecture:  "unknown",
+			CPUArchitecture:  "cascade-lake",
 			HypervisorFamily: "kvm",
 			HypervisorType:   "test",
 			WorkloadType:     "general-purpose",
@@ -161,7 +161,7 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 		{
 			ComputeHost:      "node003-bb03",
 			AvailabilityZone: "az2",
-			CPUArchitecture:  "unknown",
+			CPUArchitecture:  "cascade-lake",
 			HypervisorType:   "test",
 			HypervisorFamily: "kvm",
 			WorkloadType:     "general-purpose",
@@ -172,7 +172,7 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 		{
 			ComputeHost:      "node004-bb03",
 			AvailabilityZone: "az2",
-			CPUArchitecture:  "unknown",
+			CPUArchitecture:  "cascade-lake",
 			HypervisorType:   "test",
 			HypervisorFamily: "kvm",
 			WorkloadType:     "general-purpose",


### PR DESCRIPTION
After last meeting we decided to consider all `!sapphire-rapids` to be `cascade-lake`. This will might change in the future since there might be a custom trait for `cascade-lake`.