### PR TITLE
Move monitoring config to monitoring module

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -265,7 +265,8 @@ func main() {
 
 	// Our custom monitoring registry can add prometheus labels to all metrics.
 	// This is useful to distinguish metrics from different deployments.
-	metrics.Registry = monitoring.WrapRegistry(metrics.Registry, config.Monitoring)
+	metricsConfig := conf.GetConfigOrDie[monitoring.Config]()
+	metrics.Registry = monitoring.WrapRegistry(metrics.Registry, metricsConfig)
 
 	// TODO: Remove me after scheduling pipeline steps don't require DB connections anymore.
 	metrics.Registry.MustRegister(&db.Monitor)

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -12,15 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// Configuration for the monitoring module.
-type MonitoringConfig struct {
-	// The labels to add to all metrics.
-	Labels map[string]string `json:"labels"`
-
-	// The port to expose the metrics on.
-	Port int `json:"port"`
-}
-
 // Endpoints for the reservations operator.
 type EndpointsConfig struct {
 	// The nova external scheduler endpoint.
@@ -51,9 +42,6 @@ type Config struct {
 
 	// List of enabled tasks.
 	EnabledTasks []string `json:"enabledTasks"`
-
-	// Monitoring configuration
-	Monitoring MonitoringConfig `json:"monitoring"`
 }
 
 // Create a new configuration from the default config json file.

--- a/pkg/monitoring/registry_test.go
+++ b/pkg/monitoring/registry_test.go
@@ -6,34 +6,33 @@ package monitoring
 import (
 	"testing"
 
-	"github.com/cobaltcore-dev/cortex/pkg/conf"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestNewRegistry(t *testing.T) {
-	config := conf.MonitoringConfig{
+	config := RegistryConfig{
 		Labels: map[string]string{
 			"env": "test",
 		},
 	}
-	registry := NewRegistry(config)
+	registry := NewRegistry(Config{Monitoring: config})
 
 	if registry == nil {
 		t.Fatalf("expected registry to be non-nil")
 		return
 	}
-	if registry.config.Labels["env"] != "test" {
-		t.Fatalf("expected registry config label 'env' to be 'test', got %v", registry.config.Labels["env"])
+	if registry.config.Monitoring.Labels["env"] != "test" {
+		t.Fatalf("expected registry config label 'env' to be 'test', got %v", registry.config.Monitoring.Labels["env"])
 	}
 }
 
 func TestRegistry_Gather(t *testing.T) {
-	config := conf.MonitoringConfig{
+	config := RegistryConfig{
 		Labels: map[string]string{
 			"env": "test",
 		},
 	}
-	registry := NewRegistry(config)
+	registry := NewRegistry(Config{Monitoring: config})
 
 	// Register a custom metric
 	counter := prometheus.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
The monitoring module should be self contained and the conf package should only contain shared logic to load the different configs.