### PR TITLE
Implement commitment-reservation exchange

### DIFF
--- a/internal/scheduler/nova/plugins/shared/filter_has_enough_capacity.go
+++ b/internal/scheduler/nova/plugins/shared/filter_has_enough_capacity.go
@@ -74,6 +74,12 @@ func (s *FilterHasEnoughCapacity) Run(traceLog *slog.Logger, request api.Externa
 		if reservation.Spec.Scheduler.CortexNova == nil {
 			continue // Not handled by us.
 		}
+		// If the requested vm matches this reservation, free the resources.
+		if reservation.Spec.Scheduler.CortexNova.ProjectID == request.Spec.Data.ProjectID &&
+			reservation.Spec.Scheduler.CortexNova.FlavorName == request.Spec.Data.Flavor.Data.Name {
+			traceLog.Info("unlocking resources reserved by matching reservation", "reservation", reservation.Name)
+			continue
+		}
 		host := reservation.Status.Host
 		if cpu, ok := reservation.Spec.Requests["cpu"]; ok {
 			vcpusReserved[host] += cpu.AsDec().UnscaledBig().Uint64()

--- a/reservations/internal/commitments/client.go
+++ b/reservations/internal/commitments/client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	gosync "sync"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/keystone"
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/projects"
 	"github.com/sapcc/go-bits/jobloop"
 	"github.com/sapcc/go-bits/must"
@@ -25,8 +25,15 @@ import (
 type CommitmentsClient interface {
 	// Init the client.
 	Init(ctx context.Context)
-	// Get all commitments with resolved metadata (e.g. project, flavor, ...).
-	GetComputeCommitments(ctx context.Context) ([]Commitment, error)
+	// List all projects to resolve commitments.
+	ListProjects(ctx context.Context) ([]Project, error)
+	// List all flavors by their name to resolve instance commitments.
+	ListFlavorsByName(ctx context.Context) (map[string]Flavor, error)
+	// List all commitments with resolved metadata (e.g. project, flavor, ...).
+	ListCommitmentsByID(ctx context.Context, projects ...Project) (map[string]Commitment, error)
+	// List all currently running (ACTIVE) servers for the given projects from nova.
+	// The result is a map from project ID to the list of active servers.
+	ListActiveServersByProjectID(ctx context.Context, projects ...Project) (map[string][]Server, error)
 }
 
 // Commitments client fetching commitments from openstack services.
@@ -97,7 +104,7 @@ func (c *commitmentsClient) Init(ctx context.Context) {
 }
 
 // Get all Nova flavors by their name to resolve instance commitments.
-func (c *commitmentsClient) getAllFlavors(ctx context.Context) ([]Flavor, error) {
+func (c *commitmentsClient) ListFlavorsByName(ctx context.Context) (map[string]Flavor, error) {
 	syncLog.Info("fetching all flavors from nova")
 	flo := flavors.ListOpts{AccessType: flavors.AllAccess}
 	pages, err := flavors.ListDetail(c.nova, flo).AllPages(ctx)
@@ -112,18 +119,22 @@ func (c *commitmentsClient) getAllFlavors(ctx context.Context) ([]Flavor, error)
 		return nil, err
 	}
 	syncLog.Info("fetched flavors from nova", "count", len(data.Flavors))
-	return data.Flavors, nil
+	flavorsByName := make(map[string]Flavor, len(data.Flavors))
+	for _, flavor := range data.Flavors {
+		flavorsByName[flavor.Name] = flavor
+	}
+	return flavorsByName, nil
 }
 
 // Get all projects from Keystone to resolve commitments.
-func (c *commitmentsClient) getAllProjects(ctx context.Context) ([]projects.Project, error) {
+func (c *commitmentsClient) ListProjects(ctx context.Context) ([]Project, error) {
 	syncLog.Info("fetching projects from keystone")
 	allPages, err := projects.List(c.keystone, nil).AllPages(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var data = &struct {
-		Projects []projects.Project `json:"projects"`
+		Projects []Project `json:"projects"`
 	}{}
 	if err := allPages.(projects.ProjectPage).ExtractInto(data); err != nil {
 		return nil, err
@@ -134,14 +145,10 @@ func (c *commitmentsClient) getAllProjects(ctx context.Context) ([]projects.Proj
 
 // Get all available commitments from limes + keystone + nova.
 // This function fetches the commitments for each project in parallel.
-func (c *commitmentsClient) GetComputeCommitments(ctx context.Context) ([]Commitment, error) {
-	projects, err := c.getAllProjects(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get projects: %w", err)
-	}
-	syncLog.Info("fetching flavor commitments from limes", "projects", len(projects))
+func (c *commitmentsClient) ListCommitmentsByID(ctx context.Context, projects ...Project) (map[string]Commitment, error) {
+	syncLog.Info("fetching commitments from limes", "projects", len(projects))
 	commitmentsMutex := gosync.Mutex{}
-	commitments := []Commitment{}
+	commitments := make(map[string]Commitment)
 	var wg gosync.WaitGroup
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -150,14 +157,16 @@ func (c *commitmentsClient) GetComputeCommitments(ctx context.Context) ([]Commit
 	for _, project := range projects {
 		wg.Go(func() {
 			// Fetch instance commitments for the project.
-			newResults, err := c.getCommitments(ctx, project)
+			newResults, err := c.listCommitments(ctx, project)
 			if err != nil {
 				errChan <- err
 				cancel()
 				return
 			}
 			commitmentsMutex.Lock()
-			commitments = append(commitments, newResults...)
+			for _, c := range newResults {
+				commitments[c.UUID] = c
+			}
 			commitmentsMutex.Unlock()
 		})
 		time.Sleep(jobloop.DefaultJitter(50 * time.Millisecond)) // Don't overload the API.
@@ -175,33 +184,11 @@ func (c *commitmentsClient) GetComputeCommitments(ctx context.Context) ([]Commit
 		}
 	}
 	syncLog.Info("resolved commitments from limes", "count", len(commitments))
-
-	flavors, err := c.getAllFlavors(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get flavors: %w", err)
-	}
-	// Resolve the flavor for each commitment.
-	flavorsByName := make(map[string]Flavor, len(flavors))
-	for _, flavor := range flavors {
-		flavorsByName[flavor.Name] = flavor
-	}
-	for i := range commitments {
-		if !strings.HasPrefix(commitments[i].ResourceName, "instances_") {
-			// Not an instance commitment.
-			continue
-		}
-		flavorName := strings.TrimPrefix(commitments[i].ResourceName, "instances_")
-		if flavor, ok := flavorsByName[flavorName]; ok {
-			commitments[i].Flavor = &flavor
-		} else {
-			syncLog.Info("flavor not found for commitment", "flavor", flavorName, "commitment_id", commitments[i].ID)
-		}
-	}
 	return commitments, nil
 }
 
 // Resolve the commitments for the given project.
-func (c *commitmentsClient) getCommitments(ctx context.Context, project projects.Project) ([]Commitment, error) {
+func (c *commitmentsClient) listCommitments(ctx context.Context, project Project) ([]Commitment, error) {
 	url := c.limes.Endpoint + "v1" +
 		"/domains/" + project.DomainID +
 		"/projects/" + project.ID +
@@ -229,13 +216,74 @@ func (c *commitmentsClient) getCommitments(ctx context.Context, project projects
 	// Add the project information to each commitment.
 	var commitments []Commitment
 	for _, c := range list.Commitments {
-		if c.ServiceType != "compute" {
-			// Not a compute commitment.
-			continue
-		}
 		c.ProjectID = project.ID
 		c.DomainID = project.DomainID
 		commitments = append(commitments, c)
 	}
 	return commitments, nil
+}
+
+// Get all currently running (ACTIVE) servers for the given project ids from nova.
+// The result is a map from project ID to the list of active servers.
+func (c *commitmentsClient) ListActiveServersByProjectID(ctx context.Context, projects ...Project) (map[string][]Server, error) {
+	syncLog.Info("fetching active servers from nova")
+	serversByProject := make(map[string][]Server, len(projects))
+	var mu gosync.Mutex
+	var wg gosync.WaitGroup
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	// Channel to communicate errors from goroutines.
+	errChan := make(chan error, len(projects))
+	for _, project := range projects {
+		wg.Go(func() {
+			servers, err := c.listActiveServersForProject(ctx, project)
+			if err != nil {
+				errChan <- err
+				cancel()
+				return
+			}
+			mu.Lock()
+			serversByProject[project.ID] = servers
+			mu.Unlock()
+		})
+		time.Sleep(jobloop.DefaultJitter(50 * time.Millisecond)) // Don't overload the API.
+	}
+	// Wait for all goroutines to finish and close the error channel.
+	go func() {
+		wg.Wait()
+		close(errChan)
+	}()
+	// Return the first error encountered, if any.
+	for err := range errChan {
+		if err != nil {
+			syncLog.Error(err, "failed to fetch active servers")
+			return nil, err
+		}
+	}
+	syncLog.Info("fetched active servers from nova", "projects", len(serversByProject))
+	return serversByProject, nil
+}
+
+// Get all currently running (ACTIVE) servers for the given project id from nova.
+func (c *commitmentsClient) listActiveServersForProject(ctx context.Context, project Project) ([]Server, error) {
+	lo := servers.ListOpts{
+		// AllTenants must be set to fetch servers from other projects
+		// than the one we are authenticated with.
+		AllTenants: true,
+		TenantID:   project.ID,
+		Status:     "ACTIVE", // Use string literal instead of servers.StateActive which is lowercase
+	}
+	pages, err := servers.List(c.nova, lo).AllPages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Parse the json data into our custom model.
+	var data = &struct {
+		Servers []Server `json:"servers"`
+	}{}
+	if err := pages.(servers.ServerPage).ExtractInto(data); err != nil {
+		return nil, err
+	}
+	syncLog.Info("fetched active servers for project", "project", project.ID, "count", len(data.Servers))
+	return data.Servers, nil
 }

--- a/reservations/internal/commitments/client_test.go
+++ b/reservations/internal/commitments/client_test.go
@@ -380,17 +380,12 @@ func TestCommitmentsClient_ListCommitmentsByID_Error(t *testing.T) {
 	}
 }
 
-func TestCommitmentsClient_ListActiveServersByProjectID(t *testing.T) {
+func TestCommitmentsClient_ListServersByProjectID(t *testing.T) {
 	// Mock server for Nova compute service
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/servers/detail") {
 			// Parse query parameters to determine which project
 			tenantID := r.URL.Query().Get("tenant_id")
-			status := r.URL.Query().Get("status")
-
-			if status != "ACTIVE" {
-				t.Errorf("expected status=ACTIVE, got %s", status)
-			}
 
 			// Return raw JSON string as the gophercloud pages expect
 			w.Header().Set("Content-Type", "application/json")
@@ -430,7 +425,7 @@ func TestCommitmentsClient_ListActiveServersByProjectID(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	serversByProject, err := client.ListActiveServersByProjectID(ctx, projects...)
+	serversByProject, err := client.ListServersByProjectID(ctx, projects...)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -461,7 +456,7 @@ func TestCommitmentsClient_ListActiveServersByProjectID(t *testing.T) {
 	}
 }
 
-func TestCommitmentsClient_ListActiveServersByProjectID_Error(t *testing.T) {
+func TestCommitmentsClient_ListServersByProjectID_Error(t *testing.T) {
 	// Mock server that returns an error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
@@ -482,7 +477,7 @@ func TestCommitmentsClient_ListActiveServersByProjectID_Error(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	servers, err := client.ListActiveServersByProjectID(ctx, projects...)
+	servers, err := client.ListServersByProjectID(ctx, projects...)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -629,7 +624,7 @@ func TestCommitmentsClient_listCommitments_JSONError(t *testing.T) {
 	}
 }
 
-func TestCommitmentsClient_listActiveServersForProject(t *testing.T) {
+func TestCommitmentsClient_listServersForProject(t *testing.T) {
 	// Mock server for Nova compute service
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/servers/detail") {
@@ -644,9 +639,6 @@ func TestCommitmentsClient_listActiveServersForProject(t *testing.T) {
 		}
 		if query.Get("tenant_id") != "test-project" {
 			t.Errorf("expected tenant_id=test-project, got %s", query.Get("tenant_id"))
-		}
-		if query.Get("status") != "ACTIVE" {
-			t.Errorf("expected status=ACTIVE, got %s", query.Get("status"))
 		}
 
 		// Return raw JSON string as the gophercloud pages expect
@@ -687,7 +679,7 @@ func TestCommitmentsClient_listActiveServersForProject(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	servers, err := client.listActiveServersForProject(ctx, project)
+	servers, err := client.listServersForProject(ctx, project)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -732,7 +724,7 @@ func TestCommitmentsClient_listActiveServersForProject(t *testing.T) {
 	}
 }
 
-func TestCommitmentsClient_listActiveServersForProject_Error(t *testing.T) {
+func TestCommitmentsClient_listServersForProject_Error(t *testing.T) {
 	// Mock server that returns an error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -751,7 +743,7 @@ func TestCommitmentsClient_listActiveServersForProject_Error(t *testing.T) {
 	project := Project{ID: "test-project"}
 
 	ctx := context.Background()
-	servers, err := client.listActiveServersForProject(ctx, project)
+	servers, err := client.listServersForProject(ctx, project)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/reservations/internal/commitments/messages.go
+++ b/reservations/internal/commitments/messages.go
@@ -3,6 +3,8 @@
 
 package commitments
 
+import "encoding/json"
+
 // Commitment model from the limes API.
 // See: https://github.com/sapcc/limes/blob/5ea068b/docs/users/api-spec-resources.md?plain=1#L493
 // See: https://github.com/sapcc/go-api-declarations/blob/94ee3e5/limes/resources/commitment.go#L19
@@ -61,10 +63,6 @@ type Commitment struct {
 	ProjectID string `json:"project_id"`
 	// The openstack domain ID this commitment is for.
 	DomainID string `json:"domain_id"`
-
-	// Resolved flavor if the commitment is for a specific instance,
-	// i.e. has the unit instances_<flavor_name>.
-	Flavor *Flavor
 }
 
 // OpenStack flavor model as returned by the Nova API under /flavors/detail.
@@ -82,4 +80,96 @@ type Flavor struct {
 
 	// JSON string of extra specifications used when scheduling the flavor.
 	ExtraSpecs map[string]string `json:"extra_specs" db:"extra_specs"`
+}
+
+// OpenStack project model as returned by the Keystone API under /projects.
+// See: https://docs.openstack.org/api-ref/identity/v3/#projects
+type Project struct {
+	// DomainID is the domain ID the project belongs to.
+	DomainID string `json:"domain_id"`
+	// ID is the unique ID of the project.
+	ID string `json:"id"`
+	// Name is the name of the project.
+	Name string `json:"name"`
+	// ParentID is the parent_id of the project.
+	ParentID string `json:"parent_id"`
+
+	// Some fields were omitted. Add them if needed.
+}
+
+// OpenStack server model as returned by the Nova API under /servers/detail.
+// See: https://docs.openstack.org/api-ref/compute/#list-servers-detailed
+type Server struct {
+	ID                             string  `json:"id" db:"id,primarykey"`
+	Name                           string  `json:"name" db:"name"`
+	Status                         string  `json:"status" db:"status"`
+	TenantID                       string  `json:"tenant_id" db:"tenant_id"`
+	UserID                         string  `json:"user_id" db:"user_id"`
+	HostID                         string  `json:"hostId" db:"host_id"`
+	Created                        string  `json:"created" db:"created"`
+	Updated                        string  `json:"updated" db:"updated"`
+	AccessIPv4                     string  `json:"accessIPv4" db:"access_ipv4"`
+	AccessIPv6                     string  `json:"accessIPv6" db:"access_ipv6"`
+	OSDCFdiskConfig                string  `json:"OS-DCF:diskConfig" db:"os_dcf_disk_config"`
+	Progress                       int     `json:"progress" db:"progress"`
+	OSEXTAvailabilityZone          string  `json:"OS-EXT-AZ:availability_zone" db:"os_ext_az_availability_zone"`
+	ConfigDrive                    string  `json:"config_drive" db:"config_drive"`
+	KeyName                        string  `json:"key_name" db:"key_name"`
+	OSSRVUSGLaunchedAt             string  `json:"OS-SRV-USG:launched_at" db:"os_srv_usg_launched_at"`
+	OSSRVUSGTerminatedAt           *string `json:"OS-SRV-USG:terminated_at" db:"os_srv_usg_terminated_at"`
+	OSEXTSRVATTRHost               string  `json:"OS-EXT-SRV-ATTR:host" db:"os_ext_srv_attr_host"`
+	OSEXTSRVATTRInstanceName       string  `json:"OS-EXT-SRV-ATTR:instance_name" db:"os_ext_srv_attr_instance_name"`
+	OSEXTSRVATTRHypervisorHostname string  `json:"OS-EXT-SRV-ATTR:hypervisor_hostname" db:"os_ext_srv_attr_hypervisor_hostname"`
+	OSEXTSTSTaskState              *string `json:"OS-EXT-STS:task_state" db:"os_ext_sts_task_state"`
+	OSEXTSTSVmState                string  `json:"OS-EXT-STS:vm_state" db:"os_ext_sts_vm_state"`
+	OSEXTSTSPowerState             int     `json:"OS-EXT-STS:power_state" db:"os_ext_sts_power_state"`
+
+	// From nested JSON
+	FlavorName string `json:"-" db:"flavor_name"`
+
+	// Note: there are some more fields that are omitted. To include them again, add
+	// custom unmarshalers and marshalers for the struct below.
+}
+
+// Custom unmarshaler for OpenStackServer to handle nested JSON.
+func (s *Server) UnmarshalJSON(data []byte) error {
+	type Alias Server
+	aux := &struct {
+		Flavor json.RawMessage `json:"flavor"`
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	var flavor struct {
+		// Starting in microversion 2.47, "id" was removed...
+		Name string `json:"original_name"`
+	}
+	if err := json.Unmarshal(aux.Flavor, &flavor); err != nil {
+		return err
+	}
+	s.FlavorName = flavor.Name
+	return nil
+}
+
+// Custom marshaler for OpenStackServer to handle nested JSON.
+func (s *Server) MarshalJSON() ([]byte, error) {
+	type Alias Server
+	aux := &struct {
+		Flavor struct {
+			// Starting in microversion 2.47, "id" was removed...
+			Name string `json:"original_name"`
+		} `json:"flavor"`
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+		Flavor: struct {
+			Name string `json:"original_name"`
+		}{
+			Name: s.FlavorName,
+		},
+	}
+	return json.Marshal(aux)
 }

--- a/reservations/internal/commitments/messages_test.go
+++ b/reservations/internal/commitments/messages_test.go
@@ -33,18 +33,6 @@ func TestCommitment_JSONSerialization(t *testing.T) {
 		NotifyOnConfirm:  true,
 		ProjectID:        "project-123",
 		DomainID:         "domain-456",
-		Flavor: &Flavor{
-			ID:          "flavor-1",
-			Name:        "small",
-			RAM:         1024,
-			VCPUs:       1,
-			Disk:        10,
-			IsPublic:    true,
-			RxTxFactor:  1.0,
-			Ephemeral:   0,
-			Description: "Small flavor",
-			ExtraSpecs:  map[string]string{"hw:cpu_policy": "shared"},
-		},
 	}
 
 	// Test marshaling

--- a/reservations/internal/commitments/syncer.go
+++ b/reservations/internal/commitments/syncer.go
@@ -81,7 +81,9 @@ func (s *Syncer) resolveUnusedCommitments(ctx context.Context) ([]resolvedCommit
 			projectsWithCommitments = append(projectsWithCommitments, project)
 		}
 	}
-	servers, err := s.ListActiveServersByProjectID(ctx, projectsWithCommitments...)
+	// List all servers, not only the active ones, like limes when it calculates
+	// subresource usage: https://github.com/sapcc/limes/blob/c146c82/internal/liquids/nova/subresources.go#L94
+	servers, err := s.ListServersByProjectID(ctx, projectsWithCommitments...)
 	if err != nil {
 		return nil, err
 	}

--- a/reservations/internal/commitments/syncer.go
+++ b/reservations/internal/commitments/syncer.go
@@ -142,6 +142,7 @@ func (s *Syncer) resolveUnusedCommitments(ctx context.Context) ([]resolvedCommit
 			}
 			mappedServers[server.ID] = struct{}{}
 			commitment.Amount--
+			syncLog.Info("subtracting server from commitment", "commitmentID", commitment.UUID, "serverID", server.ID, "remainingAmount", commitment.Amount)
 		}
 		if commitment.Amount <= 0 {
 			syncLog.Info("skipping commitment that is fully used by active servers", "id", commitment.UUID, "project", commitment.ProjectID)

--- a/reservations/internal/commitments/syncer_test.go
+++ b/reservations/internal/commitments/syncer_test.go
@@ -26,8 +26,8 @@ type mockCommitmentsClient struct {
 	listFlavorsByNameFuncCalled   bool
 	listCommitmentsByIDFunc       func(ctx context.Context, projects ...Project) (map[string]Commitment, error)
 	listCommitmentsByIDFuncCalled bool
-	listActiveServersFunc         func(ctx context.Context, projects ...Project) (map[string][]Server, error)
-	listActiveServersFuncCalled   bool
+	listServersFunc               func(ctx context.Context, projects ...Project) (map[string][]Server, error)
+	listServersFuncCalled         bool
 }
 
 func (m *mockCommitmentsClient) Init(ctx context.Context) {
@@ -57,12 +57,12 @@ func (m *mockCommitmentsClient) ListCommitmentsByID(ctx context.Context, project
 	}
 	return m.listCommitmentsByIDFunc(ctx, projects...)
 }
-func (m *mockCommitmentsClient) ListActiveServersByProjectID(ctx context.Context, projects ...Project) (map[string][]Server, error) {
-	m.listActiveServersFuncCalled = true
-	if m.listActiveServersFunc == nil {
+func (m *mockCommitmentsClient) ListServersByProjectID(ctx context.Context, projects ...Project) (map[string][]Server, error) {
+	m.listServersFuncCalled = true
+	if m.listServersFunc == nil {
 		return map[string][]Server{}, nil
 	}
-	return m.listActiveServersFunc(ctx, projects...)
+	return m.listServersFunc(ctx, projects...)
 }
 
 func TestNewSyncer(t *testing.T) {
@@ -168,7 +168,7 @@ func TestSyncer_SyncReservations_InstanceCommitments(t *testing.T) {
 				{ID: "test-project-1", DomainID: "test-domain-1", Name: "Test Project 1"},
 			}, nil
 		},
-		listActiveServersFunc: func(ctx context.Context, projects ...Project) (map[string][]Server, error) {
+		listServersFunc: func(ctx context.Context, projects ...Project) (map[string][]Server, error) {
 			return map[string][]Server{}, nil // No active servers
 		},
 		initFunc: func(ctx context.Context) {
@@ -297,7 +297,7 @@ func TestSyncer_SyncReservations_UpdateExisting(t *testing.T) {
 				{ID: "new-project", DomainID: "new-domain", Name: "New Project"},
 			}, nil
 		},
-		listActiveServersFunc: func(ctx context.Context, projects ...Project) (map[string][]Server, error) {
+		listServersFunc: func(ctx context.Context, projects ...Project) (map[string][]Server, error) {
 			return map[string][]Server{}, nil // No active servers
 		},
 		initFunc: func(ctx context.Context) {
@@ -388,7 +388,7 @@ func TestSyncer_SyncReservations_ShortUUID(t *testing.T) {
 				{ID: "test-project", DomainID: "test-domain", Name: "Test Project"},
 			}, nil
 		},
-		listActiveServersFunc: func(ctx context.Context, projects ...Project) (map[string][]Server, error) {
+		listServersFunc: func(ctx context.Context, projects ...Project) (map[string][]Server, error) {
 			return map[string][]Server{}, nil // No active servers
 		},
 		initFunc: func(ctx context.Context) {


### PR DESCRIPTION
This implements the handover between limes + nova and cortex so that vms are slotted and used commitments no longer reserved.
- The reservations operator now looks for existing virtual machines of projects that have a commitment. It checks if this commitment matches the virtual machine(s) and subtract the current usage from the space we still need to reserve. 
- Furthermore, cortex sees incoming initial placement requests matching a reservation and unlocks it's space for the project.
- Additional refactoring so the reservations operator commitments syncer handles the filtering of commitments to convert to a reservation
