### PR TITLE
Add hypervisor family label for flavor usage kpi

### DIFF
--- a/internal/knowledge/kpis/plugins/compute/flavor_running_vms.go
+++ b/internal/knowledge/kpis/plugins/compute/flavor_running_vms.go
@@ -5,6 +5,7 @@ package compute
 
 import (
 	"log/slog"
+	"regexp"
 
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/datasources/plugins/openstack/identity"
 	"github.com/cobaltcore-dev/cortex/internal/knowledge/datasources/plugins/openstack/nova"
@@ -22,6 +23,10 @@ type FlavorRunningVMs struct {
 	ProjectID        string  `db:"project_id"`
 	ProjectName      string  `db:"project_name"`
 }
+
+// kvmFlavorPattern matches flavors where the second underscore-delimited
+// segment is "k", e.g. "type_k_cXXX_mXXXX".
+var kvmFlavorPattern = regexp.MustCompile(`^[^_]+_k_`)
 
 type FlavorRunningVMsKPI struct {
 	// Common base for all KPIs that provides standard functionality.
@@ -45,6 +50,7 @@ func (k *FlavorRunningVMsKPI) Init(db *db.DB, client client.Client, opts conf.Ra
 			"availability_zone",
 			"project_id",
 			"project_name",
+			"hypervisor_family",
 		},
 		nil,
 	)
@@ -83,6 +89,10 @@ func (k *FlavorRunningVMsKPI) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 	for _, r := range results {
+		hypervisorFamily := "vmware"
+		if kvmFlavorPattern.MatchString(r.FlavorName) {
+			hypervisorFamily = "kvm"
+		}
 		ch <- prometheus.MustNewConstMetric(
 			k.flavorRunningVMs,
 			prometheus.GaugeValue,
@@ -91,6 +101,7 @@ func (k *FlavorRunningVMsKPI) Collect(ch chan<- prometheus.Metric) {
 			r.AvailabilityZone,
 			r.ProjectID,
 			r.ProjectName,
+			hypervisorFamily,
 		)
 	}
 }

--- a/internal/knowledge/kpis/plugins/compute/flavor_running_vms_test.go
+++ b/internal/knowledge/kpis/plugins/compute/flavor_running_vms_test.go
@@ -38,33 +38,30 @@ func TestFlavorRunningVMsKPI_Collect(t *testing.T) {
 	}
 
 	mockData := []any{
+		// VMware flavor (no "_k_" segment)
 		&nova.Server{
 			ID:                    "id-1",
-			FlavorName:            "small",
+			FlavorName:            "small_vmware_flavor",
 			OSEXTAvailabilityZone: "zone1",
 			TenantID:              "project-1",
 		},
+		// KVM flavor ("_k_" as second segment)
 		&nova.Server{
 			ID:                    "id-2",
-			FlavorName:            "medium",
+			FlavorName:            "medium_k_flavor",
 			OSEXTAvailabilityZone: "zone1",
 			TenantID:              "project-1",
 		},
 		&nova.Server{
 			ID:                    "id-3",
-			FlavorName:            "medium",
-			OSEXTAvailabilityZone: "zone2",
+			FlavorName:            "medium_k_flavor",
+			OSEXTAvailabilityZone: "zone1",
 			TenantID:              "project-1",
 		},
+		// Another VMware flavor in a different zone and project
 		&nova.Server{
 			ID:                    "id-4",
-			FlavorName:            "medium",
-			OSEXTAvailabilityZone: "zone2",
-			TenantID:              "project-1",
-		},
-		&nova.Server{
-			ID:                    "id-5",
-			FlavorName:            "medium",
+			FlavorName:            "large_vmware_flavor",
 			OSEXTAvailabilityZone: "zone2",
 			TenantID:              "project-2",
 		},
@@ -98,9 +95,10 @@ func TestFlavorRunningVMsKPI_Collect(t *testing.T) {
 		RunningVMs       float64
 		ProjectID        string
 		ProjectName      string
+		HypervisorFamily string
 	}
 
-	metrics := make(map[string]FlavorRunningVMsMetric, 0)
+	metrics := make(map[string]FlavorRunningVMsMetric)
 
 	for metric := range ch {
 		var m prometheusgo.Metric
@@ -117,6 +115,7 @@ func TestFlavorRunningVMsKPI_Collect(t *testing.T) {
 		availabilityZone := labels["availability_zone"]
 		projectID := labels["project_id"]
 		projectName := labels["project_name"]
+		hypervisorFamily := labels["hypervisor_family"]
 
 		key := flavor + "|" + availabilityZone + "|" + projectID
 
@@ -126,37 +125,34 @@ func TestFlavorRunningVMsKPI_Collect(t *testing.T) {
 			ProjectID:        projectID,
 			ProjectName:      projectName,
 			RunningVMs:       m.GetGauge().GetValue(),
+			HypervisorFamily: hypervisorFamily,
 		}
 	}
 
 	expectedMetrics := map[string]FlavorRunningVMsMetric{
-		"small|zone1|project-1": {
-			FlavorName:       "small",
+		"small_vmware_flavor|zone1|project-1": {
+			FlavorName:       "small_vmware_flavor",
 			AvailabilityZone: "zone1",
 			ProjectID:        "project-1",
 			ProjectName:      "Project One",
 			RunningVMs:       1,
+			HypervisorFamily: "vmware",
 		},
-		"medium|zone1|project-1": {
-			FlavorName:       "medium",
+		"medium_k_flavor|zone1|project-1": {
+			FlavorName:       "medium_k_flavor",
 			AvailabilityZone: "zone1",
-			ProjectID:        "project-1",
-			ProjectName:      "Project One",
-			RunningVMs:       1,
-		},
-		"medium|zone2|project-1": {
-			FlavorName:       "medium",
-			AvailabilityZone: "zone2",
 			ProjectID:        "project-1",
 			ProjectName:      "Project One",
 			RunningVMs:       2,
+			HypervisorFamily: "kvm",
 		},
-		"medium|zone2|project-2": {
-			FlavorName:       "medium",
+		"large_vmware_flavor|zone2|project-2": {
+			FlavorName:       "large_vmware_flavor",
 			AvailabilityZone: "zone2",
-			RunningVMs:       1,
 			ProjectID:        "project-2",
 			ProjectName:      "Project Two",
+			RunningVMs:       1,
+			HypervisorFamily: "vmware",
 		},
 	}
 
@@ -166,9 +162,28 @@ func TestFlavorRunningVMsKPI_Collect(t *testing.T) {
 			t.Errorf("expected metric %q not found", key)
 			continue
 		}
-
 		if !reflect.DeepEqual(expected, actual) {
 			t.Errorf("metric %q: expected %+v, got %+v", key, expected, actual)
+		}
+	}
+}
+
+func TestKVMFlavorPattern(t *testing.T) {
+	tests := []struct {
+		flavor string
+		isKVM  bool
+	}{
+		{"x_k_c89_m7890_v2", true},
+		{"x_k_c89_m7890", true},
+		{"x_v_c12_m3456", false},
+		{"x_kvm_c12_m3456", false}, // "kvm" != "k"
+		{"k_c12_m3456", false},     // "k" must be second segment
+		{"", false},
+	}
+	for _, tc := range tests {
+		got := kvmFlavorPattern.MatchString(tc.flavor)
+		if got != tc.isKVM {
+			t.Errorf("kvmFlavorPattern.MatchString(%q) = %v, want %v", tc.flavor, got, tc.isKVM)
 		}
 	}
 }

--- a/tools/plutono/provisioning/dashboards/compute/flavors.json
+++ b/tools/plutono/provisioning/dashboards/compute/flavors.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 5,
-  "iteration": 1770195363564,
+  "id": 8,
+  "iteration": 1776069882965,
   "links": [],
   "panels": [
     {
@@ -89,7 +89,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sort_desc(sum(cortex_flavor_running_vms{project_name=~\"$project_name\", flavor_name=~\"$flavor_name\", availability_zone=~\"$availability_zone\"}) by (project_name, flavor_name))",
+          "expr": "sort_desc(sum(cortex_flavor_running_vms{project_name=~\"$project_name\", flavor_name=~\"$flavor_name\", availability_zone=~\"$availability_zone\", hypervisor_family=~\"$hypervisor_family\"}) by (project_name, flavor_name, hypervisor_family))",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -173,7 +173,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "topk(20,sort_desc(sum(cortex_flavor_running_vms{project_name=~\"$project_name\", flavor_name=~\"$flavor_name\", availability_zone=~\"$availability_zone\"}) by (flavor_name)))",
+          "expr": "topk(20,sort_desc(sum(cortex_flavor_running_vms{project_name=~\"$project_name\", flavor_name=~\"$flavor_name\", availability_zone=~\"$availability_zone\", hypervisor_family=~\"$hypervisor_family\"}) by (flavor_name)))",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -251,17 +251,10 @@
             "showHeader": true
           },
           "pluginVersion": "7.5.37",
-          "scopedVars": {
-            "availability_zone": {
-              "selected": false,
-              "text": "qa-de-1a",
-              "value": "qa-de-1a"
-            }
-          },
           "targets": [
             {
               "exemplar": true,
-              "expr": "sort_desc(cortex_flavor_running_vms{availability_zone=\"$availability_zone\", project_name=~\"$project_name\", flavor_name=~\"$flavor_name\"})",
+              "expr": "sort_desc(cortex_flavor_running_vms{availability_zone=\"$availability_zone\", project_name=~\"$project_name\", flavor_name=~\"$flavor_name\", hypervisor_family=~\"$hypervisor_family\"})",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -369,17 +362,10 @@
             "text": {}
           },
           "pluginVersion": "7.5.37",
-          "scopedVars": {
-            "availability_zone": {
-              "selected": false,
-              "text": "qa-de-1a",
-              "value": "qa-de-1a"
-            }
-          },
           "targets": [
             {
               "exemplar": true,
-              "expr": "topk(20, sum(cortex_flavor_running_vms{availability_zone=\"$availability_zone\", flavor_name=~\"$flavor_name\", project_name=~\"$project_name\"}) by (flavor_name))",
+              "expr": "topk(20, sum(cortex_flavor_running_vms{availability_zone=\"$availability_zone\", flavor_name=~\"$flavor_name\", project_name=~\"$project_name\", hypervisor_family=~\"$hypervisor_family\"}) by (flavor_name))",
               "instant": true,
               "interval": "",
               "legendFormat": "{{flavor_name}} ",
@@ -443,7 +429,6 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -479,7 +464,6 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -510,6 +494,42 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "prometheus-openstack",
+        "definition": "label_values(cortex_flavor_running_vms, hypervisor_family)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Hypervisor Family",
+        "multi": true,
+        "name": "hypervisor_family",
+        "options": [],
+        "query": {
+          "query": "label_values(cortex_flavor_running_vms, hypervisor_family)",
+          "refId": "prometheus-openstack-hypervisor_family-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -519,7 +539,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Cortex Compute Flavors",
+  "title": "Cortex Flavor Usage",
   "uid": "cortex-compute-flavors",
   "version": 2
 }

--- a/tools/plutono/provisioning/dashboards/compute/flavors.json
+++ b/tools/plutono/provisioning/dashboards/compute/flavors.json
@@ -117,7 +117,8 @@
             "renameByName": {
               "Value": "#",
               "flavor_name": "Flavor",
-              "project_name": "Project"
+              "project_name": "Project",
+              "hypervisor_family": "Hypervisor Family"
             }
           }
         }
@@ -309,7 +310,8 @@
                   "Value": "#",
                   "availability_zone": "",
                   "flavor_name": "Flavor",
-                  "project_name": "Project"
+                  "project_name": "Project",
+                  "hypervisor_family": "Hypervisor Family"
                 }
               }
             }


### PR DESCRIPTION
## Changes

- Add `hypervisor_family` label to flavor usage kpi
- Distinguishes based on SAP specific flavor names for kvm hypervisors