### PR TITLE
Fix SHA length mismatch between Docker image tags and Helm chart appVersions

### DIFF
--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -49,6 +49,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             latest
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
       - name: Build and Push Cortex Postgres
         if: steps.changed_postgres_files.outputs.all_changed_files != ''
         id: push_cortex_postgres
@@ -81,6 +83,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             latest
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
       - name: Build and Push Cortex
         id: push_cortex
         uses: docker/build-push-action@v6

--- a/.github/workflows/update-appversion.yml
+++ b/.github/workflows/update-appversion.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get short commit SHA
         id: vars
-        run: echo "sha=sha-$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+        run: echo "sha=sha-$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT
 
       - name: Get all changed postgres/ files
         id: changed_postgres_files


### PR DESCRIPTION
## Context

Since Friday (23.01.2026), the update-appversion workflow started generating 8-character short hashes using `git rev-parse --short HEAD`. This happens when Git detects potential collisions in the repository's commit history.

The `docker/metadata-action` uses a fixed length of 7 characters by default ([docs](https://github.com/docker/metadata-action?tab=readme-ov-file#typesha)), causing a mismatch between the pushed Docker image tags (7 chars, eg. `sha-7f3a6ce`) and the appVersion in Helm charts (8 chars, eg. `sha-7f3a6ce1`).

## Changes

- Set `DOCKER_METADATA_SHORT_SHA_LENGTH: 8` in `push-images.yaml` for both Cortex and Cortex Postgres image builds
- Set `--short=8` in `update-appversion.yml` to force consistent 8-character SHAs
- This ensures both workflows generate matching SHA tags and provides better hash collision resistance