### PR TITLE
Enable auto merge for minor and patches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,9 @@
   },
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "osvVulnerabilityAlerts": true,
+  "platformAutomerge": true,
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"
@@ -42,6 +45,7 @@
         "minor",
         "patch"
       ],
+      "automerge": true,
       "groupName": "External dependencies"
     },
     {


### PR DESCRIPTION
With only one Go module remaining (no weird dependencies anymore) we can safely automate the merge process for renovate PRs. 

## Changes

- Added `platformAutomerge: true` to enable GitHub's native automerge feature
- Added `automergeType: "pr"` to wait for CI workflows before merging
- Added `automergeStrategy: "squash"`
- Enabled automerge for all `github.com/sapcc/*` packages
- Enabled automerge for minor and patch updates of external dependencies

What will NOT be automerged: 
- Major version updates of external dependencies (requires manual review)
- Any PR where CI fails (Prayge, time will tell)
- Updates to `golang` package (pinned to 1.25.x)