### PR TITLE
Fix multicluster indexing

### DIFF
--- a/docs/guides/multicluster/readme.md
+++ b/docs/guides/multicluster/readme.md
@@ -79,6 +79,10 @@ tee $TILT_OVERRIDES_PATH <<EOF
 global:
   conf:
     apiServerOverrides:
+    - gvk: cortex.cloud/v1alpha1/DecisionList
+      host: https://host.docker.internal:8444
+      caCert: |
+$(cat /tmp/root-ca-remote.pem | sed 's/^/        /')
     - gvk: cortex.cloud/v1alpha1/Decision
       host: https://host.docker.internal:8444
       caCert: |


### PR DESCRIPTION
With the current multicluster implementation, the client will create subclients and associated caches for each resource registered. Since we're registering the resource and resource list type separately, two caches will be created. This opens up potential issues when indexing the wrong cache, as seen in the explanations controller. Here, we declared an index on the single resource, while requesting a List with a indexed field. With this PR we provide a new IndexField method on the multicluster client which handles these intricacies, abstracting them away from the controller implementation.