### PR TITLE
Downgrade toolchain to go1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cobaltcore-dev/cortex
 
 go 1.24.0
 
-toolchain go1.25.0
+toolchain go1.24.2
 
 replace (
 	github.com/cobaltcore-dev/cortex/commands => ./commands


### PR DESCRIPTION
Introduced by renovate PR https://github.com/cobaltcore-dev/cortex/pull/263

But since renovate.json limits go version to 1.24.x this PR reverts this change. 

Maybe we can add a custom package rule to restrict go toolchain to 1.24.x as well? Or maybe upgrade go to 1.25.x?