### PR TITLE
Scaffold placement shim e2e tests and add entrypoint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
           # Exclude e2e files from the coverage profile so they don't
           # count against the coverage percentage.
           head -1 profile.cov > profile_filtered.cov
-          grep -v '_e2e\.go' profile.cov >> profile_filtered.cov || true
+          tail -n +2 profile.cov | grep -v '_e2e\.go' >> profile_filtered.cov || true
 
           go tool cover -func profile_filtered.cov > func_coverage.txt
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,13 @@ jobs:
           go test -v \
             -coverpkg=./internal/... \
             -coverprofile=profile.cov ./internal/...
-          go tool cover -func profile.cov > func_coverage.txt
+
+          # Exclude e2e files from the coverage profile so they don't
+          # count against the coverage percentage.
+          head -1 profile.cov > profile_filtered.cov
+          grep -v '_e2e\.go' profile.cov >> profile_filtered.cov || true
+
+          go tool cover -func profile_filtered.cov > func_coverage.txt
 
       - name: Upload coverage files
         uses: actions/upload-artifact@v7

--- a/Tiltfile
+++ b/Tiltfile
@@ -279,6 +279,13 @@ if 'pods' in ACTIVE_DEPLOYMENTS:
 if 'placement' in ACTIVE_DEPLOYMENTS:
     print("Activating Cortex Placement Shim bundle")
     k8s_yaml(helm('./helm/bundles/cortex-placement-shim', name='cortex-placement-shim', values=tilt_values, set=env_set_overrides))
