### PR TITLE
Add custom openstack client implementation

### DIFF
--- a/internal/knowledge/datasources/openstack/manila/manila_api.go
+++ b/internal/knowledge/datasources/openstack/manila/manila_api.go
@@ -61,8 +61,7 @@ func (api *manilaAPI) GetAllStoragePools(ctx context.Context) ([]StoragePool, er
 	}
 
 	var pools []StoragePool
-	err := api.client.List(ctx, "shares/detail", url.Values{"all_tenants": []string{"true"}}, "pools", &pools)
-	if err != nil {
+	if err := api.client.List(ctx, "shares/detail", url.Values{"all_tenants": []string{"true"}}, "pools", &pools); err != nil {
 		return nil, err
 	}
 	slog.Info("fetched", "label", label, "count", len(pools))

--- a/internal/knowledge/datasources/openstack/nova/nova_api.go
+++ b/internal/knowledge/datasources/openstack/nova/nova_api.go
@@ -72,8 +72,7 @@ func (api *novaAPI) GetAllServers(ctx context.Context) ([]Server, error) {
 	}
 
 	var allServers []Server
-	err := api.client.List(ctx, "servers/detail", url.Values{"all_tenants": []string{"true"}}, "servers", &allServers)
-	if err != nil {
+	if err := api.client.List(ctx, "servers/detail", url.Values{"all_tenants": []string{"true"}}, "servers", &allServers); err != nil {
 		return nil, err
 	}
 	slog.Info("fetched", "label", label, "count", len(allServers))
@@ -102,8 +101,7 @@ func (api *novaAPI) GetDeletedServers(ctx context.Context, since time.Time) ([]D
 		"all_tenants":   []string{"true"},
 		"changes-since": []string{since.Format(time.RFC3339)},
 	}
-	err := api.client.List(ctx, "servers/detail", query, "servers", &allDeletedServers)
-	if err != nil {
+	if err := api.client.List(ctx, "servers/detail", query, "servers", &allDeletedServers); err != nil {
 		return nil, err
 	}
 	slog.Info("fetched", "label", label, "count", len(allDeletedServers))
@@ -121,8 +119,7 @@ func (api *novaAPI) GetAllHypervisors(ctx context.Context) ([]Hypervisor, error)
 	}
 
 	var hypervisors []Hypervisor
-	err := api.client.List(ctx, "os-hypervisors/detail", url.Values{}, "hypervisors", &hypervisors)
-	if err != nil {
+	if err := api.client.List(ctx, "os-hypervisors/detail", url.Values{}, "hypervisors", &hypervisors); err != nil {
 		return nil, err
 	}
 	slog.Info("fetched", "label", label, "count", len(hypervisors))
@@ -139,8 +136,7 @@ func (api *novaAPI) GetAllFlavors(ctx context.Context) ([]Flavor, error) {
 		"all_tenants": []string{"true"},
 	}
 
-	err := api.client.List(ctx, "flavors/detail", query, "flavors", &flavors)
-	if err != nil {
+	if err := api.client.List(ctx, "flavors/detail", query, "flavors", &flavors); err != nil {
 		return nil, err
 	}
 	slog.Info("fetched", "label", label, "count", len(flavors))
@@ -169,8 +165,7 @@ func (api *novaAPI) GetAllMigrations(ctx context.Context) ([]Migration, error) {
 	}
 
 	var migrations []Migration
-	err := api.client.List(ctx, "os-migrations", url.Values{}, "migrations", &migrations)
-	if err != nil {
+	if err := api.client.List(ctx, "os-migrations", url.Values{}, "migrations", &migrations); err != nil {
 		return nil, err
 	}
 	slog.Info("fetched", "label", label, "count", len(migrations))
@@ -183,8 +178,7 @@ func (api *novaAPI) GetAllAggregates(ctx context.Context) ([]Aggregate, error) {
 	slog.Info("fetching nova data", "label", label)
 
 	var rawAggregates []RawAggregate
-	err := api.client.List(ctx, "os-aggregates", url.Values{}, "aggregates", &rawAggregates)
-	if err != nil {
+	if err := api.client.List(ctx, "os-aggregates", url.Values{}, "aggregates", &rawAggregates); err != nil {
 		return nil, err
 	}
 	slog.Info("fetched", "label", label, "count", len(rawAggregates))

--- a/internal/scheduling/decisions/cinder/cleanup.go
+++ b/internal/scheduling/decisions/cinder/cleanup.go
@@ -5,17 +5,16 @@ package cinder
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 
 	"github.com/cobaltcore-dev/cortex/api/v1alpha1"
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	"github.com/cobaltcore-dev/cortex/pkg/openstack"
 
 	"github.com/cobaltcore-dev/cortex/pkg/keystone"
 	"github.com/cobaltcore-dev/cortex/pkg/sso"
-	"github.com/gophercloud/gophercloud/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,62 +34,19 @@ func Cleanup(ctx context.Context, client client.Client, conf conf.Config) error 
 	if err != nil {
 		return err
 	}
-	pc := authenticatedKeystone.Client()
-	cinderURL, err := pc.EndpointLocator(gophercloud.EndpointOpts{
-		Type:         "volumev3",
-		Availability: gophercloud.Availability(authenticatedKeystone.Availability()),
-	})
+
+	cinderClient, err := openstack.CinderClient(ctx, authenticatedKeystone)
 	if err != nil {
 		return err
 	}
-	cinderSC := &gophercloud.ServiceClient{
-		ProviderClient: pc,
-		Endpoint:       cinderURL,
-		Microversion:   "3.70",
-	}
-
-	initialURL := cinderSC.Endpoint + "volumes/detail?all_tenants=true"
-	var nextURL = &initialURL
 	var volumes []struct {
 		ID string `json:"id"`
 	}
-
-	for nextURL != nil {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, *nextURL, http.NoBody)
-		if err != nil {
-			return err
-		}
-		req.Header.Set("X-Auth-Token", cinderSC.Token())
-		req.Header.Set("OpenStack-API-Version", "volume "+cinderSC.Microversion)
-		resp, err := cinderSC.HTTPClient.Do(req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		}
-		var list struct {
-			Volumes []struct {
-				ID string `json:"id"`
-			} `json:"volumes"`
-			Links []struct {
-				Rel  string `json:"rel"`
-				Href string `json:"href"`
-			} `json:"volumes_links"`
-		}
-		err = json.NewDecoder(resp.Body).Decode(&list)
-		if err != nil {
-			return err
-		}
-		volumes = append(volumes, list.Volumes...)
-		nextURL = nil
-		for _, link := range list.Links {
-			if link.Rel == "next" {
-				nextURL = &link.Href
-				break
-			}
-		}
+	query := url.Values{
+		"all_tenants": []string{"true"},
+	}
+	if err := cinderClient.List(ctx, "volumes/detail", query, "volumes", &volumes); err != nil {
+		return err
 	}
 
 	slog.Info("found volumes", "count", len(volumes))

--- a/pkg/openstack/cinder.go
+++ b/pkg/openstack/cinder.go
@@ -1,0 +1,44 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cobaltcore-dev/cortex/pkg/keystone"
+	"github.com/gophercloud/gophercloud/v2"
+)
+
+func CinderClient(ctx context.Context, keystoneAPI keystone.KeystoneAPI) (*OpenstackClient, error) {
+	if err := keystoneAPI.Authenticate(ctx); err != nil {
+		return nil, fmt.Errorf("failed to authenticate keystone: %w", err)
+	}
+	// Automatically fetch the nova endpoint from the keystone service catalog.
+	provider := keystoneAPI.Client()
+	serviceType := "volumev3"
+	sameAsKeystone := keystoneAPI.Availability()
+	url, err := keystoneAPI.FindEndpoint(sameAsKeystone, serviceType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find cinder endpoint: %w", err)
+	}
+
+	microversion := "3.70"
+	slog.Info("using cinder endpoint", "url", url)
+	serviceClient := &gophercloud.ServiceClient{
+		ProviderClient: provider,
+		Endpoint:       url,
+		Microversion:   microversion,
+	}
+
+	apiVersionHeaderKey := "OpenStack-API-Version"
+	apiVersionHeader := "volume " + microversion
+	return &OpenstackClient{
+		keystoneAPI:         keystoneAPI,
+		serviceClient:       serviceClient,
+		apiVersionHeaderKey: &apiVersionHeaderKey,
+		apiVersionHeader:    &apiVersionHeader,
+	}, nil
+}

--- a/pkg/openstack/identity.go
+++ b/pkg/openstack/identity.go
@@ -1,0 +1,36 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cobaltcore-dev/cortex/pkg/keystone"
+	"github.com/gophercloud/gophercloud/v2"
+)
+
+func IdentityClient(ctx context.Context, keystoneAPI keystone.KeystoneAPI) (*OpenstackClient, error) {
+	if err := keystoneAPI.Authenticate(ctx); err != nil {
+		return nil, fmt.Errorf("failed to authenticate keystone: %w", err)
+	}
+	// Automatically fetch the nova endpoint from the keystone service catalog.
+	provider := keystoneAPI.Client()
+	serviceType := "identity"
+	url, err := keystoneAPI.FindEndpoint("public", serviceType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find identity endpoint: %w", err)
+	}
+
+	slog.Info("using identity endpoint", "url", url)
+	serviceClient := &gophercloud.ServiceClient{
+		ProviderClient: provider,
+		Endpoint:       url,
+	}
+	return &OpenstackClient{
+		keystoneAPI:   keystoneAPI,
+		serviceClient: serviceClient,
+	}, nil
+}

--- a/pkg/openstack/limes.go
+++ b/pkg/openstack/limes.go
@@ -1,0 +1,39 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cobaltcore-dev/cortex/pkg/keystone"
+	"github.com/gophercloud/gophercloud/v2"
+)
+
+func LimesClient(ctx context.Context, keystoneAPI keystone.KeystoneAPI) (*OpenstackClient, error) {
+	if err := keystoneAPI.Authenticate(ctx); err != nil {
+		return nil, fmt.Errorf("failed to authenticate keystone: %w", err)
+	}
+
+	// Automatically fetch the limes endpoint from the keystone service catalog.
+	// See: https://github.com/sapcc/limes/blob/5ea068b/docs/users/api-example.md?plain=1#L23
+	provider := keystoneAPI.Client()
+
+	serviceType := "resources"
+	sameAsKeystone := keystoneAPI.Availability()
+	url, err := keystoneAPI.FindEndpoint(sameAsKeystone, serviceType)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceClient := &gophercloud.ServiceClient{
+		ProviderClient: provider,
+		Endpoint:       url,
+		Type:           serviceType,
+	}
+	return &OpenstackClient{
+		keystoneAPI:   keystoneAPI,
+		serviceClient: serviceClient,
+	}, nil
+}

--- a/pkg/openstack/manila.go
+++ b/pkg/openstack/manila.go
@@ -1,0 +1,44 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cobaltcore-dev/cortex/pkg/keystone"
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+)
+
+func ManilaClient(ctx context.Context, keystoneAPI keystone.KeystoneAPI) (*OpenstackClient, error) {
+	if err := keystoneAPI.Authenticate(ctx); err != nil {
+		return nil, fmt.Errorf("failed to authenticate keystone: %w", err)
+	}
+	// Automatically fetch the nova endpoint from the keystone service catalog.
+	provider := keystoneAPI.Client()
+
+	gophercloud.ServiceTypeAliases["shared-file-system"] = []string{"sharev2"}
+	manilaSC, err := openstack.NewSharedFileSystemV2(provider, gophercloud.EndpointOpts{
+		Type:         "sharev2",
+		Availability: gophercloud.Availability(keystoneAPI.Availability()),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	microversion := "2.65"
+	manilaSC.Microversion = microversion
+
+	slog.Info("using manila endpoint", "url", manilaSC.Endpoint)
+
+	apiVersionHeaderKey := "X-OpenStack-Manila-API-Version"
+	return &OpenstackClient{
+		keystoneAPI:         keystoneAPI,
+		serviceClient:       manilaSC,
+		apiVersionHeaderKey: &apiVersionHeaderKey,
+		apiVersionHeader:    &microversion,
+	}, nil
+}

--- a/pkg/openstack/nova.go
+++ b/pkg/openstack/nova.go
@@ -1,0 +1,46 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cobaltcore-dev/cortex/pkg/keystone"
+	"github.com/gophercloud/gophercloud/v2"
+)
+
+func NovaClient(ctx context.Context, keystoneAPI keystone.KeystoneAPI) (*OpenstackClient, error) {
+	if err := keystoneAPI.Authenticate(ctx); err != nil {
+		return nil, fmt.Errorf("failed to authenticate keystone: %w", err)
+	}
+	// Automatically fetch the nova endpoint from the keystone service catalog.
+	provider := keystoneAPI.Client()
+	serviceType := "compute"
+	sameAsKeystone := keystoneAPI.Availability()
+	url, err := keystoneAPI.FindEndpoint(sameAsKeystone, serviceType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find nova endpoint: %w", err)
+	}
+
+	microversion := "2.61"
+	slog.Info("using nova endpoint", "url", url)
+	serviceClient := &gophercloud.ServiceClient{
+		ProviderClient: provider,
+		Endpoint:       url,
+		// Since microversion 2.53, the hypervisor id and service id is a UUID.
+		// We need that to find placement resource providers for hypervisors.
+		// Since 2.61, the extra_specs are returned in the flavor details.
+		Microversion: microversion,
+	}
+
+	apiVersionHeaderKey := "X-OpenStack-Nova-API-Version"
+	return &OpenstackClient{
+		keystoneAPI:         keystoneAPI,
+		serviceClient:       serviceClient,
+		apiVersionHeaderKey: &apiVersionHeaderKey,
+		apiVersionHeader:    &microversion,
+	}, nil
+}

--- a/pkg/openstack/placement.go
+++ b/pkg/openstack/placement.go
@@ -1,0 +1,45 @@
+// Copyright 2025 SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cobaltcore-dev/cortex/pkg/keystone"
+	"github.com/gophercloud/gophercloud/v2"
+)
+
+func PlacementClient(ctx context.Context, keystoneAPI keystone.KeystoneAPI) (*OpenstackClient, error) {
+	if err := keystoneAPI.Authenticate(ctx); err != nil {
+		return nil, fmt.Errorf("failed to authenticate keystone: %w", err)
+	}
+	// Automatically fetch the nova endpoint from the keystone service catalog.
+	provider := keystoneAPI.Client()
+	serviceType := "placement"
+	sameAsKeystone := keystoneAPI.Availability()
+	url, err := keystoneAPI.FindEndpoint(sameAsKeystone, serviceType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find placement endpoint: %w", err)
+	}
+
+	microversion := "1.29"
+	slog.Info("using placement endpoint", "url", url)
+	serviceClient := &gophercloud.ServiceClient{
+		ProviderClient: provider,
+		Endpoint:       url,
+		// Needed, otherwise openstack will return 404s for traits.
+		Microversion: microversion,
+	}
+
+	apiVersionHeaderKey := "OpenStack-API-Version"
+	apiVersionHeader := "placement " + microversion
+	return &OpenstackClient{
+		keystoneAPI:         keystoneAPI,
+		serviceClient:       serviceClient,
+		apiVersionHeaderKey: &apiVersionHeaderKey,
+		apiVersionHeader:    &apiVersionHeader,
+	}, nil
+}


### PR DESCRIPTION
We want to get rid of gophercloud since we had lots of obscure issues with it.

## Changes
- Implement custom openstack client with pagination and authentication
- Replace usage of gophercloud with custom openstack client

## ToDo
- [x] Implement this for other syncers as well (clean up tasks ...)
- [x] Do it for limes + identity as well
- [ ] Placement
- [ ] Reservations operator
- [ ] Internally still has a dependency on gophercloud, maybe we can get rid of this as well
- [ ] Test that it works as expected
- [ ] Descheduling
- [ ] e2e tests
- [ ] Keystone?
- [ ] Workload spawner
- [ ] Fix limit in nova servers endpoint e2e test