### PR TITLE
Fix KPI unready alert

### DIFF
--- a/helm/bundles/cortex-nova/alerts/nova.alerts.yaml
+++ b/helm/bundles/cortex-nova/alerts/nova.alerts.yaml
@@ -244,8 +244,7 @@ groups:
 
   - alert: CortexNovaKPIUnready
     expr: |
-      cortex_kpi_state{domain="nova",state!="ready"} != 0 or
-      absent(cortex_kpi_state{domain="nova"})
+      cortex_kpi_state{domain="nova",state!="ready"} != 0
     for: 60m
     labels:
       context: kpis


### PR DESCRIPTION
## Changes

- Adjusted `domain` label to be `nova` (before `cortex-nova`)
- Removed `absent` check from KPI unready alert

If we want to check if there is NO KPI at all (and datasource, knowledge, ...) we would need to create a separate alert for this, since `absent` wont return the name of the custom resource in this case. 