### PR TITLE
Update Go version to 1.25

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
   ],
   "commitMessageAction": "Renovate: Update",
   "constraints": {
-    "go": "1.24"
+    "go": "1.25"
   },
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "osvVulnerabilityAlerts": true,
@@ -25,7 +25,7 @@
       "matchPackageNames": [
         "golang"
       ],
-      "allowedVersions": "1.24.x"
+      "allowedVersions": "1.25.x"
     },
     {
       "matchPackageNames": [

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           check-latest: true
-          go-version: 1.25.0
+          go-version-file: 'go.mod'
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           check-latest: true
-          go-version: 1.25.0
+          go-version-file: 'go.mod'
       - name: Build all binaries
         run: make build-all
   test:
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           check-latest: true
-          go-version: 1.25.0
+          go-version-file: 'go.mod'
       - name: Run tests and generate coverage report
         run: |
           sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           check-latest: true
-          go-version: 1.25.0
+          go-version-file: 'go.mod'
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.0
+          go-version-file: 'go.mod'
       - name: Test quickly without Docker
         run: |
           echo "Testing main module..."
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.0
+          go-version-file: 'go.mod'
       - name: Run tests with Docker and calculate coverage
         run: |
           export GITHUB_ACTIONS=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6-alpine3.21 AS builder
+FROM golang:1.25.1-alpine3.21 AS builder
 
 ARG GOCACHE=/root/.cache/go-build
 ENV GOCACHE=${GOCACHE}
@@ -8,8 +8,8 @@ RUN apk add --no-cache --no-progress ca-certificates gcc git make musl-dev
 COPY . /src
 ARG BININFO_BUILD_DATE BININFO_COMMIT_HASH BININFO_VERSION # provided to 'make install'
 RUN --mount=type=cache,target=/go/pkg/mod/ \
-    --mount=type=cache,target=${GOCACHE} \
-    make -C /src install PREFIX=/pkg GOTOOLCHAIN=local
+  --mount=type=cache,target=${GOCACHE} \
+  make -C /src install PREFIX=/pkg GOTOOLCHAIN=local
 
 ################################################################################
 

--- a/Dockerfile.kubebuilder
+++ b/Dockerfile.kubebuilder
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 # Path of our go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/cobaltcore-dev/cortex
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.0
 
 replace (
 	github.com/cobaltcore-dev/cortex/commands => ./commands

--- a/reservations/api/go.mod
+++ b/reservations/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/cobaltcore-dev/cortex/reservations/api
 
-go 1.24.0
+go 1.25.0
 
 require (
 	k8s.io/apimachinery v0.34.0

--- a/reservations/go.mod
+++ b/reservations/go.mod
@@ -1,6 +1,6 @@
 module github.com/cobaltcore-dev/cortex/reservations
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/cobaltcore-dev/cortex => ../

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@ mkShell {
   nativeBuildInputs = [
     addlicense
     go-licence-detector
-    go_1_24
+    go_1_25
     gotools # goimports
     postgresql_17
 


### PR DESCRIPTION
- Upgrade go to `1.25`
- Adjusted renovate constraints to go `1.25.x`
- Replaced `go-version` with `go-version-file` in `go-setup-action` (See: https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file)

---

- The workflows have been already upgraded to `1.25.x` via renovate PRs. If we don't want that we should add a packageRule for this as well. Example:

```js
{
      "matchManagers": ["github-actions"],
      "matchPackageNames": ["actions/setup-go"],
      "allowedVersions": "1.25.x"
},
```