### PR TITLE
Pinned project labels of host capacity kpi include project and domain name

### DIFF
--- a/extractor/api/features/shared/host_pinned_projects.go
+++ b/extractor/api/features/shared/host_pinned_projects.go
@@ -15,13 +15,17 @@ type HostPinnedProjects struct {
 	AggregateUUID *string `db:"aggregate_uuid"`
 	// Tenant ID that belongs to the filter
 	ProjectID *string `db:"project_id"`
+	// Domain ID of the project
+	DomainID *string `db:"domain_id"`
+	// Combination of project name and domain name
+	Label *string `db:"label"`
 	// Name of the OpenStack compute host.
 	ComputeHost *string `db:"compute_host"`
 }
 
 // Table under which the feature is stored.
 func (HostPinnedProjects) TableName() string {
-	return "feature_host_pinned_projects"
+	return "feature_host_pinned_projects_v2"
 }
 
 // Indexes for the feature.

--- a/extractor/internal/plugins/sap/host_details.sql
+++ b/extractor/internal/plugins/sap/host_details.sql
@@ -15,8 +15,8 @@ WITH host_traits AS (
 pinned_projects AS (
     SELECT
         compute_host,
-        STRING_AGG(project_id, ',' ORDER BY project_id) AS pinned_projects
-    FROM feature_host_pinned_projects
+        STRING_AGG(label, ',' ORDER BY label) AS pinned_projects
+    FROM feature_host_pinned_projects_v2
     GROUP BY compute_host
 )
 SELECT

--- a/extractor/internal/plugins/sap/host_details_test.go
+++ b/extractor/internal/plugins/sap/host_details_test.go
@@ -57,13 +57,13 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 	}
 
 	hostPinnedProjects := []any{
-		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("nova-compute-bb01"), ProjectID: testlib.Ptr("project-123")},
-		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("nova-compute-bb01"), ProjectID: testlib.Ptr("project-456")},
-		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("node001-bb02"), ProjectID: nil},
+		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("nova-compute-bb01"), Label: testlib.Ptr("project-123")},
+		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("nova-compute-bb01"), Label: testlib.Ptr("project-456")},
+		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("node001-bb02"), Label: nil},
 		// No entry for ironic-host-1 since it is excluded in the feature host pinned projects
-		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("node002-bb03"), ProjectID: nil},
-		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("node003-bb03"), ProjectID: nil},
-		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("node004-bb03"), ProjectID: nil},
+		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("node002-bb03"), Label: nil},
+		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("node003-bb03"), Label: nil},
+		&sharedapi.HostPinnedProjects{ComputeHost: testlib.Ptr("node004-bb03"), Label: nil},
 	}
 
 	if err := testDB.Insert(hostPinnedProjects...); err != nil {

--- a/extractor/internal/plugins/shared/host_pinned_projects.sql
+++ b/extractor/internal/plugins/shared/host_pinned_projects.sql
@@ -1,37 +1,64 @@
+-- Extract host-to-project pinning relationships from Nova aggregates
+-- This query identifies which projects are restricted to specific compute hosts
+-- and which hosts are unrestricted (accept any project)
+
+-- CTE to identify all compute hosts that have project restrictions
+-- These are hosts that belong to aggregates with 'filter_tenant_id' metadata
+WITH restricted_hosts AS (
+    SELECT DISTINCT compute_host
+    FROM openstack_aggregates_v2
+    WHERE metadata::jsonb ? 'filter_tenant_id'  -- Check if metadata contains the filter key
+      AND compute_host IS NOT NULL
+)
+
+-- Main query combining restricted and unrestricted hosts
 SELECT DISTINCT
     aggregate_uuid,
     aggregate_name,
     compute_host,
-    project_id
+    project_id,
+    domain_id,
+    label  -- Formatted label showing "project_name (domain_name)"
 FROM (
+    -- Part 1: Extract hosts with specific project restrictions
+    -- Parse comma-separated tenant IDs from aggregate metadata
     SELECT
-        uuid as aggregate_uuid,
-        name as aggregate_name,
-        compute_host,
-        trim(tenant.value) as project_id
-    FROM openstack_aggregates_v2 agg
-    CROSS JOIN LATERAL unnest(string_to_array(agg.metadata::jsonb ->> 'filter_tenant_id', ',')) AS tenant(value)
-    WHERE agg.metadata::jsonb ? 'filter_tenant_id'
-      AND agg.metadata::jsonb ->> 'filter_tenant_id' != ''
-      AND agg.metadata::jsonb ->> 'filter_tenant_id' != '[]'
-      AND trim(tenant.value) != ''
-      AND trim(tenant.value) IS NOT NULL
+        a.uuid as aggregate_uuid,
+        a.name as aggregate_name,
+        a.compute_host,
+        trim(tenant_value) as project_id,  -- Clean whitespace from parsed tenant IDs
+        p.domain_id,
+        -- Create label only when project_id is not NULL, otherwise NULL
+        CASE
+            WHEN trim(tenant_value) IS NOT NULL AND trim(tenant_value) != '' THEN
+                COALESCE(p.name, 'unknown') || ' (' || COALESCE(d.name, 'unknown') || ')'
+            ELSE NULL
+        END AS label
+    FROM openstack_aggregates_v2 a
+    CROSS JOIN unnest(string_to_array(a.metadata::jsonb ->> 'filter_tenant_id', ',')) AS tenant_value
+    -- Join with projects table to get project details and domain information
+    LEFT JOIN openstack_projects p ON trim(tenant_value) = p.id
+    -- Join with domains table to get domain names for the label
+    LEFT JOIN openstack_domains d ON p.domain_id = d.id
+    WHERE a.metadata::jsonb ->> 'filter_tenant_id' IS NOT NULL
+      AND a.metadata::jsonb ->> 'filter_tenant_id' NOT IN ('', '[]')  -- Exclude empty values
+      AND trim(tenant_value) != ''  -- Exclude empty tenant values after trimming
 
     UNION ALL
 
+    -- Part 2: Find unrestricted hosts (no project limitations)
+    -- These hosts can accept VMs from any project
     SELECT
-        NULL as aggregate_uuid,
+        NULL as aggregate_uuid,  -- No aggregate association for unrestricted hosts
         NULL as aggregate_name,
         h.service_host as compute_host,
-        NULL as project_id
+        NULL as project_id,  -- No specific project restriction
+        NULL as domain_id,   -- No domain for unrestricted hosts
+        NULL as label        -- No label for unrestricted hosts
     FROM openstack_hypervisors h
-    WHERE h.hypervisor_type != 'ironic'
+    WHERE h.hypervisor_type != 'ironic'  -- Exclude baremetal hypervisors
       AND h.service_host IS NOT NULL
-      AND h.service_host NOT IN (
-          SELECT DISTINCT agg.compute_host
-          FROM openstack_aggregates_v2 agg
-          WHERE agg.metadata::jsonb ? 'filter_tenant_id'
-            AND agg.compute_host IS NOT NULL
-      )
+      AND h.service_host NOT IN (SELECT compute_host FROM restricted_hosts)  -- Only unrestricted hosts
 ) AS combined_results
+
 ORDER BY compute_host, aggregate_uuid NULLS LAST;


### PR DESCRIPTION
Before: `project_id_1,project_id_2`
Now: `name_of_project_1 (name_of_domain_of_project_1), name_of_project_2 (name_of_domain_of_project_2)`