### PR TITLE
Support structured and traceable logging in placement shim

### DIFF
--- a/internal/shim/placement/handle_allocation_candidates.go
+++ b/internal/shim/placement/handle_allocation_candidates.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleListAllocationCandidates handles GET /allocation_candidates requests.
@@ -35,8 +33,5 @@ import (
 // inventory capacity and usage for informed decision-making. Available since
 // microversion 1.10.
 func (s *Shim) HandleListAllocationCandidates(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_allocations.go
+++ b/internal/shim/placement/handle_allocations.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleManageAllocations handles POST /allocations requests.
@@ -25,9 +23,6 @@ import (
 // success, or 409 Conflict if inventory is insufficient or a concurrent
 // update is detected (error code: placement.concurrent_update).
 func (s *Shim) HandleManageAllocations(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path)
 	s.forward(w, r)
 }
 
@@ -43,14 +38,9 @@ func (s *Shim) HandleManageAllocations(w http.ResponseWriter, r *http.Request) {
 // The consumer_generation and consumer_type fields are absent when the
 // consumer has no allocations.
 func (s *Shim) HandleListAllocations(w http.ResponseWriter, r *http.Request) {
-	consumerUUID, ok := requiredUUIDPathParam(w, r, "consumer_uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "consumer_uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path,
-		"consumer_uuid", consumerUUID)
 	s.forward(w, r)
 }
 
@@ -66,14 +56,9 @@ func (s *Shim) HandleListAllocations(w http.ResponseWriter, r *http.Request) {
 // Returns 204 No Content on success. Returns 409 Conflict if there is
 // insufficient inventory or if a concurrent update was detected.
 func (s *Shim) HandleUpdateAllocations(w http.ResponseWriter, r *http.Request) {
-	consumerUUID, ok := requiredUUIDPathParam(w, r, "consumer_uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "consumer_uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path,
-		"consumer_uuid", consumerUUID)
 	s.forward(w, r)
 }
 
@@ -83,13 +68,8 @@ func (s *Shim) HandleUpdateAllocations(w http.ResponseWriter, r *http.Request) {
 // providers. Returns 204 No Content on success, or 404 Not Found if the
 // consumer has no existing allocations.
 func (s *Shim) HandleDeleteAllocations(w http.ResponseWriter, r *http.Request) {
-	consumerUUID, ok := requiredUUIDPathParam(w, r, "consumer_uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "consumer_uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path,
-		"consumer_uuid", consumerUUID)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_reshaper.go
+++ b/internal/shim/placement/handle_reshaper.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandlePostReshaper handles POST /reshaper requests.
@@ -25,8 +23,5 @@ import (
 // resource provider does not exist or if inventory/allocation constraints
 // would be violated. Available since microversion 1.30.
 func (s *Shim) HandlePostReshaper(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_resource_classes.go
+++ b/internal/shim/placement/handle_resource_classes.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleListResourceClasses handles GET /resource_classes requests.
@@ -17,9 +15,6 @@ import (
 // categorize the types of resources that resource providers can offer as
 // inventory. Available since microversion 1.2.
 func (s *Shim) HandleListResourceClasses(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path)
 	s.forward(w, r)
 }
 
@@ -31,9 +26,6 @@ func (s *Shim) HandleListResourceClasses(w http.ResponseWriter, r *http.Request)
 // is missing, and 409 Conflict if a class with the same name already exists.
 // Available since microversion 1.2.
 func (s *Shim) HandleCreateResourceClass(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path)
 	s.forward(w, r)
 }
 
@@ -43,13 +35,9 @@ func (s *Shim) HandleCreateResourceClass(w http.ResponseWriter, r *http.Request)
 // This can be used to verify the existence of a resource class. Returns 404
 // if the class does not exist. Available since microversion 1.2.
 func (s *Shim) HandleShowResourceClass(w http.ResponseWriter, r *http.Request) {
-	name, ok := requiredPathParam(w, r, "name")
-	if !ok {
+	if _, ok := requiredPathParam(w, r, "name"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "name", name)
 	s.forward(w, r)
 }
 
@@ -62,13 +50,9 @@ func (s *Shim) HandleShowResourceClass(w http.ResponseWriter, r *http.Request) {
 // endpoint allowed renaming a class via a request body, but this usage is
 // discouraged. Returns 400 Bad Request if the CUSTOM_ prefix is missing.
 func (s *Shim) HandleUpdateResourceClass(w http.ResponseWriter, r *http.Request) {
-	name, ok := requiredPathParam(w, r, "name")
-	if !ok {
+	if _, ok := requiredPathParam(w, r, "name"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "name", name)
 	s.forward(w, r)
 }
 
@@ -80,12 +64,8 @@ func (s *Shim) HandleUpdateResourceClass(w http.ResponseWriter, r *http.Request)
 // class, and 404 if the class does not exist. Returns 204 No Content on
 // success. Available since microversion 1.2.
 func (s *Shim) HandleDeleteResourceClass(w http.ResponseWriter, r *http.Request) {
-	name, ok := requiredPathParam(w, r, "name")
-	if !ok {
+	if _, ok := requiredPathParam(w, r, "name"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "name", name)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_resource_provider_aggregates.go
+++ b/internal/shim/placement/handle_resource_provider_aggregates.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleListResourceProviderAggregates handles
@@ -23,13 +21,9 @@ import (
 // includes the resource_provider_generation for concurrency tracking. Returns
 // 404 if the provider does not exist.
 func (s *Shim) HandleListResourceProviderAggregates(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }
 
@@ -44,12 +38,8 @@ func (s *Shim) HandleListResourceProviderAggregates(w http.ResponseWriter, r *ht
 // concurrency control. Returns 409 Conflict if the generation does not match
 // (1.19+). Returns 200 with the updated aggregate list on success.
 func (s *Shim) HandleUpdateResourceProviderAggregates(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_resource_provider_allocations.go
+++ b/internal/shim/placement/handle_resource_provider_allocations.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleListResourceProviderAllocations handles
@@ -18,12 +16,8 @@ import (
 // endpoint. The response includes the resource_provider_generation. Returns
 // 404 if the provider does not exist.
 func (s *Shim) HandleListResourceProviderAllocations(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_resource_provider_inventories.go
+++ b/internal/shim/placement/handle_resource_provider_inventories.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleListResourceProviderInventories handles
@@ -19,13 +17,9 @@ import (
 // resource_provider_generation, which is needed for subsequent update or
 // delete operations. Returns 404 if the provider does not exist.
 func (s *Shim) HandleListResourceProviderInventories(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }
 
@@ -40,13 +34,9 @@ func (s *Shim) HandleListResourceProviderInventories(w http.ResponseWriter, r *h
 // are deleted. Returns 409 Conflict if allocations exceed the new capacity
 // or if a concurrent update has occurred.
 func (s *Shim) HandleUpdateResourceProviderInventories(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }
 
@@ -60,13 +50,9 @@ func (s *Shim) HandleUpdateResourceProviderInventories(w http.ResponseWriter, r 
 // Returns 404 if the provider does not exist. Available since microversion
 // 1.5.
 func (s *Shim) HandleDeleteResourceProviderInventories(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }
 
@@ -78,18 +64,12 @@ func (s *Shim) HandleDeleteResourceProviderInventories(w http.ResponseWriter, r 
 // step_size, allocation_ratio, and the resource_provider_generation. Returns
 // 404 if the provider or inventory for that class does not exist.
 func (s *Shim) HandleShowResourceProviderInventory(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	resourceClass, ok := requiredPathParam(w, r, "resource_class")
-	if !ok {
+	if _, ok := requiredPathParam(w, r, "resource_class"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path,
-		"uuid", uuid, "resource_class", resourceClass)
 	s.forward(w, r)
 }
 
@@ -103,18 +83,12 @@ func (s *Shim) HandleShowResourceProviderInventory(w http.ResponseWriter, r *htt
 // Since microversion 1.26, the reserved value must not exceed total. Returns
 // 409 Conflict on generation mismatch or if allocations would be violated.
 func (s *Shim) HandleUpdateResourceProviderInventory(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	resourceClass, ok := requiredPathParam(w, r, "resource_class")
-	if !ok {
+	if _, ok := requiredPathParam(w, r, "resource_class"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path,
-		"uuid", uuid, "resource_class", resourceClass)
 	s.forward(w, r)
 }
 
@@ -126,17 +100,11 @@ func (s *Shim) HandleUpdateResourceProviderInventory(w http.ResponseWriter, r *h
 // class combination, or if a concurrent update has occurred. Returns 404 if
 // the provider or inventory does not exist. Returns 204 No Content on success.
 func (s *Shim) HandleDeleteResourceProviderInventory(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	resourceClass, ok := requiredPathParam(w, r, "resource_class")
-	if !ok {
+	if _, ok := requiredPathParam(w, r, "resource_class"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path,
-		"uuid", uuid, "resource_class", resourceClass)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_resource_provider_traits.go
+++ b/internal/shim/placement/handle_resource_provider_traits.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleListResourceProviderTraits handles
@@ -17,13 +15,9 @@ import (
 // resource_provider_generation for concurrency tracking. Returns 404 if the
 // provider does not exist.
 func (s *Shim) HandleListResourceProviderTraits(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }
 
@@ -38,13 +32,9 @@ func (s *Shim) HandleListResourceProviderTraits(w http.ResponseWriter, r *http.R
 // not returned by GET /traits). Returns 409 Conflict if the generation does
 // not match.
 func (s *Shim) HandleUpdateResourceProviderTraits(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }
 
@@ -58,12 +48,8 @@ func (s *Shim) HandleUpdateResourceProviderTraits(w http.ResponseWriter, r *http
 // Returns 404 if the provider does not exist. Returns 409 Conflict on
 // concurrent modification. Returns 204 No Content on success.
 func (s *Shim) HandleDeleteResourceProviderTraits(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_resource_provider_usages.go
+++ b/internal/shim/placement/handle_resource_provider_usages.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleListResourceProviderUsages handles
@@ -18,12 +16,8 @@ import (
 // Unlike the provider allocations endpoint, this does not break down usage by
 // individual consumer. Returns 404 if the provider does not exist.
 func (s *Shim) HandleListResourceProviderUsages(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_resource_providers.go
+++ b/internal/shim/placement/handle_resource_providers.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleListResourceProviders handles GET /resource_providers requests.
@@ -23,9 +21,6 @@ import (
 // requirements at 1.18, forbidden traits at 1.22, forbidden aggregates at
 // 1.32, and the in: syntax for required at 1.39.
 func (s *Shim) HandleListResourceProviders(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path)
 	s.forward(w, r)
 }
 
@@ -42,9 +37,6 @@ func (s *Shim) HandleListResourceProviders(w http.ResponseWriter, r *http.Reques
 // provider object in the body. Returns 409 Conflict if a provider with the
 // same name or UUID already exists.
 func (s *Shim) HandleCreateResourceProvider(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path)
 	s.forward(w, r)
 }
 
@@ -57,13 +49,9 @@ func (s *Shim) HandleCreateResourceProvider(w http.ResponseWriter, r *http.Reque
 // provider's position in a hierarchical tree. Returns 404 if the provider
 // does not exist.
 func (s *Shim) HandleShowResourceProvider(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }
 
@@ -75,13 +63,9 @@ func (s *Shim) HandleShowResourceProvider(w http.ResponseWriter, r *http.Request
 // to null to make the provider a root. Returns 409 Conflict if another
 // provider already has the requested name.
 func (s *Shim) HandleUpdateResourceProvider(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }
 
@@ -92,12 +76,8 @@ func (s *Shim) HandleUpdateResourceProvider(w http.ResponseWriter, r *http.Reque
 // allocations against the provider's inventories or if the provider has
 // child providers in a tree hierarchy. Returns 204 No Content on success.
 func (s *Shim) HandleDeleteResourceProvider(w http.ResponseWriter, r *http.Request) {
-	uuid, ok := requiredUUIDPathParam(w, r, "uuid")
-	if !ok {
+	if _, ok := requiredUUIDPathParam(w, r, "uuid"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "uuid", uuid)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_root.go
+++ b/internal/shim/placement/handle_root.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleGetRoot handles GET / requests.
@@ -18,8 +16,5 @@ import (
 // supported by the running service. Clients use this endpoint to discover API
 // capabilities and negotiate microversions before making further requests.
 func (s *Shim) HandleGetRoot(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_traits.go
+++ b/internal/shim/placement/handle_traits.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleListTraits handles GET /traits requests.
@@ -21,9 +19,6 @@ import (
 // associated filters to only traits that are or are not associated with at
 // least one resource provider.
 func (s *Shim) HandleListTraits(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path)
 	s.forward(w, r)
 }
 
@@ -32,13 +27,9 @@ func (s *Shim) HandleListTraits(w http.ResponseWriter, r *http.Request) {
 // Checks whether a trait with the given name exists. Returns 204 No Content
 // (with no response body) if the trait is found, or 404 Not Found otherwise.
 func (s *Shim) HandleShowTrait(w http.ResponseWriter, r *http.Request) {
-	name, ok := requiredPathParam(w, r, "name")
-	if !ok {
+	if _, ok := requiredPathParam(w, r, "name"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "name", name)
 	s.forward(w, r)
 }
 
@@ -49,13 +40,9 @@ func (s *Shim) HandleShowTrait(w http.ResponseWriter, r *http.Request) {
 // is newly inserted, or 204 No Content if it already exists. Returns 400
 // Bad Request if the name does not carry the CUSTOM_ prefix.
 func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
-	name, ok := requiredPathParam(w, r, "name")
-	if !ok {
+	if _, ok := requiredPathParam(w, r, "name"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "name", name)
 	s.forward(w, r)
 }
 
@@ -66,12 +53,8 @@ func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
 // the trait is still associated with any resource provider. Returns 404 if
 // the trait does not exist. Returns 204 No Content on success.
 func (s *Shim) HandleDeleteTrait(w http.ResponseWriter, r *http.Request) {
-	name, ok := requiredPathParam(w, r, "name")
-	if !ok {
+	if _, ok := requiredPathParam(w, r, "name"); !ok {
 		return
 	}
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path, "name", name)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/handle_usages.go
+++ b/internal/shim/placement/handle_usages.go
@@ -5,8 +5,6 @@ package placement
 
 import (
 	"net/http"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // HandleListUsages handles GET /usages requests.
@@ -22,8 +20,5 @@ import (
 // microversion 1.38, an optional consumer_type query parameter allows
 // filtering the results. Available since microversion 1.9.
 func (s *Shim) HandleListUsages(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logf.FromContext(ctx)
-	log.Info("placement request", "method", r.Method, "path", r.URL.Path)
 	s.forward(w, r)
 }

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/pkg/sso"
 	hv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/api/resource"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -40,6 +41,13 @@ type contextKey struct{}
 // measurement middleware (set in RegisterRoutes) to the forward method.
 var routePatternKey = contextKey{}
 
+// requestIDContextKey is a separate type so it cannot collide with routePatternKey.
+type requestIDContextKey struct{}
+
+// requestIDKey is the context key used to propagate the X-OpenStack-Request-Id
+// header value through the request lifecycle for tracing.
+var requestIDKey = requestIDContextKey{}
+
 // config holds configuration for the placement shim.
 type config struct {
 	// SSO is an optional reference to a Kubernetes secret containing
@@ -48,6 +56,11 @@ type config struct {
 	// PlacementURL is the URL of the OpenStack Placement API the shim
 	// should forward requests to.
 	PlacementURL string `json:"placementURL,omitempty"`
+	// MaxBodyLogSize is the maximum number of bytes of request/response
+	// bodies to include in debug-level log lines, specified as a
+	// Kubernetes resource.Quantity string (e.g. "4Ki"). Defaults to "4Ki"
+	// when unset or empty.
+	MaxBodyLogSize string `json:"maxBodyLogSize,omitempty"`
 }
 
 // validate checks the config for required fields and returns an error if the
@@ -68,6 +81,10 @@ type Shim struct {
 	// HTTP client that can talk to openstack placement, if needed, over
 	// ingress with single-sign-on.
 	httpClient *http.Client
+	// maxBodyLogSize is the maximum number of bytes of request/response
+	// bodies to capture for debug-level logging. Parsed from
+	// config.MaxBodyLogSize at setup time.
+	maxBodyLogSize int64
 
 	// downstreamRequestTimer is a prometheus histogram to measure the duration
 	// (and count) of requests coming from the client that wants to talk to the
@@ -76,25 +93,6 @@ type Shim struct {
 	// upstreamRequestTimer is a prometheus histogram to measure the duration
 	// (and count) of requests to the upstream placement API by route and method.
 	upstreamRequestTimer *prometheus.HistogramVec
-}
-
-// statusCapturingResponseWriter wraps http.ResponseWriter to capture the
-// HTTP status code written via WriteHeader for use in metrics labels.
-type statusCapturingResponseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func (w *statusCapturingResponseWriter) WriteHeader(code int) {
-	w.statusCode = code
-	w.ResponseWriter.WriteHeader(code)
-}
-
-func (w *statusCapturingResponseWriter) Write(b []byte) (int, error) {
-	if w.statusCode == 0 {
-		w.statusCode = http.StatusOK
-	}
-	return w.ResponseWriter.Write(b)
 }
 
 // Describe implements prometheus.Collector.
@@ -207,6 +205,17 @@ func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err erro
 	if err := s.config.validate(); err != nil {
 		return err
 	}
+
+	// Parse the body log size limit from config (default 4Ki).
+	bodyLogQty := s.config.MaxBodyLogSize
+	if bodyLogQty == "" {
+		bodyLogQty = "4Ki"
+	}
+	qty, err := resource.ParseQuantity(bodyLogQty)
+	if err != nil {
+		return fmt.Errorf("invalid maxBodyLogSize %q: %w", bodyLogQty, err)
+	}
+	s.maxBodyLogSize = qty.Value()
 
 	// Initialize Prometheus histogram timers for request monitoring.
 	s.downstreamRequestTimer = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -358,18 +367,7 @@ func (s *Shim) RegisterRoutes(mux *http.ServeMux) {
 	}
 	for _, h := range handlers {
 		setupLog.Info("Registering route", "method", h.method, "pattern", h.pattern)
-		routePattern := fmt.Sprintf("%s %s", h.method, h.pattern)
-		handlerPattern := h.pattern
-		next := h.handler
-		mux.HandleFunc(routePattern, func(w http.ResponseWriter, r *http.Request) {
-			r = r.WithContext(context.WithValue(r.Context(), routePatternKey, handlerPattern))
-			sw := &statusCapturingResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
-			start := time.Now()
-			next.ServeHTTP(sw, r)
-			s.downstreamRequestTimer.
-				WithLabelValues(r.Method, handlerPattern, strconv.Itoa(sw.statusCode)).
-				Observe(time.Since(start).Seconds())
-		})
+		mux.HandleFunc(fmt.Sprintf("%s %s", h.method, h.pattern), s.wrapHandler(h.pattern, h.handler))
 	}
 	setupLog.Info("Successfully registered placement API routes")
 }

--- a/internal/shim/placement/shim_io.go
+++ b/internal/shim/placement/shim_io.go
@@ -1,0 +1,158 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// shimReader wraps an io.Reader and counts the bytes read through it.
+type shimReader struct {
+	r io.Reader
+	n int64
+}
+
+func (sr *shimReader) Read(p []byte) (int, error) {
+	n, err := sr.r.Read(p)
+	sr.n += int64(n)
+	return n, err
+}
+
+// shimWriter writes to an underlying writer up to a byte limit, silently
+// discarding anything beyond that limit.
+type shimWriter struct {
+	w io.Writer
+	n int64 // remaining bytes allowed
+}
+
+func (sw *shimWriter) Write(p []byte) (int, error) {
+	if sw.n <= 0 {
+		return len(p), nil // discard
+	}
+	if int64(len(p)) > sw.n {
+		p = p[:sw.n]
+	}
+	n, err := sw.w.Write(p)
+	sw.n -= int64(n)
+	return n, err
+}
+
+// shimResponseWriter wraps http.ResponseWriter to capture the HTTP status
+// code and count the bytes written to the response body. When bodyBuf is
+// non-nil (debug level), it also captures up to bodyLimit bytes of the
+// response body for logging.
+type shimResponseWriter struct {
+	http.ResponseWriter
+	statusCode   int
+	bytesWritten int64
+	bodyBuf      *bytes.Buffer // non-nil only at debug level
+	bodyLimit    int64         // max bytes to capture in bodyBuf
+}
+
+func (w *shimResponseWriter) WriteHeader(code int) {
+	w.statusCode = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *shimResponseWriter) Write(b []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.statusCode = http.StatusOK
+	}
+	n, err := w.ResponseWriter.Write(b)
+	w.bytesWritten += int64(n)
+	if w.bodyBuf != nil && int64(w.bodyBuf.Len()) < w.bodyLimit {
+		// Capture up to bodyLimit bytes for debug logging.
+		remaining := w.bodyLimit - int64(w.bodyBuf.Len())
+		if int64(n) <= remaining {
+			w.bodyBuf.Write(b[:n])
+		} else {
+			w.bodyBuf.Write(b[:remaining])
+		}
+	}
+	return n, err
+}
+
+// wrapHandler returns an http.HandlerFunc that wraps next with logging,
+// metrics collection, and request-ID propagation. It is used by
+// RegisterRoutes to apply uniform middleware to every placement API handler.
+func (s *Shim) wrapHandler(pattern string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, routePatternKey, pattern)
+
+		// Extract X-OpenStack-Request-Id for tracing and add it to the
+		// context and logger so all downstream code includes it.
+		reqID := r.Header.Get("X-OpenStack-Request-Id")
+		log := logf.FromContext(ctx)
+		if reqID != "" {
+			log = log.WithValues("requestID", reqID)
+			ctx = context.WithValue(ctx, requestIDKey, reqID)
+		}
+		ctx = logf.IntoContext(ctx, log)
+		r = r.WithContext(ctx)
+
+		debug := log.V(1).Enabled()
+
+		// Wrap the request body to count bytes read. At debug level,
+		// also tee the body into a limited buffer for logging.
+		sr := &shimReader{r: r.Body}
+		var reqBodyBuf *bytes.Buffer
+		if debug && r.Body != nil && r.Body != http.NoBody {
+			reqBodyBuf = &bytes.Buffer{}
+			sr.r = io.TeeReader(r.Body, &shimWriter{w: reqBodyBuf, n: s.maxBodyLogSize})
+		}
+		r.Body = io.NopCloser(sr)
+
+		// Wrap the response writer to capture status code, body size,
+		// and optionally body content at debug level.
+		sw := &shimResponseWriter{
+			ResponseWriter: w,
+			statusCode:     http.StatusOK,
+			bodyLimit:      s.maxBodyLogSize,
+		}
+		if debug {
+			sw.bodyBuf = &bytes.Buffer{}
+		}
+
+		start := time.Now()
+		next.ServeHTTP(sw, r)
+		latencyMs := time.Since(start).Milliseconds()
+
+		// NOTE: We intentionally never log HTTP headers to avoid
+		// leaking X-Auth-Token or other sensitive header values.
+		log.Info("handled request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"query", r.URL.RawQuery,
+			"status", sw.statusCode,
+			"latencyMs", latencyMs,
+			"requestSize", sr.n,
+			"responseSize", sw.bytesWritten,
+		)
+
+		if debug {
+			if reqBodyBuf != nil && reqBodyBuf.Len() > 0 {
+				log.V(1).Info("request body", "body", reqBodyBuf.String())
+			} else {
+				log.V(1).Info("request body", "body", "<empty>")
+			}
+			if sw.bodyBuf != nil && sw.bodyBuf.Len() > 0 {
+				log.V(1).Info("response body", "body", sw.bodyBuf.String())
+			} else {
+				log.V(1).Info("response body", "body", "<empty>")
+			}
+		}
+
+		s.downstreamRequestTimer.
+			WithLabelValues(r.Method, pattern, strconv.Itoa(sw.statusCode)).
+			Observe(time.Since(start).Seconds())
+	}
+}

--- a/internal/shim/placement/shim_io_test.go
+++ b/internal/shim/placement/shim_io_test.go
@@ -1,0 +1,191 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestShimReader(t *testing.T) {
+	data := "hello, world"
+	sr := &shimReader{r: strings.NewReader(data)}
+	got, err := io.ReadAll(sr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != data {
+		t.Errorf("read = %q, want %q", string(got), data)
+	}
+	if sr.n != int64(len(data)) {
+		t.Errorf("byte count = %d, want %d", sr.n, len(data))
+	}
+}
+
+func TestShimReaderEmpty(t *testing.T) {
+	sr := &shimReader{r: strings.NewReader("")}
+	got, err := io.ReadAll(sr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("read = %q, want empty", string(got))
+	}
+	if sr.n != 0 {
+		t.Errorf("byte count = %d, want 0", sr.n)
+	}
+}
+
+func TestShimWriter(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int64
+		input string
+		want  string
+	}{
+		{"within limit", 100, "hello", "hello"},
+		{"exact limit", 5, "hello", "hello"},
+		{"exceeds limit", 3, "hello", "hel"},
+		{"zero limit", 0, "hello", ""},
+		{"multi write within limit", 10, "hello", "hello"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			sw := &shimWriter{w: &buf, n: tt.limit}
+			_, err := sw.Write([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if buf.String() != tt.want {
+				t.Errorf("buffer = %q, want %q", buf.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestShimWriterMultipleWrites(t *testing.T) {
+	var buf bytes.Buffer
+	sw := &shimWriter{w: &buf, n: 5}
+	if _, err := sw.Write([]byte("abc")); err != nil { // 3 bytes, 2 remaining
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := sw.Write([]byte("defgh")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.String() != "abcde" {
+		t.Errorf("buffer = %q, want %q", buf.String(), "abcde")
+	}
+}
+
+func TestShimResponseWriterStatusCode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &shimResponseWriter{ResponseWriter: rec, statusCode: http.StatusOK}
+	sw.WriteHeader(http.StatusNotFound)
+	if sw.statusCode != http.StatusNotFound {
+		t.Errorf("statusCode = %d, want %d", sw.statusCode, http.StatusNotFound)
+	}
+}
+
+func TestShimResponseWriterDefaultStatus(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &shimResponseWriter{ResponseWriter: rec}
+	if _, err := sw.Write([]byte("body")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// First Write without WriteHeader should default to 200.
+	if sw.statusCode != http.StatusOK {
+		t.Errorf("statusCode = %d, want %d", sw.statusCode, http.StatusOK)
+	}
+}
+
+func TestShimResponseWriterBytesWritten(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &shimResponseWriter{ResponseWriter: rec, statusCode: http.StatusOK}
+	if _, err := sw.Write([]byte("hello")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := sw.Write([]byte(" world")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sw.bytesWritten != 11 {
+		t.Errorf("bytesWritten = %d, want 11", sw.bytesWritten)
+	}
+}
+
+func TestShimResponseWriterBodyCapture(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &shimResponseWriter{
+		ResponseWriter: rec,
+		statusCode:     http.StatusOK,
+		bodyBuf:        &bytes.Buffer{},
+		bodyLimit:      8,
+	}
+	if _, err := sw.Write([]byte("hello")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := sw.Write([]byte(" world!")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// bodyBuf should contain at most 8 bytes.
+	if sw.bodyBuf.String() != "hello wo" {
+		t.Errorf("bodyBuf = %q, want %q", sw.bodyBuf.String(), "hello wo")
+	}
+	// But bytesWritten counts everything.
+	if sw.bytesWritten != 12 {
+		t.Errorf("bytesWritten = %d, want 12", sw.bytesWritten)
+	}
+}
+
+func TestShimResponseWriterNilBodyBuf(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &shimResponseWriter{ResponseWriter: rec, statusCode: http.StatusOK}
+	// Should not panic when bodyBuf is nil.
+	if _, err := sw.Write([]byte("hello")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sw.bytesWritten != 5 {
+		t.Errorf("bytesWritten = %d, want 5", sw.bytesWritten)
+	}
+}
+
+func TestWrapHandlerLogsAndMetrics(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	down, up := newTestTimers()
+	s := &Shim{
+		config:                 config{PlacementURL: upstream.URL},
+		httpClient:             upstream.Client(),
+		maxBodyLogSize:         4096,
+		downstreamRequestTimer: down,
+		upstreamRequestTimer:   up,
+	}
+
+	wrapped := s.wrapHandler("/test", func(w http.ResponseWriter, r *http.Request) {
+		s.forward(w, r)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test?foo=bar", http.NoBody)
+	req.Header.Set("X-OpenStack-Request-Id", "req-test-123")
+	w := httptest.NewRecorder()
+	wrapped(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	// Downstream metric should have one observation.
+	if n := histSampleCount(t, down, "GET", "/test", "200"); n != 1 {
+		t.Errorf("downstream observation count = %d, want 1", n)
+	}
+}

--- a/internal/shim/placement/shim_test.go
+++ b/internal/shim/placement/shim_test.go
@@ -64,6 +64,7 @@ func newTestShim(t *testing.T, status int, body string, gotPath *string) *Shim {
 	return &Shim{
 		config:                 config{PlacementURL: upstream.URL},
 		httpClient:             upstream.Client(),
+		maxBodyLogSize:         4096,
 		downstreamRequestTimer: down,
 		upstreamRequestTimer:   up,
 	}
@@ -159,8 +160,9 @@ func TestForward(t *testing.T) {
 			defer upstream.Close()
 
 			s := &Shim{
-				config:     config{PlacementURL: upstream.URL},
-				httpClient: upstream.Client(),
+				config:         config{PlacementURL: upstream.URL},
+				httpClient:     upstream.Client(),
+				maxBodyLogSize: 4096,
 			}
 			s.downstreamRequestTimer, s.upstreamRequestTimer = newTestTimers()
 			target := tt.path
@@ -198,6 +200,7 @@ func TestForwardUpstreamUnreachable(t *testing.T) {
 	s := &Shim{
 		config:                 config{PlacementURL: "http://127.0.0.1:1"},
 		httpClient:             &http.Client{},
+		maxBodyLogSize:         4096,
 		downstreamRequestTimer: down,
 		upstreamRequestTimer:   up,
 	}
@@ -218,6 +221,7 @@ func TestRegisterRoutes(t *testing.T) {
 	s := &Shim{
 		config:                 config{PlacementURL: upstream.URL},
 		httpClient:             upstream.Client(),
+		maxBodyLogSize:         4096,
 		downstreamRequestTimer: down,
 		upstreamRequestTimer:   up,
 	}
@@ -259,6 +263,7 @@ func TestRegisterRoutesDownstreamMetrics(t *testing.T) {
 	s := &Shim{
 		config:                 config{PlacementURL: upstream.URL},
 		httpClient:             upstream.Client(),
+		maxBodyLogSize:         4096,
 		downstreamRequestTimer: down,
 		upstreamRequestTimer:   up,
 	}
@@ -290,6 +295,7 @@ func TestForwardUpstreamMetrics(t *testing.T) {
 		s := &Shim{
 			config:                 config{PlacementURL: upstream.URL},
 			httpClient:             upstream.Client(),
+			maxBodyLogSize:         4096,
 			downstreamRequestTimer: down,
 			upstreamRequestTimer:   up,
 		}
@@ -309,6 +315,7 @@ func TestForwardUpstreamMetrics(t *testing.T) {
 		s := &Shim{
 			config:                 config{PlacementURL: "http://127.0.0.1:1"},
 			httpClient:             &http.Client{},
+			maxBodyLogSize:         4096,
 			downstreamRequestTimer: down,
 			upstreamRequestTimer:   up,
 		}
@@ -321,4 +328,72 @@ func TestForwardUpstreamMetrics(t *testing.T) {
 			t.Errorf("upstream observation count = %d, want 1", n)
 		}
 	})
+}
+
+func TestRequestIDPropagation(t *testing.T) {
+	const wantID = "req-abc-123"
+	var gotID string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The shim forwards all headers, so the request ID should arrive.
+		gotID = r.Header.Get("X-OpenStack-Request-Id")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	down, up := newTestTimers()
+	s := &Shim{
+		config:                 config{PlacementURL: upstream.URL},
+		httpClient:             upstream.Client(),
+		maxBodyLogSize:         4096,
+		downstreamRequestTimer: down,
+		upstreamRequestTimer:   up,
+	}
+	mux := http.NewServeMux()
+	s.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/resource_providers", http.NoBody)
+	req.Header.Set("X-OpenStack-Request-Id", wantID)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if gotID != wantID {
+		t.Errorf("upstream X-OpenStack-Request-Id = %q, want %q", gotID, wantID)
+	}
+}
+
+func TestRequestIDInContext(t *testing.T) {
+	// Verify that the middleware in RegisterRoutes injects the request ID
+	// into the context so that forward() and all downstream code can read it.
+	// We confirm this indirectly: the forward method copies headers from the
+	// original request (which include X-OpenStack-Request-Id), and the
+	// middleware enriches the logger. Here we just verify that the context
+	// key is populated by checking it survives through to the upstream.
+	const wantID = "req-xyz-789"
+	var gotHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-OpenStack-Request-Id")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	down, up := newTestTimers()
+	s := &Shim{
+		config:                 config{PlacementURL: upstream.URL},
+		httpClient:             upstream.Client(),
+		maxBodyLogSize:         4096,
+		downstreamRequestTimer: down,
+		upstreamRequestTimer:   up,
+	}
+	mux := http.NewServeMux()
+	s.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/traits", http.NoBody)
+	req.Header.Set("X-OpenStack-Request-Id", wantID)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if gotHeader != wantID {
+		t.Errorf("upstream received X-OpenStack-Request-Id = %q, want %q", gotHeader, wantID)
+	}
 }


### PR DESCRIPTION
This adds structured and traceable logging to the placement shim. Every request is now logged with: method, path, query params, X-OpenStack-Request-Id, response status code, latency (ms), request/response body size. Also, the request id is passed down to the context so handlers can provide traceable logging. If loglevel verbosity `.V(1)` is given, the debug logging will be activated exposing the request + response body, which are truncated to a configurable limit (`4Ki` by default).