### PR TITLE
Fix missing run conditions in push-charts workflow

### DIFF
--- a/.github/workflows/push-charts.yaml
+++ b/.github/workflows/push-charts.yaml
@@ -95,6 +95,13 @@ jobs:
         shell: bash
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-chart-yaml-files-scheduler.outputs.all_changed_files }}
+        run: |
+          for CHART_FILE in ${ALL_CHANGED_FILES}; do
+            CHART_DIR=$(dirname $CHART_FILE)
+            helm package $CHART_DIR --dependency-update --destination $CHART_DIR
+            CHART_PACKAGE=$(ls $CHART_DIR/*.tgz)
+            helm push $CHART_PACKAGE oci://${{ env.REGISTRY }}/${{ github.repository }}/charts/
+          done
 
       - name: Get all changed descheduler Chart.yaml files
         id: changed-chart-yaml-files-descheduler
@@ -107,6 +114,13 @@ jobs:
         shell: bash
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-chart-yaml-files-descheduler.outputs.all_changed_files }}
+        run: |
+          for CHART_FILE in ${ALL_CHANGED_FILES}; do
+            CHART_DIR=$(dirname $CHART_FILE)
+            helm package $CHART_DIR --dependency-update --destination $CHART_DIR
+            CHART_PACKAGE=$(ls $CHART_DIR/*.tgz)
+            helm push $CHART_PACKAGE oci://${{ env.REGISTRY }}/${{ github.repository }}/charts/
+          done
 
       - name: Get all changed extractor Chart.yaml files
         id: changed-chart-yaml-files-extractor
@@ -119,6 +133,13 @@ jobs:
         shell: bash
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-chart-yaml-files-extractor.outputs.all_changed_files }}
+        run: |
+          for CHART_FILE in ${ALL_CHANGED_FILES}; do
+            CHART_DIR=$(dirname $CHART_FILE)
+            helm package $CHART_DIR --dependency-update --destination $CHART_DIR
+            CHART_PACKAGE=$(ls $CHART_DIR/*.tgz)
+            helm push $CHART_PACKAGE oci://${{ env.REGISTRY }}/${{ github.repository }}/charts/
+          done
 
       - name: Get all changed kpis Chart.yaml files
         id: changed-chart-yaml-files-kpis
@@ -131,6 +152,13 @@ jobs:
         shell: bash
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-chart-yaml-files-kpis.outputs.all_changed_files }}
+        run: |
+          for CHART_FILE in ${ALL_CHANGED_FILES}; do
+            CHART_DIR=$(dirname $CHART_FILE)
+            helm package $CHART_DIR --dependency-update --destination $CHART_DIR
+            CHART_PACKAGE=$(ls $CHART_DIR/*.tgz)
+            helm push $CHART_PACKAGE oci://${{ env.REGISTRY }}/${{ github.repository }}/charts/
+          done
 
       - name: Get all changed syncer Chart.yaml files
         id: changed-chart-yaml-files-syncer
@@ -143,6 +171,13 @@ jobs:
         shell: bash
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-chart-yaml-files-syncer.outputs.all_changed_files }}
+        run: |
+          for CHART_FILE in ${ALL_CHANGED_FILES}; do
+            CHART_DIR=$(dirname $CHART_FILE)
+            helm package $CHART_DIR --dependency-update --destination $CHART_DIR
+            CHART_PACKAGE=$(ls $CHART_DIR/*.tgz)
+            helm push $CHART_PACKAGE oci://${{ env.REGISTRY }}/${{ github.repository }}/charts/
+          done
 
       - name: Get all changed decisions Chart.yaml files
         id: changed-chart-yaml-files-decisions


### PR DESCRIPTION
The push charts workflow got triggered when creating a new PR: (YEK ?)

https://github.com/cobaltcore-dev/cortex/actions/runs/18461078322

It failed with the following error:
```
[Invalid workflow file: .github/workflows/push-charts.yaml#L1](https://github.com/cobaltcore-dev/cortex/actions/runs/18461078322/workflow)
(Line: 93, Col: 9): Required property is missing: run, (Line: 105, Col: 9): Required property is missing: run, (Line: 117, Col: 9): Required property is missing: run, (Line: 129, Col: 9): Required property is missing: run, (Line: 141, Col: 9): Required property is missing: run
```

@PhilippMatthes Since these were `descheduler`, `scheduler`, `kpis` and `extractor` I wonder if you had a reason not to push them? But if so, why are they included in this workflow in the first place?