+    local_resource(
+        'Placement Shim E2E Tests',
+        '/bin/sh -c "kubectl exec deploy/cortex-placement-shim -- /main e2e-placement-shim"',
+        labels=['Cortex-Placement'],
+        trigger_mode=TRIGGER_MODE_MANUAL,
+        auto_init=False,
+    )
 
 ########### Dev Dependencies
 local('sh helm/sync.sh helm/dev/cortex-prometheus-operator')

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -51,6 +51,13 @@ func init() {
 
 func main() {
 	ctx := ctrl.SetupSignalHandler()
+
+	// Custom entrypoint for placement shim e2e tests.
+	if len(os.Args) == 2 && os.Args[1] == "e2e-placement-shim" {
+		placement.RunE2E(ctx)
+		return
+	}
+
 	restConfig := ctrl.GetConfigOrDie()
 
 	var metricsAddr string

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"flag"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -54,7 +55,9 @@ func main() {
 
 	// Custom entrypoint for placement shim e2e tests.
 	if len(os.Args) == 2 && os.Args[1] == "e2e-placement-shim" {
-		placement.RunE2E(ctx)
+		if err := placement.RunE2E(ctx); err != nil {
+			log.Fatalf("E2E tests failed: %v", err)
+		}
 		return
 	}
 

--- a/internal/shim/placement/handle_allocation_candidates_e2e.go
+++ b/internal/shim/placement/handle_allocation_candidates_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "allocation_candidates",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_allocation_candidates_e2e.go
+++ b/internal/shim/placement/handle_allocation_candidates_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "allocation_candidates",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_allocations_e2e.go
+++ b/internal/shim/placement/handle_allocations_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "allocations",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_allocations_e2e.go
+++ b/internal/shim/placement/handle_allocations_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "allocations",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_reshaper_e2e.go
+++ b/internal/shim/placement/handle_reshaper_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "reshaper",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_reshaper_e2e.go
+++ b/internal/shim/placement/handle_reshaper_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "reshaper",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_resource_classes_e2e.go
+++ b/internal/shim/placement/handle_resource_classes_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "resource_classes",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_resource_classes_e2e.go
+++ b/internal/shim/placement/handle_resource_classes_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "resource_classes",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_resource_provider_aggregates_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_aggregates_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "resource_provider_aggregates",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_resource_provider_aggregates_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_aggregates_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "resource_provider_aggregates",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_resource_provider_allocations_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_allocations_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "resource_provider_allocations",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_resource_provider_allocations_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_allocations_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "resource_provider_allocations",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_resource_provider_inventories_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_inventories_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "resource_provider_inventories",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_resource_provider_inventories_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_inventories_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "resource_provider_inventories",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_resource_provider_traits_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_traits_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "resource_provider_traits",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_resource_provider_traits_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_traits_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "resource_provider_traits",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_resource_provider_usages_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_usages_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "resource_provider_usages",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_resource_provider_usages_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_usages_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "resource_provider_usages",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_resource_providers_e2e.go
+++ b/internal/shim/placement/handle_resource_providers_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "resource_providers",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_resource_providers_e2e.go
+++ b/internal/shim/placement/handle_resource_providers_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "resource_providers",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_root_e2e.go
+++ b/internal/shim/placement/handle_root_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "root",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_root_e2e.go
+++ b/internal/shim/placement/handle_root_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "root",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_traits_e2e.go
+++ b/internal/shim/placement/handle_traits_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "traits",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_traits_e2e.go
+++ b/internal/shim/placement/handle_traits_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "traits",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/handle_usages_e2e.go
+++ b/internal/shim/placement/handle_usages_e2e.go
@@ -1,0 +1,13 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import "context"
+
+func init() {
+	e2eTests = append(e2eTests, e2eTest{
+		name: "usages",
+		run:  func(ctx context.Context) {},
+	})
+}

--- a/internal/shim/placement/handle_usages_e2e.go
+++ b/internal/shim/placement/handle_usages_e2e.go
@@ -8,6 +8,6 @@ import "context"
 func init() {
 	e2eTests = append(e2eTests, e2eTest{
 		name: "usages",
-		run:  func(ctx context.Context) {},
+		run:  func(ctx context.Context) error { return nil },
 	})
 }

--- a/internal/shim/placement/shim_e2e.go
+++ b/internal/shim/placement/shim_e2e.go
@@ -5,6 +5,7 @@ package placement
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 )
@@ -12,21 +13,26 @@ import (
 // e2eTest is a named end-to-end test registered by handler e2e files.
 type e2eTest struct {
 	name string
-	run  func(ctx context.Context)
+	run  func(ctx context.Context) error
 }
 
 // e2eTests is populated by init() functions in the handle_*_e2e.go files.
 var e2eTests []e2eTest
 
 // RunE2E executes end-to-end tests for all placement shim handlers.
-func RunE2E(ctx context.Context) {
+// It stops on the first failure and returns the error.
+func RunE2E(ctx context.Context) error {
 	log.Printf("Running %d e2e test(s)", len(e2eTests))
 	totalStart := time.Now()
 	for i, test := range e2eTests {
 		log.Printf("[%d/%d] Starting: %s", i+1, len(e2eTests), test.name)
 		start := time.Now()
-		test.run(ctx)
+		if err := test.run(ctx); err != nil {
+			log.Printf("[%d/%d] FAIL: %s (took: %d ms): %v", i+1, len(e2eTests), test.name, time.Since(start).Milliseconds(), err)
+			return fmt.Errorf("e2e test %q failed: %w", test.name, err)
+		}
 		log.Printf("[%d/%d] Done: %s (took: %d ms)", i+1, len(e2eTests), test.name, time.Since(start).Milliseconds())
 	}
 	log.Printf("All e2e tests passed (took: %d ms)", time.Since(totalStart).Milliseconds())
+	return nil
 }

--- a/internal/shim/placement/shim_e2e.go
+++ b/internal/shim/placement/shim_e2e.go
@@ -1,0 +1,32 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// e2eTest is a named end-to-end test registered by handler e2e files.
+type e2eTest struct {
+	name string
+	run  func(ctx context.Context)
+}
+
+// e2eTests is populated by init() functions in the handle_*_e2e.go files.
+var e2eTests []e2eTest
+
+// RunE2E executes end-to-end tests for all placement shim handlers.
+func RunE2E(ctx context.Context) {
+	log.Printf("Running %d e2e test(s)", len(e2eTests))
+	totalStart := time.Now()
+	for i, test := range e2eTests {
+		log.Printf("[%d/%d] Starting: %s", i+1, len(e2eTests), test.name)
+		start := time.Now()
+		test.run(ctx)
+		log.Printf("[%d/%d] Done: %s (took: %d ms)", i+1, len(e2eTests), test.name, time.Since(start).Milliseconds())
+	}
+	log.Printf("All e2e tests passed (took: %d ms)", time.Since(totalStart).Milliseconds())
+}


### PR DESCRIPTION
This adds empty e2e test functions for every placement api shim endpoint, and binds them together `shim_e2e.go` from where it can be executed using the `e2e-placement-shim` entrypoint. It also excludes any `*_e2e.go` files from our test coverage.