### PR TITLE
Provide helper to initialize multicluster client, pull out config

### DIFF
--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -12,19 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// Config which maps a kubernetes resource URI to a remote kubernetes apiserver.
-// This override config can be used to manage CRDs in a different kubernetes cluster.
-// It is assumed that the remote apiserver accepts the serviceaccount tokens
-// issued by the local cluster.
-type APIServerOverrideConfig struct {
-	// The resource GVK formatted as "<group>/<version>", e.g. "cortex.cloud/v1alpha1/Decision"
-	GVK string `json:"gvk"`
-	// The remote kubernetes apiserver url, e.g. "https://my-apiserver:6443"
-	Host string `json:"host"`
-	// The root CA certificate to verify the remote apiserver.
-	CACert string `json:"caCert,omitempty"`
-}
-
 // Configuration for the monitoring module.
 type MonitoringConfig struct {
 	// The labels to add to all metrics.
@@ -67,9 +54,6 @@ type Config struct {
 
 	// Monitoring configuration
 	Monitoring MonitoringConfig `json:"monitoring"`
-
-	// Apiserver overrides.
-	APIServerOverrides []APIServerOverrideConfig `json:"apiServerOverrides,omitempty"`
 }
 
 // Create a new configuration from the default config json file.


### PR DESCRIPTION
At the moment we have lots of code in out main.go which initializes the multicluster client. This change pulls out the code into the multicluster client library, and also pulls out the conf struct from pkg/conf which should only contain shared logic to load configs.