### PR TITLE
Add push main criteria to test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,8 @@ name: Test and Report Coverage
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
I noticed that our test workflows are currently triggered twice when we push on a PR. Thats why I propose to limit òn: push:` to the main branch. 