### PR TITLE
Move pkg/tools/histogram to knowledge/math

### DIFF
--- a/internal/knowledge/extractor/plugins/compute/vm_host_residency.go
+++ b/internal/knowledge/extractor/plugins/compute/vm_host_residency.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/extractor/plugins"
-	"github.com/cobaltcore-dev/cortex/pkg/tools"
+	"github.com/cobaltcore-dev/cortex/internal/knowledge/math"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -68,7 +68,7 @@ func (e *VMHostResidencyExtractor) Extract() ([]plugins.Feature, error) {
 	valueFunc := func(hostResidency VMHostResidencyRaw) float64 {
 		return float64(hostResidency.Duration)
 	}
-	hists, counts, sums := tools.Histogram(hostResidencies, buckets, keysFunc, valueFunc)
+	hists, counts, sums := math.Histogram(hostResidencies, buckets, keysFunc, valueFunc)
 	var features []VMHostResidencyHistogramBucket
 	for key, hist := range hists {
 		labels := strings.Split(key, ",")

--- a/internal/knowledge/extractor/plugins/compute/vm_life_span.go
+++ b/internal/knowledge/extractor/plugins/compute/vm_life_span.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/extractor/plugins"
-	"github.com/cobaltcore-dev/cortex/pkg/tools"
+	"github.com/cobaltcore-dev/cortex/internal/knowledge/math"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -66,7 +66,7 @@ func extractHistogramBuckets(lifeSpansRaw []VMLifeSpanRaw, deleted bool) []VMLif
 	valueFunc := func(lifeSpan VMLifeSpanRaw) float64 {
 		return float64(lifeSpan.Duration)
 	}
-	hists, counts, sums := tools.Histogram(lifeSpans, buckets, keysFunc, valueFunc)
+	hists, counts, sums := math.Histogram(lifeSpans, buckets, keysFunc, valueFunc)
 	var features []VMLifeSpanHistogramBucket
 	for key, hist := range hists {
 		labels := strings.Split(key, ",")

--- a/internal/knowledge/kpis/plugins/compute/host_contention.go
+++ b/internal/knowledge/kpis/plugins/compute/host_contention.go
@@ -11,8 +11,8 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/db"
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/extractor/plugins/compute"
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/kpis/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/knowledge/math"
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
-	"github.com/cobaltcore-dev/cortex/pkg/tools"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -74,7 +74,7 @@ func (k *VMwareHostContentionKPI) Collect(ch chan<- prometheus.Metric) {
 	valueFunc := func(contention compute.VROpsHostsystemContentionLongTerm) float64 {
 		return contention.MaxCPUContention
 	}
-	hists, counts, sums := tools.Histogram(contentions, buckets, keysFunc, valueFunc)
+	hists, counts, sums := math.Histogram(contentions, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.hostCPUContentionMax, counts[key], sums[key], hist)
 	}
@@ -84,7 +84,7 @@ func (k *VMwareHostContentionKPI) Collect(ch chan<- prometheus.Metric) {
 	valueFunc = func(contention compute.VROpsHostsystemContentionLongTerm) float64 {
 		return float64(contention.AvgCPUContention)
 	}
-	hists, counts, sums = tools.Histogram(contentions, buckets, keysFunc, valueFunc)
+	hists, counts, sums = math.Histogram(contentions, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.hostCPUContentionAvg, counts[key], sums[key], hist)
 	}

--- a/internal/knowledge/kpis/plugins/compute/project_noisiness.go
+++ b/internal/knowledge/kpis/plugins/compute/project_noisiness.go
@@ -11,8 +11,8 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/db"
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/extractor/plugins/compute"
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/kpis/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/knowledge/math"
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
-	"github.com/cobaltcore-dev/cortex/pkg/tools"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -67,7 +67,7 @@ func (k *VMwareProjectNoisinessKPI) Collect(ch chan<- prometheus.Metric) {
 	valueFunc := func(noisiness compute.VROpsProjectNoisiness) float64 {
 		return float64(noisiness.AvgCPUOfProject)
 	}
-	hists, counts, sums := tools.Histogram(features, buckets, keysFunc, valueFunc)
+	hists, counts, sums := math.Histogram(features, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.projectNoisinessDesc, counts[key], sums[key], hist)
 	}

--- a/internal/knowledge/kpis/plugins/storage/storage_pool_cpu.go
+++ b/internal/knowledge/kpis/plugins/storage/storage_pool_cpu.go
@@ -11,8 +11,8 @@ import (
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/db"
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/extractor/plugins/storage"
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/kpis/plugins"
+	"github.com/cobaltcore-dev/cortex/internal/knowledge/math"
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
-	"github.com/cobaltcore-dev/cortex/pkg/tools"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -74,7 +74,7 @@ func (k *NetAppStoragePoolCPUUsageKPI) Collect(ch chan<- prometheus.Metric) {
 	valueFunc := func(usage storage.StoragePoolCPUUsage) float64 {
 		return usage.MaxCPUUsagePct
 	}
-	hists, counts, sums := tools.Histogram(usages, buckets, keysFunc, valueFunc)
+	hists, counts, sums := math.Histogram(usages, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.storagePoolCPUUsageMax, counts[key], sums[key], hist)
 	}
@@ -84,7 +84,7 @@ func (k *NetAppStoragePoolCPUUsageKPI) Collect(ch chan<- prometheus.Metric) {
 	valueFunc = func(usage storage.StoragePoolCPUUsage) float64 {
 		return float64(usage.AvgCPUUsagePct)
 	}
-	hists, counts, sums = tools.Histogram(usages, buckets, keysFunc, valueFunc)
+	hists, counts, sums = math.Histogram(usages, buckets, keysFunc, valueFunc)
 	for key, hist := range hists {
 		ch <- prometheus.MustNewConstHistogram(k.storagePoolCPUUsageAvg, counts[key], sums[key], hist)
 	}

--- a/internal/knowledge/math/histogram.go
+++ b/internal/knowledge/math/histogram.go
@@ -1,7 +1,7 @@
 // Copyright SAP SE
 // SPDX-License-Identifier: Apache-2.0
 
-package tools
+package math
 
 // Create a histogram from features.
 func Histogram[O any](

--- a/internal/knowledge/math/histogram_test.go
+++ b/internal/knowledge/math/histogram_test.go
@@ -1,7 +1,7 @@
 // Copyright SAP SE
 // SPDX-License-Identifier: Apache-2.0
 
-package tools
+package math
 
 import (
 	"reflect"


### PR DESCRIPTION
We provide a histogram helper function which is used in knowledge extractors as well as kpis. Since this module is not needed for the scheduler, it should be moved under knowledge/.