### PR TITLE
configure Renovate to track Makefile tool versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,26 @@
     "gomodTidy",
     "gomodUpdateImportPaths"
   ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": ["CONTROLLER_TOOLS_VERSION \\?= (?<currentValue>v[\\d.]+)"],
+      "depNameTemplate": "sigs.k8s.io/controller-tools",
+      "datasourceTemplate": "go"
+    },
+    {
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": ["GOLANGCI_LINT_VERSION \\?= (?<currentValue>v[\\d.]+)"],
+      "depNameTemplate": "github.com/golangci/golangci-lint/v2",
+      "datasourceTemplate": "go"
+    },
+    {
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": ["GOTESTSUM_VERSION \\?= (?<currentValue>v[\\d.]+)"],
+      "depNameTemplate": "gotest.tools/gotestsum",
+      "datasourceTemplate": "go"
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": [

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cobaltcore-dev/cortex
 
 go 1.26
 
+toolchain go1.26.1
+
 require (
 	github.com/cobaltcore-dev/openstack-hypervisor-operator v1.0.2-0.20260402091752-888f1313a307
 	github.com/go-gorp/gorp v2.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/cobaltcore-dev/cortex
 
 go 1.26
 
-toolchain go1.26.1
-
 require (
 	github.com/cobaltcore-dev/openstack-hypervisor-operator v1.0.2-0.20260402091752-888f1313a307
 	github.com/go-gorp/gorp v2.2.0+incompatible

--- a/internal/scheduling/reservations/commitments/api_change_commitments.go
+++ b/internal/scheduling/reservations/commitments/api_change_commitments.go
@@ -294,9 +294,9 @@ ProcessLoop:
 		// Build rejection reason from failed commitments
 		if len(failedCommitments) > 0 {
 			var reasonBuilder strings.Builder
-			reasonBuilder.WriteString(fmt.Sprintf("%d commitment(s) failed to apply: ", len(failedCommitments)))
+			fmt.Fprintf(&reasonBuilder, "%d commitment(s) failed to apply: ", len(failedCommitments))
 			for commitmentUUID, reason := range failedCommitments {
-				reasonBuilder.WriteString(fmt.Sprintf("\n- commitment %s: %s", commitmentUUID, reason))
+				fmt.Fprintf(&reasonBuilder, "\n- commitment %s: %s", commitmentUUID, reason)
 			}
 			resp.RejectionReason = reasonBuilder.String()
 		}

--- a/internal/scheduling/reservations/commitments/state.go
+++ b/internal/scheduling/reservations/commitments/state.go
@@ -194,7 +194,7 @@ func FromChangeCommitmentTargetState(
 	smallestFlavorMemoryBytes := int64(smallestFlavor.MemoryMB) * 1024 * 1024 //nolint:gosec // flavor memory from specs, realistically bounded
 
 	// Amount represents multiples of the smallest flavor in the group
-	totalMemoryBytes := int64(amountMultiple) * smallestFlavorMemoryBytes //nolint:gosec // commitment amount from Limes API, bounded by quota limits
+	totalMemoryBytes := int64(amountMultiple) * smallestFlavorMemoryBytes //nolint:gosec // commitment amount from Limes API, realistically bounded
 
 	return &CommitmentState{
 		CommitmentUUID:   string(commitment.UUID),

--- a/tools/logs/parser.go
+++ b/tools/logs/parser.go
@@ -450,7 +450,7 @@ func formatWeightMapFullColorized(weights map[string]float64, indent int) string
 		if i%4 == 0 {
 			sb.WriteString(indentStr)
 		}
-		sb.WriteString(fmt.Sprintf("%s: %.4f", colorizeHost(hw.host), hw.weight))
+		fmt.Fprintf(&sb, "%s: %.4f", colorizeHost(hw.host), hw.weight)
 		if i < len(sorted)-1 {
 			sb.WriteString(", ")
 		}


### PR DESCRIPTION
This change updates Renovate to track versions pinned in the Makefile,
including golangci-lint, gotestsum, and controller-tools.