### PR TITLE
Implement placement shim e2e tests

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -281,7 +281,7 @@ if 'placement' in ACTIVE_DEPLOYMENTS:
     k8s_yaml(helm('./helm/bundles/cortex-placement-shim', name='cortex-placement-shim', values=tilt_values, set=env_set_overrides))
     local_resource(
         'Placement Shim E2E Tests',
-        '/bin/sh -c "kubectl exec deploy/cortex-placement-shim -- /main e2e-placement-shim"',
+        '/bin/sh -c "kubectl exec deploy/cortex-placement-shim -- /main --e2e-placement-shim"',
         labels=['Cortex-Placement'],
         trigger_mode=TRIGGER_MODE_MANUAL,
         auto_init=False,

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -53,14 +53,6 @@ func init() {
 func main() {
 	ctx := ctrl.SetupSignalHandler()
 
-	// Custom entrypoint for placement shim e2e tests.
-	if len(os.Args) == 2 && os.Args[1] == "e2e-placement-shim" {
-		if err := placement.RunE2E(ctx); err != nil {
-			log.Fatalf("E2E tests failed: %v", err)
-		}
-		return
-	}
-
 	restConfig := ctrl.GetConfigOrDie()
 
 	var metricsAddr string
@@ -74,6 +66,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var enablePlacementShim bool
+	var runPlacementShimE2E bool
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -95,6 +88,8 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.BoolVar(&enablePlacementShim, "placement-shim", false,
 		"If set, the placement API shim handlers are registered on the API server.")
+	flag.BoolVar(&runPlacementShimE2E, "e2e-placement-shim", false,
+		"If set, runs end-to-end tests for the placement shim instead of starting the manager. ")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -116,6 +111,14 @@ func main() {
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Custom entrypoint for placement shim e2e tests.
+	if runPlacementShimE2E {
+		if err := placement.RunE2E(ctx); err != nil {
+			log.Fatalf("E2E tests failed: %v", err)
+		}
+		os.Exit(0)
+	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -8,7 +8,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"flag"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -115,7 +114,8 @@ func main() {
 	// Custom entrypoint for placement shim e2e tests.
 	if runPlacementShimE2E {
 		if err := placement.RunE2E(ctx); err != nil {
-			log.Fatalf("E2E tests failed: %v", err)
+			setupLog.Error(err, "E2E tests failed")
+			os.Exit(1)
 		}
 		os.Exit(0)
 	}

--- a/helm/bundles/cortex-placement-shim/values.yaml
+++ b/helm/bundles/cortex-placement-shim/values.yaml
@@ -24,6 +24,8 @@ cortex-shim:
     container:
       extraArgs: ["--placement-shim=true"]
   conf:
+    e2e:
+      svcURL: "http://cortex-placement-shim-service:8080"
     apiservers:
       home:
         gvks:

--- a/helm/bundles/cortex-placement-shim/values.yaml
+++ b/helm/bundles/cortex-placement-shim/values.yaml
@@ -26,6 +26,15 @@ cortex-shim:
   conf:
     e2e:
       svcURL: "http://cortex-placement-shim-service:8080"
+      # Openstack credentials for e2e tests. These are not used by the shim
+      # itself, but are passed to the e2e test suite to generate an authenticated
+      # openstack client token for testing the shim's integration with openstack.
+      osKeystoneURL:
+      osUsername:
+      osPassword:
+      osProjectName:
+      osUserDomainName:
+      osProjectDomainName:
     apiservers:
       home:
         gvks:

--- a/internal/shim/placement/handle_allocation_candidates_e2e.go
+++ b/internal/shim/placement/handle_allocation_candidates_e2e.go
@@ -67,7 +67,7 @@ func e2eTestAllocationCandidates(ctx context.Context) error {
 			log.Error(err, "failed to send pre-cleanup request", "url", cleanup.url)
 			return err
 		}
-		defer resp.Body.Close()
+		resp.Body.Close()
 		log.Info("Pre-cleanup request completed", "url", cleanup.url, "status", resp.StatusCode)
 	}
 

--- a/internal/shim/placement/handle_allocation_candidates_e2e.go
+++ b/internal/shim/placement/handle_allocation_candidates_e2e.go
@@ -3,11 +3,297 @@
 
 package placement
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestAllocationCandidates tests the /allocation_candidates endpoint.
+//
+//  1. Pre-cleanup: DELETE leftover RP and custom resource class.
+//  2. Create fixtures: PUT a custom resource class, POST a test RP, PUT
+//     inventory on the RP (total=100, max_unit=100).
+//  3. GET /allocation_candidates?resources=CUSTOM_...:1 — request candidates
+//     that can satisfy 1 unit of the custom resource class, then verify:
+//     - allocation_requests is non-empty (at least one candidate found).
+//     - provider_summaries contains the test RP's UUID.
+//  4. Cleanup: DELETE the test RP and custom resource class.
+func e2eTestAllocationCandidates(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running allocation candidates endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for allocation candidates e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for allocation candidates e2e test")
+
+	const testRPUUID = "e2e10000-0000-0000-0000-000000000008"
+	const testRPName = "cortex-e2e-test-rp-cand"
+	const testRC = "CUSTOM_CORTEX_E2E_CAND_RC"
+	const apiVersion = "placement 1.26"
+
+	// Pre-cleanup: delete leftover test resources from a prior run.
+	log.Info("Pre-cleanup: deleting leftover test resources")
+	for _, cleanup := range []struct {
+		method string
+		url    string
+	}{
+		{http.MethodDelete, sc.Endpoint + "/resource_providers/" + testRPUUID},
+		{http.MethodDelete, sc.Endpoint + "/resource_classes/" + testRC},
+	} {
+		req, err := http.NewRequestWithContext(ctx, cleanup.method, cleanup.url, http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create pre-cleanup request", "url", cleanup.url)
+			return err
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", apiVersion)
+		resp, err := sc.HTTPClient.Do(req)
+		if err != nil {
+			log.Error(err, "failed to send pre-cleanup request", "url", cleanup.url)
+			return err
+		}
+		defer resp.Body.Close()
+		log.Info("Pre-cleanup request completed", "url", cleanup.url, "status", resp.StatusCode)
+	}
+
+	// Create fixtures: custom resource class, resource provider, and inventory.
+	log.Info("Creating custom resource class for allocation candidates test", "class", testRC)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create PUT request for resource class", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for resource class", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT /resource_classes returned an error", "class", testRC)
+		return err
+	}
+	log.Info("Successfully created custom resource class", "class", testRC)
+
+	log.Info("Creating test resource provider for allocation candidates test",
+		"uuid", testRPUUID, "name", testRPName)
+	body, err := json.Marshal(map[string]string{
+		"name": testRPName,
+		"uuid": testRPUUID,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPost, sc.Endpoint+"/resource_providers", bytes.NewReader(body))
+	if err != nil {
+		log.Error(err, "failed to create POST request for resource_providers")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send POST request to /resource_providers")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "POST /resource_providers returned an error")
+		return err
+	}
+	log.Info("Successfully created test resource provider", "uuid", testRPUUID)
+
+	// Get the generation for the resource provider.
+	log.Info("Getting resource provider generation", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP inventories returned an error", "uuid", testRPUUID)
+		return err
+	}
+	var invResp struct {
+		ResourceProviderGeneration int `json:"resource_provider_generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&invResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP inventories response", "uuid", testRPUUID)
+		return err
+	}
+	generation := invResp.ResourceProviderGeneration
+
+	// Set inventory on the resource provider.
+	log.Info("Setting inventory on test resource provider",
+		"uuid", testRPUUID, "class", testRC, "generation", generation)
+	putBody, err := json.Marshal(map[string]any{
+		"resource_provider_generation": generation,
+		"inventories": map[string]any{
+			testRC: map[string]any{
+				"total":    100,
+				"max_unit": 100,
+			},
+		},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories",
+		bytes.NewReader(putBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT RP inventories returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully set inventory on test resource provider",
+		"uuid", testRPUUID, "class", testRC)
+
+	// Test GET /allocation_candidates with our custom resource class.
+	log.Info("Testing GET /allocation_candidates", "resources", testRC+":1")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet,
+		sc.Endpoint+"/allocation_candidates?resources="+testRC+":1",
+		http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for allocation_candidates")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request to /allocation_candidates")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET /allocation_candidates returned an error")
+		return err
+	}
+	var candResp struct {
+		AllocationRequests []json.RawMessage          `json:"allocation_requests"`
+		ProviderSummaries  map[string]json.RawMessage `json:"provider_summaries"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&candResp)
+	if err != nil {
+		log.Error(err, "failed to decode allocation candidates response")
+		return err
+	}
+	if len(candResp.AllocationRequests) == 0 {
+		err := errors.New("expected at least 1 allocation request, got 0")
+		log.Error(err, "no allocation candidates returned")
+		return err
+	}
+	if _, ok := candResp.ProviderSummaries[testRPUUID]; !ok {
+		err := fmt.Errorf("expected provider %s in summaries", testRPUUID)
+		log.Error(err, "test resource provider not found in provider summaries")
+		return err
+	}
+	log.Info("Successfully retrieved allocation candidates",
+		"allocationRequests", len(candResp.AllocationRequests),
+		"providerSummaries", len(candResp.ProviderSummaries))
+
+	// Cleanup: delete the resource provider and custom resource class.
+	log.Info("Cleaning up test resources")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE resource provider returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully deleted test resource provider", "uuid", testRPUUID)
+
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource class", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource class", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE resource class returned an error", "class", testRC)
+		return err
+	}
+	log.Info("Successfully deleted custom resource class", "class", testRC)
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "allocation_candidates",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "allocation_candidates", run: e2eTestAllocationCandidates})
 }

--- a/internal/shim/placement/handle_allocations_e2e.go
+++ b/internal/shim/placement/handle_allocations_e2e.go
@@ -3,11 +3,511 @@
 
 package placement
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestAllocations tests the /allocations/{consumer_uuid} and
+// POST /allocations (batch) endpoints.
+//
+//  1. Pre-cleanup: DELETE leftover consumer allocations, RP, and custom RC.
+//  2. Create fixtures: PUT a custom resource class, POST a test RP, PUT
+//     inventory on the RP (total=100).
+//  3. GET /allocations/{consumer1} — verify allocations are empty.
+//  4. PUT /allocations/{consumer1} — create an allocation of 10 units against
+//     the test RP using fake project/user IDs.
+//  5. GET /allocations/{consumer1} — verify the allocation exists and points
+//     to the test RP.
+//  6. POST /allocations — batch-create a second consumer's allocation of
+//     5 units against the same RP.
+//  7. GET /allocations/{consumer2} — verify the second allocation exists.
+//  8. DELETE /allocations/{consumer} — remove allocations for both consumers.
+//  9. GET /allocations/{consumer1} — verify allocations are empty again.
+//  10. Cleanup: DELETE the test RP and custom resource class.
+func e2eTestAllocations(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running allocations endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for allocations e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for allocations e2e test")
+
+	const testRPUUID = "e2e10000-0000-0000-0000-000000000007"
+	const testRPName = "cortex-e2e-test-rp-alloc"
+	const testRC = "CUSTOM_CORTEX_E2E_ALLOC_RC"
+	const consumerUUID1 = "e2e20000-0000-0000-0000-000000000001"
+	const consumerUUID2 = "e2e20000-0000-0000-0000-000000000002"
+	const projectID = "e2e40000-0000-0000-0000-000000000001"
+	const userID = "e2e50000-0000-0000-0000-000000000001"
+	const apiVersion = "placement 1.28"
+
+	// Pre-cleanup: delete allocations, resource provider, and resource class.
+	log.Info("Pre-cleanup: deleting leftover test resources")
+	for _, cleanup := range []struct {
+		method string
+		url    string
+	}{
+		{http.MethodDelete, sc.Endpoint + "/allocations/" + consumerUUID1},
+		{http.MethodDelete, sc.Endpoint + "/allocations/" + consumerUUID2},
+		{http.MethodDelete, sc.Endpoint + "/resource_providers/" + testRPUUID},
+		{http.MethodDelete, sc.Endpoint + "/resource_classes/" + testRC},
+	} {
+		req, err := http.NewRequestWithContext(ctx, cleanup.method, cleanup.url, http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create pre-cleanup request", "url", cleanup.url)
+			return err
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", apiVersion)
+		resp, err := sc.HTTPClient.Do(req)
+		if err != nil {
+			log.Error(err, "failed to send pre-cleanup request", "url", cleanup.url)
+			return err
+		}
+		defer resp.Body.Close()
+		log.Info("Pre-cleanup request completed", "url", cleanup.url, "status", resp.StatusCode)
+	}
+
+	// Create fixtures: custom resource class, resource provider, and inventory.
+	log.Info("Creating custom resource class for allocations test", "class", testRC)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create PUT request for resource class", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for resource class", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT /resource_classes returned an error", "class", testRC)
+		return err
+	}
+	log.Info("Successfully created custom resource class", "class", testRC)
+
+	log.Info("Creating test resource provider for allocations test",
+		"uuid", testRPUUID, "name", testRPName)
+	body, err := json.Marshal(map[string]string{
+		"name": testRPName,
+		"uuid": testRPUUID,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPost, sc.Endpoint+"/resource_providers", bytes.NewReader(body))
+	if err != nil {
+		log.Error(err, "failed to create POST request for resource_providers")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send POST request to /resource_providers")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "POST /resource_providers returned an error")
+		return err
+	}
+	log.Info("Successfully created test resource provider", "uuid", testRPUUID)
+
+	// Get the generation for the resource provider.
+	log.Info("Getting resource provider generation", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP inventories")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP inventories")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP inventories returned an error")
+		return err
+	}
+	var invResp struct {
+		ResourceProviderGeneration int `json:"resource_provider_generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&invResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP inventories response")
+		return err
+	}
+	generation := invResp.ResourceProviderGeneration
+
+	// Set inventory on the resource provider.
+	log.Info("Setting inventory on test resource provider",
+		"uuid", testRPUUID, "class", testRC, "total", 100)
+	putBody, err := json.Marshal(map[string]any{
+		"resource_provider_generation": generation,
+		"inventories": map[string]any{
+			testRC: map[string]any{"total": 100},
+		},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories",
+		bytes.NewReader(putBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for RP inventories")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for RP inventories")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT RP inventories returned an error")
+		return err
+	}
+	log.Info("Successfully set inventory on test resource provider", "uuid", testRPUUID)
+
+	// Test GET /allocations/{consumer_uuid} (empty).
+	log.Info("Testing GET /allocations/{consumer_uuid} (empty)", "consumer", consumerUUID1)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/allocations/"+consumerUUID1, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for allocations", "consumer", consumerUUID1)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for allocations", "consumer", consumerUUID1)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET /allocations returned an error", "consumer", consumerUUID1)
+		return err
+	}
+	var allocResp struct {
+		Allocations map[string]json.RawMessage `json:"allocations"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&allocResp)
+	if err != nil {
+		log.Error(err, "failed to decode allocations response", "consumer", consumerUUID1)
+		return err
+	}
+	log.Info("Successfully retrieved empty allocations for consumer",
+		"consumer", consumerUUID1, "allocationCount", len(allocResp.Allocations))
+
+	// Test PUT /allocations/{consumer_uuid} (create allocation).
+	log.Info("Testing PUT /allocations/{consumer_uuid} to create allocation",
+		"consumer", consumerUUID1, "rp", testRPUUID, "amount", 10)
+	allocBody, err := json.Marshal(map[string]any{
+		"allocations": map[string]any{
+			testRPUUID: map[string]any{
+				"resources": map[string]int{
+					testRC: 10,
+				},
+			},
+		},
+		"project_id":          projectID,
+		"user_id":             userID,
+		"consumer_generation": nil,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/allocations/"+consumerUUID1,
+		bytes.NewReader(allocBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for allocations", "consumer", consumerUUID1)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for allocations", "consumer", consumerUUID1)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT /allocations returned an error", "consumer", consumerUUID1)
+		return err
+	}
+	log.Info("Successfully created allocation for consumer",
+		"consumer", consumerUUID1, "rp", testRPUUID)
+
+	// Test GET /allocations/{consumer_uuid} (after PUT).
+	log.Info("Testing GET /allocations/{consumer_uuid} (after PUT)",
+		"consumer", consumerUUID1)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/allocations/"+consumerUUID1, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for allocations", "consumer", consumerUUID1)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for allocations", "consumer", consumerUUID1)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET /allocations returned an error", "consumer", consumerUUID1)
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&allocResp)
+	if err != nil {
+		log.Error(err, "failed to decode allocations response", "consumer", consumerUUID1)
+		return err
+	}
+	if _, ok := allocResp.Allocations[testRPUUID]; !ok {
+		err := fmt.Errorf("expected allocation against RP %s", testRPUUID)
+		log.Error(err, "allocation not found", "consumer", consumerUUID1)
+		return err
+	}
+	log.Info("Successfully verified allocation for consumer",
+		"consumer", consumerUUID1, "allocationCount", len(allocResp.Allocations))
+
+	// Test POST /allocations (batch manage) — create a second consumer.
+	log.Info("Testing POST /allocations (batch) to create second consumer allocation",
+		"consumer", consumerUUID2, "rp", testRPUUID, "amount", 5)
+	batchBody, err := json.Marshal(map[string]any{
+		consumerUUID2: map[string]any{
+			"allocations": map[string]any{
+				testRPUUID: map[string]any{
+					"resources": map[string]int{
+						testRC: 5,
+					},
+				},
+			},
+			"project_id":          projectID,
+			"user_id":             userID,
+			"consumer_generation": nil,
+		},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPost, sc.Endpoint+"/allocations",
+		bytes.NewReader(batchBody))
+	if err != nil {
+		log.Error(err, "failed to create POST request for batch allocations")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send POST request for batch allocations")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "POST /allocations returned an error")
+		return err
+	}
+	log.Info("Successfully created batch allocation for second consumer",
+		"consumer", consumerUUID2)
+
+	// Verify the second consumer's allocation.
+	log.Info("Verifying second consumer's allocation", "consumer", consumerUUID2)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/allocations/"+consumerUUID2, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for allocations", "consumer", consumerUUID2)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for allocations", "consumer", consumerUUID2)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET /allocations returned an error", "consumer", consumerUUID2)
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&allocResp)
+	if err != nil {
+		log.Error(err, "failed to decode allocations response", "consumer", consumerUUID2)
+		return err
+	}
+	if _, ok := allocResp.Allocations[testRPUUID]; !ok {
+		err := fmt.Errorf("expected allocation against RP %s", testRPUUID)
+		log.Error(err, "allocation not found for second consumer", "consumer", consumerUUID2)
+		return err
+	}
+	log.Info("Successfully verified second consumer's allocation",
+		"consumer", consumerUUID2)
+
+	// Test DELETE /allocations/{consumer_uuid} for both consumers.
+	for _, consumer := range []string{consumerUUID1, consumerUUID2} {
+		log.Info("Testing DELETE /allocations/{consumer_uuid}", "consumer", consumer)
+		req, err = http.NewRequestWithContext(ctx,
+			http.MethodDelete, sc.Endpoint+"/allocations/"+consumer, http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create DELETE request for allocations", "consumer", consumer)
+			return err
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", apiVersion)
+		resp, err = sc.HTTPClient.Do(req)
+		if err != nil {
+			log.Error(err, "failed to send DELETE request for allocations", "consumer", consumer)
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			log.Error(err, "DELETE /allocations returned an error", "consumer", consumer)
+			return err
+		}
+		log.Info("Successfully deleted allocation for consumer", "consumer", consumer)
+	}
+
+	// Verify first consumer's allocations are empty.
+	log.Info("Verifying first consumer's allocations are empty", "consumer", consumerUUID1)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/allocations/"+consumerUUID1, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for allocations", "consumer", consumerUUID1)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for allocations", "consumer", consumerUUID1)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET /allocations returned an error", "consumer", consumerUUID1)
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&allocResp)
+	if err != nil {
+		log.Error(err, "failed to decode allocations response", "consumer", consumerUUID1)
+		return err
+	}
+	if len(allocResp.Allocations) != 0 {
+		err := fmt.Errorf("expected 0 allocations, got %d", len(allocResp.Allocations))
+		log.Error(err, "allocations not cleared", "consumer", consumerUUID1)
+		return err
+	}
+	log.Info("Verified first consumer's allocations are empty", "consumer", consumerUUID1)
+
+	// Cleanup: delete the resource provider and custom resource class.
+	log.Info("Cleaning up test resources")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE resource provider returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully deleted test resource provider", "uuid", testRPUUID)
+
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource class", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource class", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE resource class returned an error", "class", testRC)
+		return err
+	}
+	log.Info("Successfully deleted custom resource class", "class", testRC)
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "allocations",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "allocations", run: e2eTestAllocations})
 }

--- a/internal/shim/placement/handle_allocations_e2e.go
+++ b/internal/shim/placement/handle_allocations_e2e.go
@@ -29,8 +29,7 @@ import (
 //     5 units against the same RP.
 //  7. GET /allocations/{consumer2} — verify the second allocation exists.
 //  8. DELETE /allocations/{consumer} — remove allocations for both consumers.
-//  9. GET /allocations/{consumer1} — verify allocations are empty again.
-//  10. Cleanup: DELETE the test RP and custom resource class.
+//  9. Cleanup: DELETE the test RP and custom resource class.
 func e2eTestAllocations(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 	log.Info("Running allocations endpoint e2e test")
@@ -426,40 +425,6 @@ func e2eTestAllocations(ctx context.Context) error {
 		}
 		log.Info("Successfully deleted allocation for consumer", "consumer", consumer)
 	}
-
-	// Verify first consumer's allocations are empty.
-	log.Info("Verifying first consumer's allocations are empty", "consumer", consumerUUID1)
-	req, err = http.NewRequestWithContext(ctx,
-		http.MethodGet, sc.Endpoint+"/allocations/"+consumerUUID1, http.NoBody)
-	if err != nil {
-		log.Error(err, "failed to create GET request for allocations", "consumer", consumerUUID1)
-		return err
-	}
-	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", apiVersion)
-	req.Header.Set("Accept", "application/json")
-	resp, err = sc.HTTPClient.Do(req)
-	if err != nil {
-		log.Error(err, "failed to send GET request for allocations", "consumer", consumerUUID1)
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		log.Error(err, "GET /allocations returned an error", "consumer", consumerUUID1)
-		return err
-	}
-	err = json.NewDecoder(resp.Body).Decode(&allocResp)
-	if err != nil {
-		log.Error(err, "failed to decode allocations response", "consumer", consumerUUID1)
-		return err
-	}
-	if len(allocResp.Allocations) != 0 {
-		err := fmt.Errorf("expected 0 allocations, got %d", len(allocResp.Allocations))
-		log.Error(err, "allocations not cleared", "consumer", consumerUUID1)
-		return err
-	}
-	log.Info("Verified first consumer's allocations are empty", "consumer", consumerUUID1)
 
 	// Cleanup: delete the resource provider and custom resource class.
 	log.Info("Cleaning up test resources")

--- a/internal/shim/placement/handle_allocations_e2e.go
+++ b/internal/shim/placement/handle_allocations_e2e.go
@@ -78,7 +78,7 @@ func e2eTestAllocations(ctx context.Context) error {
 			log.Error(err, "failed to send pre-cleanup request", "url", cleanup.url)
 			return err
 		}
-		defer resp.Body.Close()
+		resp.Body.Close()
 		log.Info("Pre-cleanup request completed", "url", cleanup.url, "status", resp.StatusCode)
 	}
 
@@ -417,12 +417,13 @@ func e2eTestAllocations(ctx context.Context) error {
 			log.Error(err, "failed to send DELETE request for allocations", "consumer", consumer)
 			return err
 		}
-		defer resp.Body.Close()
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			resp.Body.Close()
 			err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 			log.Error(err, "DELETE /allocations returned an error", "consumer", consumer)
 			return err
 		}
+		resp.Body.Close()
 		log.Info("Successfully deleted allocation for consumer", "consumer", consumer)
 	}
 

--- a/internal/shim/placement/handle_reshaper_e2e.go
+++ b/internal/shim/placement/handle_reshaper_e2e.go
@@ -187,7 +187,7 @@ func e2eTestReshaper(ctx context.Context) error {
 	putBody, err := json.Marshal(map[string]any{
 		"resource_provider_generation": genA,
 		"inventories": map[string]any{
-			testRC: map[string]any{"total": 100},
+			testRC: map[string]any{"total": 100, "max_unit": 100},
 		},
 	})
 	if err != nil {
@@ -317,7 +317,7 @@ func e2eTestReshaper(ctx context.Context) error {
 			},
 			rpBUUID: map[string]any{
 				"inventories": map[string]any{
-					testRC: map[string]any{"total": 100},
+					testRC: map[string]any{"total": 100, "max_unit": 100},
 				},
 				"resource_provider_generation": genB,
 			},

--- a/internal/shim/placement/handle_reshaper_e2e.go
+++ b/internal/shim/placement/handle_reshaper_e2e.go
@@ -3,11 +3,526 @@
 
 package placement
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestReshaper tests the POST /reshaper endpoint by atomically moving
+// inventory and allocations from one resource provider to another.
+//
+//  1. Pre-cleanup: DELETE leftover allocation, both RPs, and custom RC.
+//  2. Create fixtures: PUT a custom resource class, POST two resource
+//     providers (RP-A and RP-B), PUT inventory on RP-A (total=100), PUT
+//     an allocation of 10 units on RP-A.
+//  3. Gather state: GET consumer_generation from the allocation, GET
+//     resource_provider_generation for both RP-A and RP-B.
+//  4. POST /reshaper — atomically clear RP-A's inventory, set inventory on
+//     RP-B, and re-point the consumer's allocation from RP-A to RP-B.
+//  5. Verify RP-A: GET inventories — expect empty.
+//  6. Verify RP-B: GET inventories — expect the custom resource class present.
+//  7. Verify allocation: GET /allocations/{consumer} — expect it to reference
+//     RP-B (not RP-A).
+//  8. Cleanup: DELETE allocation, both RPs, and custom resource class.
+func e2eTestReshaper(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running reshaper endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for reshaper e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for reshaper e2e test")
+
+	const rpAUUID = "e2e10000-0000-0000-0000-000000000009"
+	const rpBUUID = "e2e10000-0000-0000-0000-00000000000a"
+	const rpAName = "cortex-e2e-test-rp-resh-a"
+	const rpBName = "cortex-e2e-test-rp-resh-b"
+	const testRC = "CUSTOM_CORTEX_E2E_RESH_RC"
+	const consumerUUID = "e2e20000-0000-0000-0000-000000000003"
+	const projectID = "e2e40000-0000-0000-0000-000000000001"
+	const userID = "e2e50000-0000-0000-0000-000000000001"
+	const apiVersion = "placement 1.30"
+
+	// Pre-cleanup: delete allocation, both RPs, and custom resource class.
+	log.Info("Pre-cleanup: deleting leftover test resources")
+	for _, cleanup := range []struct {
+		method string
+		url    string
+	}{
+		{http.MethodDelete, sc.Endpoint + "/allocations/" + consumerUUID},
+		{http.MethodDelete, sc.Endpoint + "/resource_providers/" + rpAUUID},
+		{http.MethodDelete, sc.Endpoint + "/resource_providers/" + rpBUUID},
+		{http.MethodDelete, sc.Endpoint + "/resource_classes/" + testRC},
+	} {
+		req, err := http.NewRequestWithContext(ctx, cleanup.method, cleanup.url, http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create pre-cleanup request", "url", cleanup.url)
+			return err
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", apiVersion)
+		resp, err := sc.HTTPClient.Do(req)
+		if err != nil {
+			log.Error(err, "failed to send pre-cleanup request", "url", cleanup.url)
+			return err
+		}
+		defer resp.Body.Close()
+		log.Info("Pre-cleanup request completed", "url", cleanup.url, "status", resp.StatusCode)
+	}
+
+	// Helper to get a resource provider's generation.
+	getGeneration := func(rpUUID string) (int, error) {
+		req, err := http.NewRequestWithContext(ctx,
+			http.MethodGet,
+			sc.Endpoint+"/resource_providers/"+rpUUID+"/inventories",
+			http.NoBody)
+		if err != nil {
+			return 0, err
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", apiVersion)
+		req.Header.Set("Accept", "application/json")
+		resp, err := sc.HTTPClient.Do(req)
+		if err != nil {
+			return 0, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return 0, fmt.Errorf("GET inventories for %s: status %d", rpUUID, resp.StatusCode)
+		}
+		var r struct {
+			ResourceProviderGeneration int `json:"resource_provider_generation"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+			return 0, err
+		}
+		return r.ResourceProviderGeneration, nil
+	}
+
+	// Create fixtures: custom resource class and two resource providers.
+	log.Info("Creating custom resource class for reshaper test", "class", testRC)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create PUT request for resource class", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for resource class", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT /resource_classes returned an error", "class", testRC)
+		return err
+	}
+	log.Info("Successfully created custom resource class", "class", testRC)
+
+	for _, rp := range []struct {
+		uuid string
+		name string
+	}{
+		{rpAUUID, rpAName},
+		{rpBUUID, rpBName},
+	} {
+		log.Info("Creating resource provider for reshaper test",
+			"uuid", rp.uuid, "name", rp.name)
+		body, err := json.Marshal(map[string]string{
+			"name": rp.name,
+			"uuid": rp.uuid,
+		})
+		if err != nil {
+			log.Error(err, "failed to marshal request body")
+			return err
+		}
+		req, err = http.NewRequestWithContext(ctx,
+			http.MethodPost, sc.Endpoint+"/resource_providers", bytes.NewReader(body))
+		if err != nil {
+			log.Error(err, "failed to create POST request for resource_providers")
+			return err
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", apiVersion)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		resp, err = sc.HTTPClient.Do(req)
+		if err != nil {
+			log.Error(err, "failed to send POST request to /resource_providers")
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			log.Error(err, "POST /resource_providers returned an error", "uuid", rp.uuid)
+			return err
+		}
+		log.Info("Successfully created resource provider", "uuid", rp.uuid)
+	}
+
+	// Set inventory on RP-A.
+	genA, err := getGeneration(rpAUUID)
+	if err != nil {
+		log.Error(err, "failed to get generation for RP-A", "uuid", rpAUUID)
+		return err
+	}
+	log.Info("Setting inventory on RP-A", "uuid", rpAUUID, "class", testRC,
+		"generation", genA)
+	putBody, err := json.Marshal(map[string]any{
+		"resource_provider_generation": genA,
+		"inventories": map[string]any{
+			testRC: map[string]any{"total": 100},
+		},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_providers/"+rpAUUID+"/inventories",
+		bytes.NewReader(putBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for RP-A inventories")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for RP-A inventories")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT RP-A inventories returned an error")
+		return err
+	}
+	log.Info("Successfully set inventory on RP-A", "uuid", rpAUUID)
+
+	// Create an allocation on RP-A.
+	log.Info("Creating allocation on RP-A", "consumer", consumerUUID,
+		"rp", rpAUUID, "amount", 10)
+	allocBody, err := json.Marshal(map[string]any{
+		"allocations": map[string]any{
+			rpAUUID: map[string]any{
+				"resources": map[string]int{testRC: 10},
+			},
+		},
+		"project_id":          projectID,
+		"user_id":             userID,
+		"consumer_generation": nil,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/allocations/"+consumerUUID,
+		bytes.NewReader(allocBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for allocations")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for allocations")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT /allocations returned an error")
+		return err
+	}
+	log.Info("Successfully created allocation on RP-A", "consumer", consumerUUID)
+
+	// Get consumer_generation.
+	log.Info("Getting consumer generation", "consumer", consumerUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/allocations/"+consumerUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for allocations")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for allocations")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET /allocations returned an error")
+		return err
+	}
+	var consumerResp struct {
+		ConsumerGeneration int `json:"consumer_generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&consumerResp)
+	if err != nil {
+		log.Error(err, "failed to decode consumer allocations response")
+		return err
+	}
+	consumerGen := consumerResp.ConsumerGeneration
+	log.Info("Got consumer generation", "consumer", consumerUUID,
+		"generation", consumerGen)
+
+	// Refresh both RP generations (may have changed due to allocation).
+	genA, err = getGeneration(rpAUUID)
+	if err != nil {
+		log.Error(err, "failed to get updated generation for RP-A")
+		return err
+	}
+	genB, err := getGeneration(rpBUUID)
+	if err != nil {
+		log.Error(err, "failed to get generation for RP-B")
+		return err
+	}
+	log.Info("Got resource provider generations", "genA", genA, "genB", genB)
+
+	// Test POST /reshaper: move inventory from RP-A to RP-B and re-point
+	// the allocation from RP-A to RP-B.
+	log.Info("Testing POST /reshaper to move inventory and allocation from RP-A to RP-B")
+	reshaperBody, err := json.Marshal(map[string]any{
+		"inventories": map[string]any{
+			rpAUUID: map[string]any{
+				"inventories":                  map[string]any{},
+				"resource_provider_generation": genA,
+			},
+			rpBUUID: map[string]any{
+				"inventories": map[string]any{
+					testRC: map[string]any{"total": 100},
+				},
+				"resource_provider_generation": genB,
+			},
+		},
+		"allocations": map[string]any{
+			consumerUUID: map[string]any{
+				"allocations": map[string]any{
+					rpBUUID: map[string]any{
+						"resources": map[string]int{testRC: 10},
+					},
+				},
+				"project_id":          projectID,
+				"user_id":             userID,
+				"consumer_generation": consumerGen,
+			},
+		},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPost, sc.Endpoint+"/reshaper",
+		bytes.NewReader(reshaperBody))
+	if err != nil {
+		log.Error(err, "failed to create POST request for reshaper")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send POST request for reshaper")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "POST /reshaper returned an error")
+		return err
+	}
+	log.Info("Successfully executed reshaper")
+
+	// Verify: RP-A inventories should be empty.
+	log.Info("Verifying RP-A inventories are empty after reshaper", "uuid", rpAUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+rpAUUID+"/inventories", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP-A inventories")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP-A inventories")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP-A inventories returned an error")
+		return err
+	}
+	var invResp struct {
+		Inventories map[string]json.RawMessage `json:"inventories"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&invResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP-A inventories response")
+		return err
+	}
+	if len(invResp.Inventories) != 0 {
+		err := fmt.Errorf("expected 0 inventories on RP-A, got %d", len(invResp.Inventories))
+		log.Error(err, "RP-A inventories not empty after reshaper")
+		return err
+	}
+	log.Info("Verified RP-A inventories are empty", "uuid", rpAUUID)
+
+	// Verify: RP-B inventories should have our resource class.
+	log.Info("Verifying RP-B inventories after reshaper", "uuid", rpBUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+rpBUUID+"/inventories", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP-B inventories")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP-B inventories")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP-B inventories returned an error")
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&invResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP-B inventories response")
+		return err
+	}
+	if _, ok := invResp.Inventories[testRC]; !ok {
+		err := fmt.Errorf("expected %s inventory on RP-B", testRC)
+		log.Error(err, "RP-B missing expected inventory after reshaper")
+		return err
+	}
+	log.Info("Verified RP-B has inventory after reshaper",
+		"uuid", rpBUUID, "class", testRC)
+
+	// Verify: allocation should now point to RP-B.
+	log.Info("Verifying allocation points to RP-B after reshaper",
+		"consumer", consumerUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/allocations/"+consumerUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for allocations")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for allocations")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET /allocations returned an error")
+		return err
+	}
+	var allocResp struct {
+		Allocations map[string]json.RawMessage `json:"allocations"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&allocResp)
+	if err != nil {
+		log.Error(err, "failed to decode allocations response")
+		return err
+	}
+	if _, ok := allocResp.Allocations[rpBUUID]; !ok {
+		err := fmt.Errorf("expected allocation against RP-B %s, got keys %v",
+			rpBUUID, func() []string {
+				keys := make([]string, 0, len(allocResp.Allocations))
+				for k := range allocResp.Allocations {
+					keys = append(keys, k)
+				}
+				return keys
+			}())
+		log.Error(err, "allocation not pointing to RP-B after reshaper")
+		return err
+	}
+	if _, ok := allocResp.Allocations[rpAUUID]; ok {
+		err := fmt.Errorf("allocation still points to RP-A %s", rpAUUID)
+		log.Error(err, "allocation should not point to RP-A after reshaper")
+		return err
+	}
+	log.Info("Verified allocation points to RP-B after reshaper",
+		"consumer", consumerUUID, "rp", rpBUUID)
+
+	// Cleanup: delete allocation, both RPs, and custom resource class.
+	log.Info("Cleaning up test resources")
+	for _, cleanup := range []struct {
+		url  string
+		desc string
+	}{
+		{sc.Endpoint + "/allocations/" + consumerUUID, "allocation"},
+		{sc.Endpoint + "/resource_providers/" + rpAUUID, "RP-A"},
+		{sc.Endpoint + "/resource_providers/" + rpBUUID, "RP-B"},
+		{sc.Endpoint + "/resource_classes/" + testRC, "resource class"},
+	} {
+		log.Info("Deleting test resource", "desc", cleanup.desc)
+		req, err = http.NewRequestWithContext(ctx,
+			http.MethodDelete, cleanup.url, http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create DELETE request", "desc", cleanup.desc)
+			return err
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", apiVersion)
+		resp, err = sc.HTTPClient.Do(req)
+		if err != nil {
+			log.Error(err, "failed to send DELETE request", "desc", cleanup.desc)
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			log.Error(err, "DELETE returned an error", "desc", cleanup.desc)
+			return err
+		}
+		log.Info("Successfully deleted test resource", "desc", cleanup.desc)
+	}
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "reshaper",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "reshaper", run: e2eTestReshaper})
 }

--- a/internal/shim/placement/handle_reshaper_e2e.go
+++ b/internal/shim/placement/handle_reshaper_e2e.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
@@ -402,9 +401,8 @@ func e2eTestReshaper(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(resp.Body)
 		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		log.Error(err, "POST /reshaper returned an error", "body", string(respBody))
+		log.Error(err, "POST /reshaper returned an error")
 		return err
 	}
 	log.Info("Successfully executed reshaper")

--- a/internal/shim/placement/handle_reshaper_e2e.go
+++ b/internal/shim/placement/handle_reshaper_e2e.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
@@ -19,11 +20,11 @@ import (
 //
 //  1. Pre-cleanup: DELETE leftover allocation, both RPs, and custom RC.
 //  2. Create fixtures: PUT a custom resource class, POST two resource
-//     providers (RP-A and RP-B), PUT inventory on RP-A (total=100), PUT
-//     an allocation of 10 units on RP-A.
+//     providers (RP-A and RP-B), PUT inventory on both RP-A and RP-B
+//     (total=100), PUT an allocation of 10 units on RP-A.
 //  3. Gather state: GET consumer_generation from the allocation, GET
 //     resource_provider_generation for both RP-A and RP-B.
-//  4. POST /reshaper — atomically clear RP-A's inventory, set inventory on
+//  4. POST /reshaper — atomically clear RP-A's inventory, update inventory on
 //     RP-B, and re-point the consumer's allocation from RP-A to RP-B.
 //  5. Verify RP-A: GET inventories — expect empty.
 //  6. Verify RP-B: GET inventories — expect the custom resource class present.
@@ -218,6 +219,50 @@ func e2eTestReshaper(ctx context.Context) error {
 	}
 	log.Info("Successfully set inventory on RP-A", "uuid", rpAUUID)
 
+	// Pre-seed inventory on RP-B so the reshaper can validate allocation
+	// constraints (some placement versions need the target RP to already have
+	// an inventory row in the database).
+	genB, err := getGeneration(rpBUUID)
+	if err != nil {
+		log.Error(err, "failed to get generation for RP-B before seeding inventory")
+		return err
+	}
+	log.Info("Seeding inventory on RP-B", "uuid", rpBUUID, "class", testRC,
+		"generation", genB)
+	seedBody, err := json.Marshal(map[string]any{
+		"resource_provider_generation": genB,
+		"inventories": map[string]any{
+			testRC: map[string]any{"total": 100, "max_unit": 100},
+		},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_providers/"+rpBUUID+"/inventories",
+		bytes.NewReader(seedBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for RP-B inventories")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for RP-B inventories")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT RP-B inventories returned an error")
+		return err
+	}
+	log.Info("Successfully seeded inventory on RP-B", "uuid", rpBUUID)
+
 	// Create an allocation on RP-A.
 	log.Info("Creating allocation on RP-A", "consumer", consumerUUID,
 		"rp", rpAUUID, "amount", 10)
@@ -299,7 +344,7 @@ func e2eTestReshaper(ctx context.Context) error {
 		log.Error(err, "failed to get updated generation for RP-A")
 		return err
 	}
-	genB, err := getGeneration(rpBUUID)
+	genB, err = getGeneration(rpBUUID)
 	if err != nil {
 		log.Error(err, "failed to get generation for RP-B")
 		return err
@@ -357,8 +402,9 @@ func e2eTestReshaper(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
 		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		log.Error(err, "POST /reshaper returned an error")
+		log.Error(err, "POST /reshaper returned an error", "body", string(respBody))
 		return err
 	}
 	log.Info("Successfully executed reshaper")

--- a/internal/shim/placement/handle_reshaper_e2e.go
+++ b/internal/shim/placement/handle_reshaper_e2e.go
@@ -79,7 +79,7 @@ func e2eTestReshaper(ctx context.Context) error {
 			log.Error(err, "failed to send pre-cleanup request", "url", cleanup.url)
 			return err
 		}
-		defer resp.Body.Close()
+		resp.Body.Close()
 		log.Info("Pre-cleanup request completed", "url", cleanup.url, "status", resp.StatusCode)
 	}
 
@@ -167,12 +167,13 @@ func e2eTestReshaper(ctx context.Context) error {
 			log.Error(err, "failed to send POST request to /resource_providers")
 			return err
 		}
-		defer resp.Body.Close()
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			resp.Body.Close()
 			err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 			log.Error(err, "POST /resource_providers returned an error", "uuid", rp.uuid)
 			return err
 		}
+		resp.Body.Close()
 		log.Info("Successfully created resource provider", "uuid", rp.uuid)
 	}
 
@@ -555,12 +556,13 @@ func e2eTestReshaper(ctx context.Context) error {
 			log.Error(err, "failed to send DELETE request", "desc", cleanup.desc)
 			return err
 		}
-		defer resp.Body.Close()
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			resp.Body.Close()
 			err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 			log.Error(err, "DELETE returned an error", "desc", cleanup.desc)
 			return err
 		}
+		resp.Body.Close()
 		log.Info("Successfully deleted test resource", "desc", cleanup.desc)
 	}
 

--- a/internal/shim/placement/handle_resource_classes_e2e.go
+++ b/internal/shim/placement/handle_resource_classes_e2e.go
@@ -3,11 +3,227 @@
 
 package placement
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestResourceClasses tests the /resource_classes and
+// /resource_classes/{name} endpoints.
+//
+//  1. Pre-cleanup: DELETE any leftover custom resource class (ignore 404).
+//  2. GET /resource_classes — list all classes and verify the response.
+//  3. GET /resource_classes/VCPU — confirm a standard class is retrievable.
+//  4. PUT /resource_classes/{name} — create a custom test class.
+//  5. GET /resource_classes/{name} — verify the custom class now exists.
+//  6. DELETE /resource_classes/{name} — remove the custom class.
+//  7. GET /resource_classes/{name} — confirm deletion returns 404.
+func e2eTestResourceClasses(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running resource classes endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for resource classes e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for resource classes e2e test")
+
+	const testRC = "CUSTOM_CORTEX_E2E_RC"
+
+	// Pre-cleanup: delete any leftover test resource class from a prior run.
+	log.Info("Pre-cleanup: deleting leftover test resource class", "class", testRC)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create pre-cleanup request")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.7")
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send pre-cleanup request")
+		return err
+	}
+	defer resp.Body.Close()
+	// Ignore 404 (not found) — that's expected if no leftover exists.
+	if resp.StatusCode != http.StatusNotFound &&
+		(resp.StatusCode < 200 || resp.StatusCode >= 300) {
+		err := fmt.Errorf("unexpected status code during pre-cleanup: %d", resp.StatusCode)
+		log.Error(err, "pre-cleanup failed")
+		return err
+	}
+	log.Info("Pre-cleanup completed", "status", resp.StatusCode)
+
+	// Test GET /resource_classes
+	log.Info("Testing GET /resource_classes endpoint of placement shim")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_classes", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create request for resource_classes endpoint")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.7")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send request to /resource_classes endpoint")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "/resource_classes endpoint returned an error")
+		return err
+	}
+	var list struct {
+		ResourceClasses []struct {
+			Name string `json:"name"`
+		} `json:"resource_classes"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&list)
+	if err != nil {
+		log.Error(err, "failed to decode response from /resource_classes endpoint")
+		return err
+	}
+	log.Info("Successfully retrieved resource classes from placement shim",
+		"count", len(list.ResourceClasses))
+
+	// Test GET /resource_classes/{name} for a standard class
+	log.Info("Testing GET /resource_classes/VCPU endpoint of placement shim")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_classes/VCPU", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create request for resource_classes/VCPU endpoint")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.7")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send request to /resource_classes/VCPU endpoint")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "/resource_classes/VCPU endpoint returned an error")
+		return err
+	}
+	log.Info("Successfully retrieved standard resource class VCPU from placement shim")
+
+	// Test PUT /resource_classes/{name} (create custom class)
+	log.Info("Testing PUT /resource_classes/{name} to create custom class", "class", testRC)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create PUT request for resource_classes", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.7")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request to /resource_classes", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT /resource_classes returned an error", "class", testRC)
+		return err
+	}
+	log.Info("Successfully created custom resource class", "class", testRC,
+		"status", resp.StatusCode)
+
+	// Test GET /resource_classes/{name} for the custom class
+	log.Info("Testing GET /resource_classes/{name} for custom class", "class", testRC)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for custom resource class", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.7")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for custom resource class", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET custom resource class returned an error", "class", testRC)
+		return err
+	}
+	log.Info("Successfully verified custom resource class exists", "class", testRC)
+
+	// Cleanup: Test DELETE /resource_classes/{name}
+	log.Info("Cleaning up test resource class from placement shim", "class", testRC)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource class", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.7")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource class", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE resource class returned an error", "class", testRC)
+		return err
+	}
+	log.Info("Successfully deleted test resource class", "class", testRC)
+
+	// Verify deletion: GET should return 404
+	log.Info("Verifying test resource class was deleted", "class", testRC)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create verification GET request", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.7")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send verification GET request", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		err := fmt.Errorf("expected 404 after deletion, got: %d", resp.StatusCode)
+		log.Error(err, "resource class still exists after deletion", "class", testRC)
+		return err
+	}
+	log.Info("Verified test resource class was deleted", "class", testRC)
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "resource_classes",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "resource_classes", run: e2eTestResourceClasses})
 }

--- a/internal/shim/placement/handle_resource_provider_aggregates_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_aggregates_e2e.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -21,9 +22,10 @@ import (
 //  2. POST /resource_providers — create a test RP.
 //  3. GET /{uuid}/aggregates — verify aggregates are empty, store generation.
 //  4. PUT /{uuid}/aggregates — associate two aggregate UUIDs with the RP.
-//  5. GET /{uuid}/aggregates — verify both aggregates are present.
+//  5. GET /{uuid}/aggregates — verify both aggregate UUIDs are present.
 //  6. PUT /{uuid}/aggregates — clear aggregates by sending an empty list.
-//  7. Cleanup: DELETE the test RP.
+//  7. GET /{uuid}/aggregates — verify aggregates are empty after clear.
+//  8. Cleanup: DELETE the test RP (also runs via deferred cleanup on failure).
 func e2eTestResourceProviderAggregates(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 	log.Info("Running resource provider aggregates endpoint e2e test")
@@ -60,8 +62,8 @@ func e2eTestResourceProviderAggregates(ctx context.Context) error {
 		log.Error(err, "failed to send pre-cleanup request")
 		return err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusConflict &&
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound &&
 		(resp.StatusCode < 200 || resp.StatusCode >= 300) {
 		err := fmt.Errorf("unexpected status code during pre-cleanup: %d", resp.StatusCode)
 		log.Error(err, "pre-cleanup failed")
@@ -103,6 +105,27 @@ func e2eTestResourceProviderAggregates(ctx context.Context) error {
 	}
 	log.Info("Successfully created test resource provider for aggregates test",
 		"uuid", testRPUUID)
+
+	// Deferred cleanup: always delete the test RP on exit so a failed
+	// assertion doesn't leave the fixed UUID behind.
+	defer func() {
+		log.Info("Deferred cleanup: deleting test resource provider", "uuid", testRPUUID)
+		dReq, dErr := http.NewRequestWithContext(ctx,
+			http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+		if dErr != nil {
+			log.Error(dErr, "deferred cleanup: failed to create DELETE request")
+			return
+		}
+		dReq.Header.Set("X-Auth-Token", sc.TokenID)
+		dReq.Header.Set("OpenStack-API-Version", "placement 1.19")
+		dResp, dErr := sc.HTTPClient.Do(dReq)
+		if dErr != nil {
+			log.Error(dErr, "deferred cleanup: failed to send DELETE request")
+			return
+		}
+		dResp.Body.Close()
+		log.Info("Deferred cleanup completed", "status", dResp.StatusCode)
+	}()
 
 	// Test GET /resource_providers/{uuid}/aggregates (empty).
 	log.Info("Testing GET /resource_providers/{uuid}/aggregates (empty)",
@@ -214,9 +237,12 @@ func e2eTestResourceProviderAggregates(ctx context.Context) error {
 		log.Error(err, "failed to decode RP aggregates response", "uuid", testRPUUID)
 		return err
 	}
-	if len(aggResp.Aggregates) != 2 {
-		err := fmt.Errorf("expected 2 aggregates, got %d", len(aggResp.Aggregates))
-		log.Error(err, "aggregate count mismatch", "uuid", testRPUUID)
+	if len(aggResp.Aggregates) != 2 ||
+		!slices.Contains(aggResp.Aggregates, testAggUUID1) ||
+		!slices.Contains(aggResp.Aggregates, testAggUUID2) {
+		err := fmt.Errorf("expected aggregates %v, got %v",
+			[]string{testAggUUID1, testAggUUID2}, aggResp.Aggregates)
+		log.Error(err, "aggregate mismatch", "uuid", testRPUUID)
 		return err
 	}
 	log.Info("Successfully verified aggregates on test resource provider",
@@ -257,6 +283,40 @@ func e2eTestResourceProviderAggregates(ctx context.Context) error {
 	}
 	log.Info("Successfully cleared aggregates on test resource provider",
 		"uuid", testRPUUID)
+
+	// Verify aggregates are empty after clear.
+	log.Info("Verifying aggregates are empty after clear", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/aggregates", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP aggregates", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.19")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP aggregates", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP aggregates returned an error", "uuid", testRPUUID)
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&aggResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP aggregates response", "uuid", testRPUUID)
+		return err
+	}
+	if len(aggResp.Aggregates) != 0 {
+		err := fmt.Errorf("expected 0 aggregates after clear, got %d", len(aggResp.Aggregates))
+		log.Error(err, "aggregates not empty after clear", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Verified aggregates are empty after clear", "uuid", testRPUUID)
 
 	// Cleanup: delete the test resource provider.
 	log.Info("Cleaning up test resource provider", "uuid", testRPUUID)

--- a/internal/shim/placement/handle_resource_provider_aggregates_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_aggregates_e2e.go
@@ -3,11 +3,287 @@
 
 package placement
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestResourceProviderAggregates tests the
+// /resource_providers/{uuid}/aggregates endpoints.
+//
+//  1. Pre-cleanup: DELETE any leftover test RP (ignore 404).
+//  2. POST /resource_providers — create a test RP.
+//  3. GET /{uuid}/aggregates — verify aggregates are empty, store generation.
+//  4. PUT /{uuid}/aggregates — associate two aggregate UUIDs with the RP.
+//  5. GET /{uuid}/aggregates — verify both aggregates are present.
+//  6. PUT /{uuid}/aggregates — clear aggregates by sending an empty list.
+//  7. Cleanup: DELETE the test RP.
+func e2eTestResourceProviderAggregates(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running resource provider aggregates endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for resource provider aggregates e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for resource provider aggregates e2e test")
+
+	const testRPUUID = "e2e10000-0000-0000-0000-000000000004"
+	const testRPName = "cortex-e2e-test-rp-agg"
+	const testAggUUID1 = "e2e30000-0000-0000-0000-000000000001"
+	const testAggUUID2 = "e2e30000-0000-0000-0000-000000000002"
+
+	// Pre-cleanup: delete any leftover test resource provider from a prior run.
+	log.Info("Pre-cleanup: deleting leftover test resource provider", "uuid", testRPUUID)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create pre-cleanup request")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.19")
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send pre-cleanup request")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusConflict &&
+		(resp.StatusCode < 200 || resp.StatusCode >= 300) {
+		err := fmt.Errorf("unexpected status code during pre-cleanup: %d", resp.StatusCode)
+		log.Error(err, "pre-cleanup failed")
+		return err
+	}
+	log.Info("Pre-cleanup completed", "status", resp.StatusCode)
+
+	// Create a test resource provider.
+	log.Info("Creating test resource provider for aggregates test",
+		"uuid", testRPUUID, "name", testRPName)
+	body, err := json.Marshal(map[string]string{
+		"name": testRPName,
+		"uuid": testRPUUID,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPost, sc.Endpoint+"/resource_providers", bytes.NewReader(body))
+	if err != nil {
+		log.Error(err, "failed to create POST request for resource_providers")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send POST request to /resource_providers")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "POST /resource_providers returned an error")
+		return err
+	}
+	log.Info("Successfully created test resource provider for aggregates test",
+		"uuid", testRPUUID)
+
+	// Test GET /resource_providers/{uuid}/aggregates (empty).
+	log.Info("Testing GET /resource_providers/{uuid}/aggregates (empty)",
+		"uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/aggregates", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP aggregates", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.19")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP aggregates", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP aggregates returned an error", "uuid", testRPUUID)
+		return err
+	}
+	var aggResp struct {
+		Aggregates                 []string `json:"aggregates"`
+		ResourceProviderGeneration int      `json:"resource_provider_generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&aggResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP aggregates response", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully retrieved empty aggregates for test resource provider",
+		"uuid", testRPUUID, "aggregates", len(aggResp.Aggregates),
+		"generation", aggResp.ResourceProviderGeneration)
+
+	// Test PUT /resource_providers/{uuid}/aggregates (set two aggregates).
+	log.Info("Testing PUT /resource_providers/{uuid}/aggregates to set aggregates",
+		"uuid", testRPUUID, "agg1", testAggUUID1, "agg2", testAggUUID2)
+	putBody, err := json.Marshal(map[string]any{
+		"resource_provider_generation": aggResp.ResourceProviderGeneration,
+		"aggregates":                   []string{testAggUUID1, testAggUUID2},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_providers/"+testRPUUID+"/aggregates",
+		bytes.NewReader(putBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for RP aggregates", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.19")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for RP aggregates", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT RP aggregates returned an error", "uuid", testRPUUID)
+		return err
+	}
+	var putAggResp struct {
+		Aggregates                 []string `json:"aggregates"`
+		ResourceProviderGeneration int      `json:"resource_provider_generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&putAggResp)
+	if err != nil {
+		log.Error(err, "failed to decode PUT RP aggregates response", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully set aggregates on test resource provider",
+		"uuid", testRPUUID, "aggregates", len(putAggResp.Aggregates),
+		"generation", putAggResp.ResourceProviderGeneration)
+
+	// Test GET /resource_providers/{uuid}/aggregates (after PUT).
+	log.Info("Testing GET /resource_providers/{uuid}/aggregates (after PUT)",
+		"uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/aggregates", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP aggregates", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.19")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP aggregates", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP aggregates returned an error", "uuid", testRPUUID)
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&aggResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP aggregates response", "uuid", testRPUUID)
+		return err
+	}
+	if len(aggResp.Aggregates) != 2 {
+		err := fmt.Errorf("expected 2 aggregates, got %d", len(aggResp.Aggregates))
+		log.Error(err, "aggregate count mismatch", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully verified aggregates on test resource provider",
+		"uuid", testRPUUID, "aggregates", aggResp.Aggregates)
+
+	// Clear aggregates by PUT with empty list.
+	log.Info("Testing PUT /resource_providers/{uuid}/aggregates to clear aggregates",
+		"uuid", testRPUUID)
+	putBody, err = json.Marshal(map[string]any{
+		"resource_provider_generation": aggResp.ResourceProviderGeneration,
+		"aggregates":                   []string{},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_providers/"+testRPUUID+"/aggregates",
+		bytes.NewReader(putBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request to clear RP aggregates", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.19")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request to clear RP aggregates", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT to clear RP aggregates returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully cleared aggregates on test resource provider",
+		"uuid", testRPUUID)
+
+	// Cleanup: delete the test resource provider.
+	log.Info("Cleaning up test resource provider", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.19")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE /resource_providers/{uuid} returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully deleted test resource provider", "uuid", testRPUUID)
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "resource_provider_aggregates",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "resource_provider_aggregates", run: e2eTestResourceProviderAggregates})
 }

--- a/internal/shim/placement/handle_resource_provider_allocations_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_allocations_e2e.go
@@ -188,12 +188,13 @@ func e2eTestResourceProviderAllocations(ctx context.Context) error {
 			log.Error(err, "failed to send GET request for RP allocations", "uuid", rp.UUID)
 			return err
 		}
-		defer rpResp.Body.Close()
 		if rpResp.StatusCode < 200 || rpResp.StatusCode >= 300 {
+			rpResp.Body.Close()
 			err := fmt.Errorf("unexpected status code: %d", rpResp.StatusCode)
 			log.Error(err, "GET RP allocations returned an error", "uuid", rp.UUID)
 			return err
 		}
+		rpResp.Body.Close()
 		log.Info("Successfully retrieved allocations for existing resource provider",
 			"uuid", rp.UUID)
 	}

--- a/internal/shim/placement/handle_resource_provider_allocations_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_allocations_e2e.go
@@ -3,11 +3,227 @@
 
 package placement
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestResourceProviderAllocations tests the
+// /resource_providers/{uuid}/allocations endpoint.
+//
+//  1. Pre-cleanup: DELETE any leftover test RP (ignore 404).
+//  2. POST /resource_providers — create a test RP.
+//  3. GET /{uuid}/allocations — retrieve allocations for the test RP (expect
+//     an empty allocations map since nothing has been allocated).
+//  4. GET /resource_providers — list real providers, then GET /{uuid}/allocations
+//     on up to 3 of them to verify the endpoint works with production data.
+//  5. Cleanup: DELETE the test RP.
+func e2eTestResourceProviderAllocations(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running resource provider allocations endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for resource provider allocations e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for resource provider allocations e2e test")
+
+	const testRPUUID = "e2e10000-0000-0000-0000-000000000006"
+	const testRPName = "cortex-e2e-test-rp-alloc-view"
+
+	// Pre-cleanup: delete any leftover test resource provider from a prior run.
+	log.Info("Pre-cleanup: deleting leftover test resource provider", "uuid", testRPUUID)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create pre-cleanup request")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send pre-cleanup request")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusConflict &&
+		(resp.StatusCode < 200 || resp.StatusCode >= 300) {
+		err := fmt.Errorf("unexpected status code during pre-cleanup: %d", resp.StatusCode)
+		log.Error(err, "pre-cleanup failed")
+		return err
+	}
+	log.Info("Pre-cleanup completed", "status", resp.StatusCode)
+
+	// Create a test resource provider.
+	log.Info("Creating test resource provider for allocations view test",
+		"uuid", testRPUUID, "name", testRPName)
+	body, err := json.Marshal(map[string]string{
+		"name": testRPName,
+		"uuid": testRPUUID,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPost, sc.Endpoint+"/resource_providers", bytes.NewReader(body))
+	if err != nil {
+		log.Error(err, "failed to create POST request for resource_providers")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send POST request to /resource_providers")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "POST /resource_providers returned an error")
+		return err
+	}
+	log.Info("Successfully created test resource provider for allocations view test",
+		"uuid", testRPUUID)
+
+	// Test GET /resource_providers/{uuid}/allocations on our test provider.
+	log.Info("Testing GET /resource_providers/{uuid}/allocations on test provider",
+		"uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/allocations", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP allocations", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP allocations", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP allocations returned an error", "uuid", testRPUUID)
+		return err
+	}
+	var allocResp struct {
+		Allocations                map[string]json.RawMessage `json:"allocations"`
+		ResourceProviderGeneration int                        `json:"resource_provider_generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&allocResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP allocations response", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully retrieved allocations for test resource provider",
+		"uuid", testRPUUID, "allocationCount", len(allocResp.Allocations))
+
+	// Also test against existing real resource providers.
+	log.Info("Testing GET /resource_providers/{uuid}/allocations on existing providers")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create request for listing resource providers")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send request to list resource providers")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "list resource providers returned an error")
+		return err
+	}
+	var rpList struct {
+		ResourceProviders []struct {
+			UUID string `json:"uuid"`
+		} `json:"resource_providers"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&rpList)
+	if err != nil {
+		log.Error(err, "failed to decode resource providers list")
+		return err
+	}
+	for i, rp := range rpList.ResourceProviders {
+		if i >= 3 {
+			break
+		}
+		log.Info("Testing GET allocations on existing resource provider", "uuid", rp.UUID)
+		rpReq, err := http.NewRequestWithContext(ctx,
+			http.MethodGet, sc.Endpoint+"/resource_providers/"+rp.UUID+"/allocations", http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create GET request for RP allocations", "uuid", rp.UUID)
+			return err
+		}
+		rpReq.Header.Set("X-Auth-Token", sc.TokenID)
+		rpReq.Header.Set("OpenStack-API-Version", "placement 1.20")
+		rpReq.Header.Set("Accept", "application/json")
+		rpResp, err := sc.HTTPClient.Do(rpReq)
+		if err != nil {
+			log.Error(err, "failed to send GET request for RP allocations", "uuid", rp.UUID)
+			return err
+		}
+		defer rpResp.Body.Close()
+		if rpResp.StatusCode < 200 || rpResp.StatusCode >= 300 {
+			err := fmt.Errorf("unexpected status code: %d", rpResp.StatusCode)
+			log.Error(err, "GET RP allocations returned an error", "uuid", rp.UUID)
+			return err
+		}
+		log.Info("Successfully retrieved allocations for existing resource provider",
+			"uuid", rp.UUID)
+	}
+
+	// Cleanup: delete the test resource provider.
+	log.Info("Cleaning up test resource provider", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE /resource_providers/{uuid} returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully deleted test resource provider", "uuid", testRPUUID)
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "resource_provider_allocations",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "resource_provider_allocations", run: e2eTestResourceProviderAllocations})
 }

--- a/internal/shim/placement/handle_resource_provider_inventories_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_inventories_e2e.go
@@ -27,10 +27,9 @@ import (
 //     verify total equals 100.
 //  6. PUT /{uuid}/inventories/{rc} — update the single inventory total to 200.
 //  7. DELETE /{uuid}/inventories/{rc} — remove the single inventory record.
-//  8. GET /{uuid}/inventories — verify the inventory list is now empty.
-//  9. PUT /{uuid}/inventories — re-add inventory (total=50) for the bulk test.
-//  10. DELETE /{uuid}/inventories — bulk-delete all inventories at once.
-//  11. Cleanup: DELETE the test RP and custom resource class.
+//  8. PUT /{uuid}/inventories — re-add inventory (total=50) for the bulk test.
+//  9. DELETE /{uuid}/inventories — bulk-delete all inventories at once.
+// 10. Cleanup: DELETE the test RP and custom resource class.
 func e2eTestResourceProviderInventories(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 	log.Info("Running resource provider inventories endpoint e2e test")
@@ -348,8 +347,8 @@ func e2eTestResourceProviderInventories(ctx context.Context) error {
 	log.Info("Successfully deleted single inventory",
 		"uuid", testRPUUID, "class", testRC)
 
-	// Verify inventory deleted by listing all inventories.
-	log.Info("Verifying inventory deleted", "uuid", testRPUUID)
+	// Get the updated generation after single-item delete for the next PUT.
+	log.Info("Getting updated generation after delete", "uuid", testRPUUID)
 	req, err = http.NewRequestWithContext(ctx,
 		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories", http.NoBody)
 	if err != nil {
@@ -375,13 +374,8 @@ func e2eTestResourceProviderInventories(ctx context.Context) error {
 		log.Error(err, "failed to decode RP inventories response", "uuid", testRPUUID)
 		return err
 	}
-	if len(invResp.Inventories) != 0 {
-		err := fmt.Errorf("expected 0 inventories, got %d", len(invResp.Inventories))
-		log.Error(err, "inventory not deleted", "uuid", testRPUUID)
-		return err
-	}
 	generation = invResp.ResourceProviderGeneration
-	log.Info("Verified inventory deleted", "uuid", testRPUUID, "generation", generation)
+	log.Info("Got updated generation after delete", "uuid", testRPUUID, "generation", generation)
 
 	// Re-add inventory via PUT all, then test bulk DELETE /inventories.
 	log.Info("Re-adding inventory for bulk delete test", "uuid", testRPUUID, "class", testRC)

--- a/internal/shim/placement/handle_resource_provider_inventories_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_inventories_e2e.go
@@ -29,6 +29,7 @@ import (
 //  7. DELETE /{uuid}/inventories/{rc} — remove the single inventory record.
 //  8. PUT /{uuid}/inventories — re-add inventory (total=50) for the bulk test.
 //  9. DELETE /{uuid}/inventories — bulk-delete all inventories at once.
+//
 // 10. Cleanup: DELETE the test RP and custom resource class.
 func e2eTestResourceProviderInventories(ctx context.Context) error {
 	log := logf.FromContext(ctx)

--- a/internal/shim/placement/handle_resource_provider_inventories_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_inventories_e2e.go
@@ -3,11 +3,494 @@
 
 package placement
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestResourceProviderInventories tests the
+// /resource_providers/{uuid}/inventories and
+// /resource_providers/{uuid}/inventories/{resource_class} endpoints.
+//
+//  1. Pre-cleanup: DELETE leftover RP and custom resource class (ignore 404).
+//  2. Create fixtures: PUT a custom resource class, POST a test RP.
+//  3. GET /{uuid}/inventories — verify the inventory list is empty.
+//  4. PUT /{uuid}/inventories — set a full inventory (total=100) and store the
+//     returned generation for subsequent requests.
+//  5. GET /{uuid}/inventories/{rc} — retrieve the single inventory record and
+//     verify total equals 100.
+//  6. PUT /{uuid}/inventories/{rc} — update the single inventory total to 200.
+//  7. DELETE /{uuid}/inventories/{rc} — remove the single inventory record.
+//  8. GET /{uuid}/inventories — verify the inventory list is now empty.
+//  9. PUT /{uuid}/inventories — re-add inventory (total=50) for the bulk test.
+//  10. DELETE /{uuid}/inventories — bulk-delete all inventories at once.
+//  11. Cleanup: DELETE the test RP and custom resource class.
+func e2eTestResourceProviderInventories(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running resource provider inventories endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for resource provider inventories e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for resource provider inventories e2e test")
+
+	const testRPUUID = "e2e10000-0000-0000-0000-000000000002"
+	const testRPName = "cortex-e2e-test-rp-inv"
+	const testRC = "CUSTOM_CORTEX_E2E_INV_RC"
+	const apiVersion = "placement 1.26"
+
+	// Pre-cleanup: delete the resource provider (cascades inventories), then
+	// the custom resource class. Ignore 404/409.
+	log.Info("Pre-cleanup: deleting leftover test resources")
+	for _, cleanup := range []struct {
+		method string
+		url    string
+	}{
+		{http.MethodDelete, sc.Endpoint + "/resource_providers/" + testRPUUID},
+		{http.MethodDelete, sc.Endpoint + "/resource_classes/" + testRC},
+	} {
+		req, err := http.NewRequestWithContext(ctx, cleanup.method, cleanup.url, http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create pre-cleanup request", "url", cleanup.url)
+			return err
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", apiVersion)
+		resp, err := sc.HTTPClient.Do(req)
+		if err != nil {
+			log.Error(err, "failed to send pre-cleanup request", "url", cleanup.url)
+			return err
+		}
+		defer resp.Body.Close()
+		log.Info("Pre-cleanup request completed", "url", cleanup.url, "status", resp.StatusCode)
+	}
+
+	// Create fixtures: custom resource class and resource provider.
+	log.Info("Creating custom resource class for inventories test", "class", testRC)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create PUT request for resource class", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for resource class", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT /resource_classes returned an error", "class", testRC)
+		return err
+	}
+	log.Info("Successfully created custom resource class", "class", testRC)
+
+	log.Info("Creating test resource provider for inventories test",
+		"uuid", testRPUUID, "name", testRPName)
+	body, err := json.Marshal(map[string]string{
+		"name": testRPName,
+		"uuid": testRPUUID,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPost, sc.Endpoint+"/resource_providers", bytes.NewReader(body))
+	if err != nil {
+		log.Error(err, "failed to create POST request for resource_providers")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send POST request to /resource_providers")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "POST /resource_providers returned an error")
+		return err
+	}
+	log.Info("Successfully created test resource provider for inventories test",
+		"uuid", testRPUUID)
+
+	// Test GET /resource_providers/{uuid}/inventories (empty).
+	log.Info("Testing GET /resource_providers/{uuid}/inventories (empty)",
+		"uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP inventories returned an error", "uuid", testRPUUID)
+		return err
+	}
+	var invResp struct {
+		Inventories                map[string]json.RawMessage `json:"inventories"`
+		ResourceProviderGeneration int                        `json:"resource_provider_generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&invResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP inventories response", "uuid", testRPUUID)
+		return err
+	}
+	generation := invResp.ResourceProviderGeneration
+	log.Info("Successfully retrieved empty inventories for test resource provider",
+		"uuid", testRPUUID, "inventories", len(invResp.Inventories),
+		"generation", generation)
+
+	// Test PUT /resource_providers/{uuid}/inventories (set full inventory).
+	log.Info("Testing PUT /resource_providers/{uuid}/inventories to set inventory",
+		"uuid", testRPUUID, "class", testRC)
+	putBody, err := json.Marshal(map[string]any{
+		"resource_provider_generation": generation,
+		"inventories": map[string]any{
+			testRC: map[string]any{
+				"total":            100,
+				"reserved":         0,
+				"min_unit":         1,
+				"max_unit":         100,
+				"step_size":        1,
+				"allocation_ratio": 1.0,
+			},
+		},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories",
+		bytes.NewReader(putBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT RP inventories returned an error", "uuid", testRPUUID)
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&invResp)
+	if err != nil {
+		log.Error(err, "failed to decode PUT RP inventories response", "uuid", testRPUUID)
+		return err
+	}
+	generation = invResp.ResourceProviderGeneration
+	log.Info("Successfully set inventory on test resource provider",
+		"uuid", testRPUUID, "inventories", len(invResp.Inventories),
+		"generation", generation)
+
+	// Test GET /resource_providers/{uuid}/inventories/{resource_class}.
+	log.Info("Testing GET /resource_providers/{uuid}/inventories/{resource_class}",
+		"uuid", testRPUUID, "class", testRC)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet,
+		sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories/"+testRC,
+		http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for single inventory",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for single inventory",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET single inventory returned an error",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	var singleInv struct {
+		Total                      int `json:"total"`
+		ResourceProviderGeneration int `json:"resource_provider_generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&singleInv)
+	if err != nil {
+		log.Error(err, "failed to decode single inventory response",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	if singleInv.Total != 100 {
+		err := fmt.Errorf("expected total 100, got %d", singleInv.Total)
+		log.Error(err, "inventory total mismatch", "uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	log.Info("Successfully retrieved single inventory",
+		"uuid", testRPUUID, "class", testRC, "total", singleInv.Total)
+
+	// Test PUT /resource_providers/{uuid}/inventories/{resource_class} (update single).
+	log.Info("Testing PUT single inventory to update total",
+		"uuid", testRPUUID, "class", testRC, "newTotal", 200)
+	putBody, err = json.Marshal(map[string]any{
+		"resource_provider_generation": generation,
+		"total":                        200,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut,
+		sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories/"+testRC,
+		bytes.NewReader(putBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for single inventory",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for single inventory",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT single inventory returned an error",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&singleInv)
+	if err != nil {
+		log.Error(err, "failed to decode PUT single inventory response",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	generation = singleInv.ResourceProviderGeneration
+	log.Info("Successfully updated single inventory",
+		"uuid", testRPUUID, "class", testRC, "total", singleInv.Total,
+		"generation", generation)
+
+	// Test DELETE /resource_providers/{uuid}/inventories/{resource_class}.
+	log.Info("Testing DELETE single inventory",
+		"uuid", testRPUUID, "class", testRC)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete,
+		sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories/"+testRC,
+		http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for single inventory",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for single inventory",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE single inventory returned an error",
+			"uuid", testRPUUID, "class", testRC)
+		return err
+	}
+	log.Info("Successfully deleted single inventory",
+		"uuid", testRPUUID, "class", testRC)
+
+	// Verify inventory deleted by listing all inventories.
+	log.Info("Verifying inventory deleted", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP inventories returned an error", "uuid", testRPUUID)
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&invResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP inventories response", "uuid", testRPUUID)
+		return err
+	}
+	if len(invResp.Inventories) != 0 {
+		err := fmt.Errorf("expected 0 inventories, got %d", len(invResp.Inventories))
+		log.Error(err, "inventory not deleted", "uuid", testRPUUID)
+		return err
+	}
+	generation = invResp.ResourceProviderGeneration
+	log.Info("Verified inventory deleted", "uuid", testRPUUID, "generation", generation)
+
+	// Re-add inventory via PUT all, then test bulk DELETE /inventories.
+	log.Info("Re-adding inventory for bulk delete test", "uuid", testRPUUID, "class", testRC)
+	putBody, err = json.Marshal(map[string]any{
+		"resource_provider_generation": generation,
+		"inventories": map[string]any{
+			testRC: map[string]any{"total": 50},
+		},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories",
+		bytes.NewReader(putBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT RP inventories returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully re-added inventory for bulk delete test", "uuid", testRPUUID)
+
+	// Test DELETE /resource_providers/{uuid}/inventories (bulk delete).
+	log.Info("Testing DELETE /resource_providers/{uuid}/inventories (bulk)",
+		"uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID+"/inventories", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for all RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for all RP inventories", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE all RP inventories returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully deleted all inventories from test resource provider",
+		"uuid", testRPUUID)
+
+	// Cleanup: delete the resource provider and custom resource class.
+	log.Info("Cleaning up test resources")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE resource provider returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully deleted test resource provider", "uuid", testRPUUID)
+
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_classes/"+testRC, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource class", "class", testRC)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource class", "class", testRC)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE resource class returned an error", "class", testRC)
+		return err
+	}
+	log.Info("Successfully deleted custom resource class", "class", testRC)
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "resource_provider_inventories",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "resource_provider_inventories", run: e2eTestResourceProviderInventories})
 }

--- a/internal/shim/placement/handle_resource_provider_inventories_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_inventories_e2e.go
@@ -74,7 +74,7 @@ func e2eTestResourceProviderInventories(ctx context.Context) error {
 			log.Error(err, "failed to send pre-cleanup request", "url", cleanup.url)
 			return err
 		}
-		defer resp.Body.Close()
+		resp.Body.Close()
 		log.Info("Pre-cleanup request completed", "url", cleanup.url, "status", resp.StatusCode)
 	}
 

--- a/internal/shim/placement/handle_resource_provider_traits_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_traits_e2e.go
@@ -3,11 +3,343 @@
 
 package placement
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestResourceProviderTraits tests the
+// /resource_providers/{uuid}/traits endpoints.
+//
+//  1. Pre-cleanup: DELETE leftover RP traits, RP, and custom trait (ignore 404).
+//  2. Create fixtures: PUT a custom trait, POST a test RP.
+//  3. GET /{uuid}/traits — verify the trait list is empty, store generation.
+//  4. PUT /{uuid}/traits — associate the custom trait with the RP.
+//  5. GET /{uuid}/traits — verify the custom trait is now present.
+//  6. DELETE /{uuid}/traits — disassociate all traits from the RP.
+//  7. GET /{uuid}/traits — verify the trait list is empty again.
+//  8. Cleanup: DELETE the test RP and custom trait.
+func e2eTestResourceProviderTraits(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running resource provider traits endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for resource provider traits e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for resource provider traits e2e test")
+
+	const testRPUUID = "e2e10000-0000-0000-0000-000000000003"
+	const testRPName = "cortex-e2e-test-rp-traits"
+	const testTrait = "CUSTOM_CORTEX_E2E_RP_TRAIT"
+
+	// Pre-cleanup: delete RP traits, then RP, then the custom trait.
+	log.Info("Pre-cleanup: deleting leftover test resources")
+	for _, cleanup := range []struct {
+		method string
+		url    string
+	}{
+		{http.MethodDelete, sc.Endpoint + "/resource_providers/" + testRPUUID + "/traits"},
+		{http.MethodDelete, sc.Endpoint + "/resource_providers/" + testRPUUID},
+		{http.MethodDelete, sc.Endpoint + "/traits/" + testTrait},
+	} {
+		req, err := http.NewRequestWithContext(ctx, cleanup.method, cleanup.url, http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create pre-cleanup request", "url", cleanup.url)
+			return err
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", "placement 1.6")
+		resp, err := sc.HTTPClient.Do(req)
+		if err != nil {
+			log.Error(err, "failed to send pre-cleanup request", "url", cleanup.url)
+			return err
+		}
+		defer resp.Body.Close()
+		log.Info("Pre-cleanup request completed", "url", cleanup.url, "status", resp.StatusCode)
+	}
+
+	// Create fixtures: custom trait and resource provider.
+	log.Info("Creating custom trait for RP traits test", "trait", testTrait)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create PUT request for trait", "trait", testTrait)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	req.Header.Set("Accept", "application/json")
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for trait", "trait", testTrait)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT /traits returned an error", "trait", testTrait)
+		return err
+	}
+	log.Info("Successfully created custom trait", "trait", testTrait)
+
+	log.Info("Creating test resource provider for RP traits test",
+		"uuid", testRPUUID, "name", testRPName)
+	body, err := json.Marshal(map[string]string{
+		"name": testRPName,
+		"uuid": testRPUUID,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPost, sc.Endpoint+"/resource_providers", bytes.NewReader(body))
+	if err != nil {
+		log.Error(err, "failed to create POST request for resource_providers")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send POST request to /resource_providers")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "POST /resource_providers returned an error")
+		return err
+	}
+	log.Info("Successfully created test resource provider for RP traits test",
+		"uuid", testRPUUID)
+
+	// Test GET /resource_providers/{uuid}/traits (empty).
+	log.Info("Testing GET /resource_providers/{uuid}/traits (empty)", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/traits", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP traits", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP traits", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP traits returned an error", "uuid", testRPUUID)
+		return err
+	}
+	var traitsResp struct {
+		Traits                     []string `json:"traits"`
+		ResourceProviderGeneration int      `json:"resource_provider_generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&traitsResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP traits response", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully retrieved empty traits for test resource provider",
+		"uuid", testRPUUID, "traits", len(traitsResp.Traits),
+		"generation", traitsResp.ResourceProviderGeneration)
+
+	// Test PUT /resource_providers/{uuid}/traits (associate trait).
+	log.Info("Testing PUT /resource_providers/{uuid}/traits to associate trait",
+		"uuid", testRPUUID, "trait", testTrait)
+	putBody, err := json.Marshal(map[string]any{
+		"resource_provider_generation": traitsResp.ResourceProviderGeneration,
+		"traits":                       []string{testTrait},
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_providers/"+testRPUUID+"/traits",
+		bytes.NewReader(putBody))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for RP traits", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for RP traits", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT RP traits returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully associated trait with test resource provider",
+		"uuid", testRPUUID, "trait", testTrait)
+
+	// Test GET /resource_providers/{uuid}/traits (after PUT).
+	log.Info("Testing GET /resource_providers/{uuid}/traits (after PUT)",
+		"uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/traits", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP traits", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP traits", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP traits returned an error", "uuid", testRPUUID)
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&traitsResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP traits response", "uuid", testRPUUID)
+		return err
+	}
+	if len(traitsResp.Traits) != 1 || traitsResp.Traits[0] != testTrait {
+		err := fmt.Errorf("expected trait %s, got %v", testTrait, traitsResp.Traits)
+		log.Error(err, "trait mismatch", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully verified trait on test resource provider",
+		"uuid", testRPUUID, "traits", traitsResp.Traits)
+
+	// Test DELETE /resource_providers/{uuid}/traits.
+	log.Info("Testing DELETE /resource_providers/{uuid}/traits", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID+"/traits", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for RP traits", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for RP traits", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE RP traits returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully deleted traits from test resource provider", "uuid", testRPUUID)
+
+	// Verify traits cleared.
+	log.Info("Verifying traits cleared on test resource provider", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/traits", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP traits", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP traits", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP traits returned an error", "uuid", testRPUUID)
+		return err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&traitsResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP traits response", "uuid", testRPUUID)
+		return err
+	}
+	if len(traitsResp.Traits) != 0 {
+		err := fmt.Errorf("expected 0 traits, got %d", len(traitsResp.Traits))
+		log.Error(err, "traits not cleared", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Verified traits cleared on test resource provider", "uuid", testRPUUID)
+
+	// Cleanup: delete the test resource provider and custom trait.
+	log.Info("Cleaning up test resources")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE resource provider returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully deleted test resource provider", "uuid", testRPUUID)
+
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for trait", "trait", testTrait)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for trait", "trait", testTrait)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE trait returned an error", "trait", testTrait)
+		return err
+	}
+	log.Info("Successfully deleted custom trait", "trait", testTrait)
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "resource_provider_traits",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "resource_provider_traits", run: e2eTestResourceProviderTraits})
 }

--- a/internal/shim/placement/handle_resource_provider_traits_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_traits_e2e.go
@@ -67,7 +67,13 @@ func e2eTestResourceProviderTraits(ctx context.Context) error {
 			log.Error(err, "failed to send pre-cleanup request", "url", cleanup.url)
 			return err
 		}
-		defer resp.Body.Close()
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound &&
+			(resp.StatusCode < 200 || resp.StatusCode >= 300) {
+			err := fmt.Errorf("unexpected status code during pre-cleanup: %d", resp.StatusCode)
+			log.Error(err, "pre-cleanup failed", "url", cleanup.url)
+			return err
+		}
 		log.Info("Pre-cleanup request completed", "url", cleanup.url, "status", resp.StatusCode)
 	}
 
@@ -129,6 +135,35 @@ func e2eTestResourceProviderTraits(ctx context.Context) error {
 	log.Info("Successfully created test resource provider for RP traits test",
 		"uuid", testRPUUID)
 
+	// Deferred cleanup: always delete test fixtures on exit so a failed
+	// assertion doesn't leave the fixed UUID/trait behind.
+	defer func() {
+		log.Info("Deferred cleanup: deleting test resources")
+		for _, c := range []struct {
+			url  string
+			desc string
+		}{
+			{sc.Endpoint + "/resource_providers/" + testRPUUID + "/traits", "RP traits"},
+			{sc.Endpoint + "/resource_providers/" + testRPUUID, "RP"},
+			{sc.Endpoint + "/traits/" + testTrait, "trait"},
+		} {
+			dReq, dErr := http.NewRequestWithContext(ctx, http.MethodDelete, c.url, http.NoBody)
+			if dErr != nil {
+				log.Error(dErr, "deferred cleanup: failed to create request", "desc", c.desc)
+				continue
+			}
+			dReq.Header.Set("X-Auth-Token", sc.TokenID)
+			dReq.Header.Set("OpenStack-API-Version", "placement 1.6")
+			dResp, dErr := sc.HTTPClient.Do(dReq)
+			if dErr != nil {
+				log.Error(dErr, "deferred cleanup: failed to send request", "desc", c.desc)
+				continue
+			}
+			dResp.Body.Close()
+			log.Info("Deferred cleanup completed", "desc", c.desc, "status", dResp.StatusCode)
+		}
+	}()
+
 	// Test GET /resource_providers/{uuid}/traits (empty).
 	log.Info("Testing GET /resource_providers/{uuid}/traits (empty)", "uuid", testRPUUID)
 	req, err = http.NewRequestWithContext(ctx,
@@ -158,6 +193,11 @@ func e2eTestResourceProviderTraits(ctx context.Context) error {
 	err = json.NewDecoder(resp.Body).Decode(&traitsResp)
 	if err != nil {
 		log.Error(err, "failed to decode RP traits response", "uuid", testRPUUID)
+		return err
+	}
+	if len(traitsResp.Traits) != 0 {
+		err := fmt.Errorf("expected 0 initial traits, got %d", len(traitsResp.Traits))
+		log.Error(err, "initial traits not empty", "uuid", testRPUUID)
 		return err
 	}
 	log.Info("Successfully retrieved empty traits for test resource provider",

--- a/internal/shim/placement/handle_resource_provider_usages_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_usages_e2e.go
@@ -3,11 +3,227 @@
 
 package placement
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestResourceProviderUsages tests the
+// /resource_providers/{uuid}/usages endpoint.
+//
+//  1. Pre-cleanup: DELETE any leftover test RP (ignore 404).
+//  2. POST /resource_providers — create a test RP.
+//  3. GET /{uuid}/usages — retrieve usages for the test RP (expect empty
+//     usages map since no inventory or allocations exist).
+//  4. GET /resource_providers — list real providers, then GET /{uuid}/usages
+//     on up to 3 of them to verify the endpoint works with production data.
+//  5. Cleanup: DELETE the test RP.
+func e2eTestResourceProviderUsages(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running resource provider usages endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for resource provider usages e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for resource provider usages e2e test")
+
+	const testRPUUID = "e2e10000-0000-0000-0000-000000000005"
+	const testRPName = "cortex-e2e-test-rp-usages"
+
+	// Pre-cleanup: delete any leftover test resource provider from a prior run.
+	log.Info("Pre-cleanup: deleting leftover test resource provider", "uuid", testRPUUID)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create pre-cleanup request")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send pre-cleanup request")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusConflict &&
+		(resp.StatusCode < 200 || resp.StatusCode >= 300) {
+		err := fmt.Errorf("unexpected status code during pre-cleanup: %d", resp.StatusCode)
+		log.Error(err, "pre-cleanup failed")
+		return err
+	}
+	log.Info("Pre-cleanup completed", "status", resp.StatusCode)
+
+	// Create a test resource provider.
+	log.Info("Creating test resource provider for usages test",
+		"uuid", testRPUUID, "name", testRPName)
+	body, err := json.Marshal(map[string]string{
+		"name": testRPName,
+		"uuid": testRPUUID,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPost, sc.Endpoint+"/resource_providers", bytes.NewReader(body))
+	if err != nil {
+		log.Error(err, "failed to create POST request for resource_providers")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send POST request to /resource_providers")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "POST /resource_providers returned an error")
+		return err
+	}
+	log.Info("Successfully created test resource provider for usages test",
+		"uuid", testRPUUID)
+
+	// Test GET /resource_providers/{uuid}/usages on our test provider.
+	log.Info("Testing GET /resource_providers/{uuid}/usages on test provider",
+		"uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID+"/usages", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for RP usages", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for RP usages", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET RP usages returned an error", "uuid", testRPUUID)
+		return err
+	}
+	var usagesResp struct {
+		Usages                     map[string]int `json:"usages"`
+		ResourceProviderGeneration int            `json:"resource_provider_generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&usagesResp)
+	if err != nil {
+		log.Error(err, "failed to decode RP usages response", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully retrieved usages for test resource provider",
+		"uuid", testRPUUID, "usages", usagesResp.Usages)
+
+	// Also test against existing real resource providers.
+	log.Info("Testing GET /resource_providers/{uuid}/usages on existing providers")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create request for listing resource providers")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send request to list resource providers")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "list resource providers returned an error")
+		return err
+	}
+	var rpList struct {
+		ResourceProviders []struct {
+			UUID string `json:"uuid"`
+		} `json:"resource_providers"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&rpList)
+	if err != nil {
+		log.Error(err, "failed to decode resource providers list")
+		return err
+	}
+	for i, rp := range rpList.ResourceProviders {
+		if i >= 3 {
+			break
+		}
+		log.Info("Testing GET usages on existing resource provider", "uuid", rp.UUID)
+		rpReq, err := http.NewRequestWithContext(ctx,
+			http.MethodGet, sc.Endpoint+"/resource_providers/"+rp.UUID+"/usages", http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create GET request for RP usages", "uuid", rp.UUID)
+			return err
+		}
+		rpReq.Header.Set("X-Auth-Token", sc.TokenID)
+		rpReq.Header.Set("OpenStack-API-Version", "placement 1.20")
+		rpReq.Header.Set("Accept", "application/json")
+		rpResp, err := sc.HTTPClient.Do(rpReq)
+		if err != nil {
+			log.Error(err, "failed to send GET request for RP usages", "uuid", rp.UUID)
+			return err
+		}
+		defer rpResp.Body.Close()
+		if rpResp.StatusCode < 200 || rpResp.StatusCode >= 300 {
+			err := fmt.Errorf("unexpected status code: %d", rpResp.StatusCode)
+			log.Error(err, "GET RP usages returned an error", "uuid", rp.UUID)
+			return err
+		}
+		log.Info("Successfully retrieved usages for existing resource provider",
+			"uuid", rp.UUID)
+	}
+
+	// Cleanup: delete the test resource provider.
+	log.Info("Cleaning up test resource provider", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE /resource_providers/{uuid} returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully deleted test resource provider", "uuid", testRPUUID)
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "resource_provider_usages",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "resource_provider_usages", run: e2eTestResourceProviderUsages})
 }

--- a/internal/shim/placement/handle_resource_provider_usages_e2e.go
+++ b/internal/shim/placement/handle_resource_provider_usages_e2e.go
@@ -188,12 +188,13 @@ func e2eTestResourceProviderUsages(ctx context.Context) error {
 			log.Error(err, "failed to send GET request for RP usages", "uuid", rp.UUID)
 			return err
 		}
-		defer rpResp.Body.Close()
 		if rpResp.StatusCode < 200 || rpResp.StatusCode >= 300 {
+			rpResp.Body.Close()
 			err := fmt.Errorf("unexpected status code: %d", rpResp.StatusCode)
 			log.Error(err, "GET RP usages returned an error", "uuid", rp.UUID)
 			return err
 		}
+		rpResp.Body.Close()
 		log.Info("Successfully retrieved usages for existing resource provider",
 			"uuid", rp.UUID)
 	}

--- a/internal/shim/placement/handle_resource_providers_e2e.go
+++ b/internal/shim/placement/handle_resource_providers_e2e.go
@@ -3,11 +3,257 @@
 
 package placement
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestResourceProviders tests the /resource_providers and
+// /resource_providers/{uuid} endpoints.
+//
+//  1. Pre-cleanup: DELETE any leftover test resource provider (ignore 404).
+//  2. GET /resource_providers — list all providers and verify the response.
+//  3. POST /resource_providers — create a test provider with a fixed UUID.
+//  4. GET /resource_providers/{uuid} — retrieve and verify the created provider.
+//  5. PUT /resource_providers/{uuid} — update the provider's name.
+//  6. DELETE /resource_providers/{uuid} — remove the test provider.
+//  7. GET /resource_providers/{uuid} — confirm deletion returns 404.
+func e2eTestResourceProviders(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running resource providers endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for resource providers e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for resource providers e2e test")
+
+	const testRPUUID = "e2e10000-0000-0000-0000-000000000001"
+	const testRPName = "cortex-e2e-test-rp"
+	const testRPNameUpdated = "cortex-e2e-test-rp-updated"
+
+	// Pre-cleanup: delete any leftover test resource provider from a prior run.
+	log.Info("Pre-cleanup: deleting leftover test resource provider", "uuid", testRPUUID)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create pre-cleanup request")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send pre-cleanup request")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusConflict &&
+		(resp.StatusCode < 200 || resp.StatusCode >= 300) {
+		err := fmt.Errorf("unexpected status code during pre-cleanup: %d", resp.StatusCode)
+		log.Error(err, "pre-cleanup failed")
+		return err
+	}
+	log.Info("Pre-cleanup completed", "status", resp.StatusCode)
+
+	// Test GET /resource_providers
+	log.Info("Testing GET /resource_providers endpoint of placement shim")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create request for resource_providers endpoint")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send request to /resource_providers endpoint")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "/resource_providers endpoint returned an error")
+		return err
+	}
+	var listResp struct {
+		ResourceProviders []json.RawMessage `json:"resource_providers"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&listResp)
+	if err != nil {
+		log.Error(err, "failed to decode response from /resource_providers endpoint")
+		return err
+	}
+	log.Info("Successfully retrieved resource providers from placement shim",
+		"count", len(listResp.ResourceProviders))
+
+	// Test POST /resource_providers (create)
+	log.Info("Testing POST /resource_providers to create test provider",
+		"uuid", testRPUUID, "name", testRPName)
+	body, err := json.Marshal(map[string]string{
+		"name": testRPName,
+		"uuid": testRPUUID,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPost, sc.Endpoint+"/resource_providers", bytes.NewReader(body))
+	if err != nil {
+		log.Error(err, "failed to create POST request for resource_providers")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send POST request to /resource_providers")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "POST /resource_providers returned an error")
+		return err
+	}
+	var createdRP struct {
+		UUID       string `json:"uuid"`
+		Name       string `json:"name"`
+		Generation int    `json:"generation"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&createdRP)
+	if err != nil {
+		log.Error(err, "failed to decode POST response from /resource_providers")
+		return err
+	}
+	log.Info("Successfully created test resource provider",
+		"uuid", createdRP.UUID, "name", createdRP.Name, "generation", createdRP.Generation)
+
+	// Test GET /resource_providers/{uuid} (show)
+	log.Info("Testing GET /resource_providers/{uuid} endpoint", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create GET request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send GET request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "GET /resource_providers/{uuid} returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully retrieved test resource provider", "uuid", testRPUUID)
+
+	// Test PUT /resource_providers/{uuid} (update)
+	log.Info("Testing PUT /resource_providers/{uuid} to update provider name",
+		"uuid", testRPUUID, "newName", testRPNameUpdated)
+	body, err = json.Marshal(map[string]string{
+		"name": testRPNameUpdated,
+	})
+	if err != nil {
+		log.Error(err, "failed to marshal request body")
+		return err
+	}
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/resource_providers/"+testRPUUID, bytes.NewReader(body))
+	if err != nil {
+		log.Error(err, "failed to create PUT request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send PUT request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "PUT /resource_providers/{uuid} returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully updated test resource provider name",
+		"uuid", testRPUUID, "newName", testRPNameUpdated)
+
+	// Cleanup: Test DELETE /resource_providers/{uuid}
+	log.Info("Cleaning up test resource provider", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send DELETE request for resource provider", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "DELETE /resource_providers/{uuid} returned an error", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Successfully deleted test resource provider", "uuid", testRPUUID)
+
+	// Verify deletion: GET should return 404
+	log.Info("Verifying test resource provider was deleted", "uuid", testRPUUID)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/resource_providers/"+testRPUUID, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create verification GET request", "uuid", testRPUUID)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.20")
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send verification GET request", "uuid", testRPUUID)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		err := fmt.Errorf("expected 404 after deletion, got: %d", resp.StatusCode)
+		log.Error(err, "resource provider still exists after deletion", "uuid", testRPUUID)
+		return err
+	}
+	log.Info("Verified test resource provider was deleted", "uuid", testRPUUID)
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "resource_providers",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "resource_providers", run: e2eTestResourceProviders})
 }

--- a/internal/shim/placement/handle_root_e2e.go
+++ b/internal/shim/placement/handle_root_e2e.go
@@ -12,8 +12,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// e2eTestGetRoot is a simple test that just sends a request to the root endpoint
-// of the shim, which should return a 200 OK response with a simple message.
+// e2eTestGetRoot verifies basic connectivity to the placement shim.
+// It sends a GET request to the root endpoint (/) and checks that the shim
+// responds with a 2xx status code, confirming the service is reachable.
 func e2eTestGetRoot(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 	log.Info("Running root endpoint e2e test")

--- a/internal/shim/placement/handle_root_e2e.go
+++ b/internal/shim/placement/handle_root_e2e.go
@@ -23,13 +23,18 @@ func e2eTestGetRoot(ctx context.Context) error {
 		log.Error(err, "failed to get e2e config")
 		return err
 	}
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx,
-		http.MethodGet, config.E2E.SVCURL+"/", http.NoBody)
+		http.MethodGet, sc.Endpoint+"/", http.NoBody)
 	if err != nil {
 		log.Error(err, "failed to create request for placement shim")
 		return err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := sc.HTTPClient.Do(req)
 	if err != nil {
 		log.Error(err, "failed to send request to placement shim")
 		return err

--- a/internal/shim/placement/handle_root_e2e.go
+++ b/internal/shim/placement/handle_root_e2e.go
@@ -3,11 +3,40 @@
 
 package placement
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestRoot is a simple test that just sends a request to the root endpoint
+// of the shim, which should return a 200 OK response with a simple message.
+func e2eTestRoot(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running root endpoint e2e test")
+	config, err := conf.GetConfig[e2eConfigRoot]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	resp, err := http.Get(config.E2E.SVCURL + "/")
+	if err != nil {
+		log.Error(err, "failed to send request to placement shim")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "placement shim returned an error")
+		return err
+	}
+	log.Info("Placement shim root endpoint is healthy")
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "root",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "root", run: e2eTestRoot})
 }

--- a/internal/shim/placement/handle_root_e2e.go
+++ b/internal/shim/placement/handle_root_e2e.go
@@ -12,17 +12,23 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// e2eTestRoot is a simple test that just sends a request to the root endpoint
+// e2eTestGetRoot is a simple test that just sends a request to the root endpoint
 // of the shim, which should return a 200 OK response with a simple message.
-func e2eTestRoot(ctx context.Context) error {
+func e2eTestGetRoot(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 	log.Info("Running root endpoint e2e test")
-	config, err := conf.GetConfig[e2eConfigRoot]()
+	config, err := conf.GetConfig[e2eRootConfig]()
 	if err != nil {
 		log.Error(err, "failed to get e2e config")
 		return err
 	}
-	resp, err := http.Get(config.E2E.SVCURL + "/")
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodGet, config.E2E.SVCURL+"/", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create request for placement shim")
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Error(err, "failed to send request to placement shim")
 		return err
@@ -38,5 +44,5 @@ func e2eTestRoot(ctx context.Context) error {
 }
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{name: "root", run: e2eTestRoot})
+	e2eTests = append(e2eTests, e2eTest{name: "root", run: e2eTestGetRoot})
 }

--- a/internal/shim/placement/handle_traits_e2e.go
+++ b/internal/shim/placement/handle_traits_e2e.go
@@ -92,7 +92,11 @@ func e2eTestTraits(ctx context.Context) error {
 
 	// Test GET /traits/{name}
 	log.Info("Testing GET /traits/{name} endpoint of placement shim")
-	for _, trait := range list.Traits[:5] { // Test only the first 5 traits to save time.
+	traitsToTest := list.Traits
+	if len(traitsToTest) > 5 {
+		traitsToTest = traitsToTest[:5]
+	}
+	for _, trait := range traitsToTest { // Test only the first 5 traits to save time.
 		log.Info("Testing trait", "trait", trait)
 		traitReq, err := http.NewRequestWithContext(ctx,
 			http.MethodGet, sc.Endpoint+"/traits/"+trait, http.NoBody)
@@ -110,13 +114,14 @@ func e2eTestTraits(ctx context.Context) error {
 				"trait", trait)
 			return err
 		}
-		defer traitResp.Body.Close()
 		if traitResp.StatusCode < 200 || traitResp.StatusCode >= 300 {
+			traitResp.Body.Close()
 			err := fmt.Errorf("unexpected status code: %d", traitResp.StatusCode)
 			log.Error(err, "placement shim /traits/{name} endpoint returned an error",
 				"trait", trait)
 			return err
 		}
+		traitResp.Body.Close()
 		log.Info("Successfully retrieved trait from placement shim /traits/{name} endpoint",
 			"trait", trait)
 	}

--- a/internal/shim/placement/handle_traits_e2e.go
+++ b/internal/shim/placement/handle_traits_e2e.go
@@ -3,11 +3,62 @@
 
 package placement
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestListTraits is a test that sends a request to the /traits endpoint of
+// the placement shim, which should return a 200 OK response with a list of traits.
+func e2eTestListTraits(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running traits endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for traits e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for traits e2e test")
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/traits", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create request for traits endpoint")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.29") // No "X-"!
+	req.Header.Set("Accept", "application/json")
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send request to traits endpoint")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "traits endpoint returned an error")
+		return err
+	}
+	dump, err := httputil.DumpResponse(resp, true)
+	if err != nil {
+		log.Error(err, "failed to dump response for traits endpoint")
+		return err
+	}
+	log.Info("Placement shim traits endpoint response", "dump", string(dump))
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "traits",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "traits", run: e2eTestListTraits})
 }

--- a/internal/shim/placement/handle_traits_e2e.go
+++ b/internal/shim/placement/handle_traits_e2e.go
@@ -5,17 +5,17 @@ package placement
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// e2eTestListTraits is a test that sends a request to the /traits endpoint of
-// the placement shim, which should return a 200 OK response with a list of traits.
-func e2eTestListTraits(ctx context.Context) error {
+// e2eTestTraits is a test that sends a request to the /traits
+// endpoints of the placement shim.
+func e2eTestTraits(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 	log.Info("Running traits endpoint e2e test")
 	config, err := conf.GetConfig[e2eRootConfig]()
@@ -30,6 +30,9 @@ func e2eTestListTraits(ctx context.Context) error {
 		return err
 	}
 	log.Info("Successfully created openstack client for traits e2e test")
+
+	// Test GET /traits
+	log.Info("Testing GET /traits endpoint of placement shim")
 	req, err := http.NewRequestWithContext(ctx,
 		http.MethodGet, sc.Endpoint+"/traits", http.NoBody)
 	if err != nil {
@@ -41,24 +44,119 @@ func e2eTestListTraits(ctx context.Context) error {
 	req.Header.Set("Accept", "application/json")
 	resp, err := sc.HTTPClient.Do(req)
 	if err != nil {
-		log.Error(err, "failed to send request to traits endpoint")
+		log.Error(err, "failed to send request to placement shim /traits endpoint")
 		return err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		log.Error(err, "traits endpoint returned an error")
+		log.Error(err, "placement shim /traits endpoint returned an error")
 		return err
 	}
-	dump, err := httputil.DumpResponse(resp, true)
+	var list struct {
+		Traits []string `json:"traits"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&list)
 	if err != nil {
-		log.Error(err, "failed to dump response for traits endpoint")
+		log.Error(err, "failed to decode response from placement shim /traits endpoint")
 		return err
 	}
-	log.Info("Placement shim traits endpoint response", "dump", string(dump))
+	log.Info("Successfully retrieved traits from placement shim",
+		"traits", list.Traits)
+
+	// Test GET /traits/{name}
+	log.Info("Testing GET /traits/{name} endpoint of placement shim")
+	for _, trait := range list.Traits[:4] { // Test only the first 4 traits to save time.
+		log.Info("Testing trait", "trait", trait)
+		req, err := http.NewRequestWithContext(ctx,
+			http.MethodGet, sc.Endpoint+"/traits/"+trait, http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create request for traits/{name} endpoint",
+				"trait", trait)
+			return err
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", "placement 1.29") // No "X-"!
+		req.Header.Set("Accept", "application/json")
+		resp, err := sc.HTTPClient.Do(req)
+		if err != nil {
+			log.Error(err, "failed to send request to placement shim /traits/{name} endpoint",
+				"trait", trait)
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			log.Error(err, "placement shim /traits/{name} endpoint returned an error",
+				"trait", trait)
+			return err
+		}
+		log.Info("Successfully retrieved trait from placement shim /traits/{name} endpoint",
+			"trait", trait)
+	}
+
+	// Test PUT /traits/{name}
+	const testTrait = "CUSTOM_CORTEX_PLACEMENT_SHIM_E2E_TEST_TRAIT"
+	log.Info("Testing PUT /traits/{name} endpoint of placement shim", "testTrait", testTrait)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create request for traits/{name} endpoint",
+			"trait", testTrait)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.29") // No "X-"!
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send request to placement shim /traits/{name} endpoint",
+			"trait", testTrait)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "placement shim /traits/{name} endpoint returned an error",
+			"trait", testTrait)
+		return err
+	}
+	log.Info("Successfully created trait with placement shim /traits/{name} endpoint",
+		"trait", testTrait)
+
+	// Cleanup: delete the test trait we just created. This is not strictly
+	// necessary since the trait doesn't actually exist in the real placement
+	// service, but it's good hygiene.
+	log.Info("Cleaning up test trait from placement shim", "testTrait", testTrait)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create request for traits/{name} endpoint",
+			"trait", testTrait)
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.29") // No "X-"!
+	req.Header.Set("Accept", "application/json")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send request to placement shim /traits/{name} endpoint",
+			"trait", testTrait)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "placement shim /traits/{name} endpoint returned an error",
+			"trait", testTrait)
+		return err
+	}
+	log.Info("Successfully deleted test trait with placement shim /traits/{name} endpoint",
+		"trait", testTrait)
+
 	return nil
 }
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{name: "traits", run: e2eTestListTraits})
+	e2eTests = append(e2eTests, e2eTest{name: "traits", run: e2eTestTraits})
 }

--- a/internal/shim/placement/handle_traits_e2e.go
+++ b/internal/shim/placement/handle_traits_e2e.go
@@ -13,8 +13,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// e2eTestTraits is a test that sends a request to the /traits
-// endpoints of the placement shim.
+// e2eTestTraits tests the /traits and /traits/{name} endpoints.
 func e2eTestTraits(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 	log.Info("Running traits endpoint e2e test")
@@ -40,7 +39,7 @@ func e2eTestTraits(ctx context.Context) error {
 		return err
 	}
 	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", "placement 1.29") // No "X-"!
+	req.Header.Set("OpenStack-API-Version", "placement 1.6") // No "X-"!
 	req.Header.Set("Accept", "application/json")
 	resp, err := sc.HTTPClient.Do(req)
 	if err != nil {
@@ -62,31 +61,31 @@ func e2eTestTraits(ctx context.Context) error {
 		return err
 	}
 	log.Info("Successfully retrieved traits from placement shim",
-		"traits", list.Traits)
+		"traits", len(list.Traits))
 
 	// Test GET /traits/{name}
 	log.Info("Testing GET /traits/{name} endpoint of placement shim")
-	for _, trait := range list.Traits[:4] { // Test only the first 4 traits to save time.
+	for _, trait := range list.Traits[:5] { // Test only the first 5 traits to save time.
 		log.Info("Testing trait", "trait", trait)
-		req, err := http.NewRequestWithContext(ctx,
+		traitReq, err := http.NewRequestWithContext(ctx,
 			http.MethodGet, sc.Endpoint+"/traits/"+trait, http.NoBody)
 		if err != nil {
 			log.Error(err, "failed to create request for traits/{name} endpoint",
 				"trait", trait)
 			return err
 		}
-		req.Header.Set("X-Auth-Token", sc.TokenID)
-		req.Header.Set("OpenStack-API-Version", "placement 1.29") // No "X-"!
-		req.Header.Set("Accept", "application/json")
-		resp, err := sc.HTTPClient.Do(req)
+		traitReq.Header.Set("X-Auth-Token", sc.TokenID)
+		traitReq.Header.Set("OpenStack-API-Version", "placement 1.6") // No "X-"!
+		traitReq.Header.Set("Accept", "application/json")
+		traitResp, err := sc.HTTPClient.Do(traitReq)
 		if err != nil {
 			log.Error(err, "failed to send request to placement shim /traits/{name} endpoint",
 				"trait", trait)
 			return err
 		}
-		defer resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		defer traitResp.Body.Close()
+		if traitResp.StatusCode < 200 || traitResp.StatusCode >= 300 {
+			err := fmt.Errorf("unexpected status code: %d", traitResp.StatusCode)
 			log.Error(err, "placement shim /traits/{name} endpoint returned an error",
 				"trait", trait)
 			return err
@@ -106,7 +105,7 @@ func e2eTestTraits(ctx context.Context) error {
 		return err
 	}
 	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", "placement 1.29") // No "X-"!
+	req.Header.Set("OpenStack-API-Version", "placement 1.6") // No "X-"!
 	req.Header.Set("Accept", "application/json")
 	resp, err = sc.HTTPClient.Do(req)
 	if err != nil {
@@ -124,9 +123,7 @@ func e2eTestTraits(ctx context.Context) error {
 	log.Info("Successfully created trait with placement shim /traits/{name} endpoint",
 		"trait", testTrait)
 
-	// Cleanup: delete the test trait we just created. This is not strictly
-	// necessary since the trait doesn't actually exist in the real placement
-	// service, but it's good hygiene.
+	// Test DELETE /traits/{name}
 	log.Info("Cleaning up test trait from placement shim", "testTrait", testTrait)
 	req, err = http.NewRequestWithContext(ctx,
 		http.MethodDelete, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
@@ -136,7 +133,7 @@ func e2eTestTraits(ctx context.Context) error {
 		return err
 	}
 	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", "placement 1.29") // No "X-"!
+	req.Header.Set("OpenStack-API-Version", "placement 1.6") // No "X-"!
 	req.Header.Set("Accept", "application/json")
 	resp, err = sc.HTTPClient.Do(req)
 	if err != nil {

--- a/internal/shim/placement/handle_traits_e2e.go
+++ b/internal/shim/placement/handle_traits_e2e.go
@@ -14,6 +14,12 @@ import (
 )
 
 // e2eTestTraits tests the /traits and /traits/{name} endpoints.
+//
+//  1. Pre-cleanup: DELETE any leftover custom test trait (ignore 404).
+//  2. GET /traits — list all traits and verify a successful response.
+//  3. GET /traits/{name} — retrieve 5 individual existing traits by name.
+//  4. PUT /traits/{name} — create a custom test trait (CUSTOM_CORTEX_...).
+//  5. DELETE /traits/{name} — remove the custom test trait to clean up.
 func e2eTestTraits(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 	log.Info("Running traits endpoint e2e test")
@@ -30,18 +36,39 @@ func e2eTestTraits(ctx context.Context) error {
 	}
 	log.Info("Successfully created openstack client for traits e2e test")
 
+	const testTrait = "CUSTOM_CORTEX_PLACEMENT_SHIM_E2E_TEST_TRAIT"
+	const apiVersion = "placement 1.6"
+
+	// Pre-cleanup: delete leftover test trait from a prior run.
+	log.Info("Pre-cleanup: deleting leftover test trait", "trait", testTrait)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create pre-cleanup request")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", apiVersion)
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send pre-cleanup request")
+		return err
+	}
+	defer resp.Body.Close()
+	log.Info("Pre-cleanup completed", "status", resp.StatusCode)
+
 	// Test GET /traits
 	log.Info("Testing GET /traits endpoint of placement shim")
-	req, err := http.NewRequestWithContext(ctx,
+	req, err = http.NewRequestWithContext(ctx,
 		http.MethodGet, sc.Endpoint+"/traits", http.NoBody)
 	if err != nil {
 		log.Error(err, "failed to create request for traits endpoint")
 		return err
 	}
 	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", "placement 1.6") // No "X-"!
+	req.Header.Set("OpenStack-API-Version", apiVersion)
 	req.Header.Set("Accept", "application/json")
-	resp, err := sc.HTTPClient.Do(req)
+	resp, err = sc.HTTPClient.Do(req)
 	if err != nil {
 		log.Error(err, "failed to send request to placement shim /traits endpoint")
 		return err
@@ -75,7 +102,7 @@ func e2eTestTraits(ctx context.Context) error {
 			return err
 		}
 		traitReq.Header.Set("X-Auth-Token", sc.TokenID)
-		traitReq.Header.Set("OpenStack-API-Version", "placement 1.6") // No "X-"!
+		traitReq.Header.Set("OpenStack-API-Version", apiVersion)
 		traitReq.Header.Set("Accept", "application/json")
 		traitResp, err := sc.HTTPClient.Do(traitReq)
 		if err != nil {
@@ -95,7 +122,6 @@ func e2eTestTraits(ctx context.Context) error {
 	}
 
 	// Test PUT /traits/{name}
-	const testTrait = "CUSTOM_CORTEX_PLACEMENT_SHIM_E2E_TEST_TRAIT"
 	log.Info("Testing PUT /traits/{name} endpoint of placement shim", "testTrait", testTrait)
 	req, err = http.NewRequestWithContext(ctx,
 		http.MethodPut, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
@@ -105,7 +131,7 @@ func e2eTestTraits(ctx context.Context) error {
 		return err
 	}
 	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", "placement 1.6") // No "X-"!
+	req.Header.Set("OpenStack-API-Version", apiVersion)
 	req.Header.Set("Accept", "application/json")
 	resp, err = sc.HTTPClient.Do(req)
 	if err != nil {
@@ -133,7 +159,7 @@ func e2eTestTraits(ctx context.Context) error {
 		return err
 	}
 	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", "placement 1.6") // No "X-"!
+	req.Header.Set("OpenStack-API-Version", apiVersion)
 	req.Header.Set("Accept", "application/json")
 	resp, err = sc.HTTPClient.Do(req)
 	if err != nil {

--- a/internal/shim/placement/handle_usages_e2e.go
+++ b/internal/shim/placement/handle_usages_e2e.go
@@ -14,6 +14,12 @@ import (
 )
 
 // e2eTestUsages tests the /usages endpoint.
+//
+//  1. GET /projects from keystone — obtain a list of real project IDs.
+//  2. GET /usages?project_id={id} — for up to 5 projects, request total
+//     resource usages and verify each returns a successful response.
+//
+// This test is read-only and does not create any resources.
 func e2eTestUsages(ctx context.Context) error {
 	log := logf.FromContext(ctx)
 	log.Info("Running usages endpoint e2e test")
@@ -29,6 +35,8 @@ func e2eTestUsages(ctx context.Context) error {
 		return err
 	}
 	log.Info("Successfully created openstack client for usages e2e test")
+
+	const apiVersion = "placement 1.9"
 
 	// Get the list of projects from the identity service, so that we can test
 	// the /usages endpoint with a valid project id.
@@ -80,7 +88,7 @@ func e2eTestUsages(ctx context.Context) error {
 			return err
 		}
 		projReq.Header.Set("X-Auth-Token", sc.TokenID)
-		projReq.Header.Set("OpenStack-API-Version", "placement 1.9") // No "X-"!
+		projReq.Header.Set("OpenStack-API-Version", apiVersion)
 		projReq.Header.Set("Accept", "application/json")
 		projResp, err := sc.HTTPClient.Do(projReq)
 		if err != nil {

--- a/internal/shim/placement/handle_usages_e2e.go
+++ b/internal/shim/placement/handle_usages_e2e.go
@@ -96,13 +96,14 @@ func e2eTestUsages(ctx context.Context) error {
 				"projectID", project.ID, "projectName", project.Name)
 			return err
 		}
-		defer projResp.Body.Close()
 		if projResp.StatusCode < 200 || projResp.StatusCode >= 300 {
+			projResp.Body.Close()
 			err := fmt.Errorf("unexpected status code: %d", projResp.StatusCode)
 			log.Error(err, "placement shim /usages endpoint returned an error",
 				"projectID", project.ID, "projectName", project.Name)
 			return err
 		}
+		projResp.Body.Close()
 		log.Info("Successfully retrieved usages from placement shim for project",
 			"projectID", project.ID, "projectName", project.Name)
 	}

--- a/internal/shim/placement/handle_usages_e2e.go
+++ b/internal/shim/placement/handle_usages_e2e.go
@@ -3,11 +3,105 @@
 
 package placement
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cobaltcore-dev/cortex/pkg/conf"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// e2eTestUsages tests the /usages endpoint.
+func e2eTestUsages(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	log.Info("Running usages endpoint e2e test")
+	config, err := conf.GetConfig[e2eRootConfig]()
+	if err != nil {
+		log.Error(err, "failed to get e2e config")
+		return err
+	}
+	log.Info("Creating openstack client for usages e2e test")
+	sc, err := makeE2EServiceClient(ctx, config)
+	if err != nil {
+		log.Error(err, "failed to create placement service client for e2e test")
+		return err
+	}
+	log.Info("Successfully created openstack client for usages e2e test")
+
+	// Get the list of projects from the identity service, so that we can test
+	// the /usages endpoint with a valid project id.
+	log.Info("Getting list of projects from identity service for usages e2e test")
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.IdentityEndpoint+"/projects", http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create request for identity service projects endpoint")
+		return err
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("Accept", "application/json")
+	resp, err := sc.HTTPClient.Do(req)
+	if err != nil {
+		log.Error(err, "failed to send request to identity service projects endpoint")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		log.Error(err, "identity service projects endpoint returned an error")
+		return err
+	}
+	var list struct {
+		Projects []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"projects"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&list)
+	if err != nil {
+		log.Error(err, "failed to decode response from identity service projects endpoint")
+		return err
+	}
+	log.Info("Successfully retrieved projects from identity service",
+		"projects", len(list.Projects))
+
+	// Pick 5 projects and test the /usages endpoint with them.
+	for i, project := range list.Projects {
+		if i >= 5 {
+			break
+		}
+		log.Info("Testing /usages endpoint with project",
+			"projectID", project.ID, "projectName", project.Name)
+		projReq, err := http.NewRequestWithContext(ctx,
+			http.MethodGet, sc.Endpoint+"/usages?project_id="+project.ID, http.NoBody)
+		if err != nil {
+			log.Error(err, "failed to create request for /usages endpoint")
+			return err
+		}
+		projReq.Header.Set("X-Auth-Token", sc.TokenID)
+		projReq.Header.Set("OpenStack-API-Version", "placement 1.9") // No "X-"!
+		projReq.Header.Set("Accept", "application/json")
+		projResp, err := sc.HTTPClient.Do(projReq)
+		if err != nil {
+			log.Error(err, "failed to send request to placement shim /usages endpoint",
+				"projectID", project.ID, "projectName", project.Name)
+			return err
+		}
+		defer projResp.Body.Close()
+		if projResp.StatusCode < 200 || projResp.StatusCode >= 300 {
+			err := fmt.Errorf("unexpected status code: %d", projResp.StatusCode)
+			log.Error(err, "placement shim /usages endpoint returned an error",
+				"projectID", project.ID, "projectName", project.Name)
+			return err
+		}
+		log.Info("Successfully retrieved usages from placement shim for project",
+			"projectID", project.ID, "projectName", project.Name)
+	}
+
+	return nil
+}
 
 func init() {
-	e2eTests = append(e2eTests, e2eTest{
-		name: "usages",
-		run:  func(ctx context.Context) error { return nil },
-	})
+	e2eTests = append(e2eTests, e2eTest{name: "usages", run: e2eTestUsages})
 }

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -50,8 +50,8 @@ var requestIDKey = requestIDContextKey{}
 
 // config holds configuration for the placement shim.
 type config struct {
-	// SSO is an optional reference to a Kubernetes secret containing
-	// credentials to talk to openstack over ingress via single-sign-on.
+	// SSO is an optional configuration for the certificates the http client
+	// should use when talking to the placement API over ingress with single-sign-on.
 	SSO *sso.SSOConfig `json:"sso,omitempty"`
 	// PlacementURL is the URL of the OpenStack Placement API the shim
 	// should forward requests to.
@@ -254,6 +254,8 @@ func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err erro
 func (s *Shim) forward(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := logf.FromContext(ctx)
+	log.Info("Forwarding request to placement API",
+		"method", r.Method, "path", r.URL.Path)
 
 	if s.httpClient == nil {
 		log.Info("placement shim not yet initialized, rejecting request")
@@ -278,9 +280,11 @@ func (s *Shim) forward(w http.ResponseWriter, r *http.Request) {
 	upstream.RawQuery = r.URL.RawQuery
 
 	// Create upstream request preserving method, body, and context.
-	upstreamReq, err := http.NewRequestWithContext(ctx, r.Method, upstream.String(), r.Body)
+	url := upstream.String()
+	log.Info("Calling URL", "url", url)
+	upstreamReq, err := http.NewRequestWithContext(ctx, r.Method, url, r.Body)
 	if err != nil {
-		log.Error(err, "failed to create upstream request", "url", upstream.String())
+		log.Error(err, "failed to create upstream request", "url", url)
 		http.Error(w, "failed to create upstream request", http.StatusBadGateway)
 		return
 	}
@@ -292,7 +296,7 @@ func (s *Shim) forward(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	resp, err := s.httpClient.Do(upstreamReq) //nolint:gosec // G704: intentional reverse proxy
 	if err != nil {
-		log.Error(err, "failed to reach placement API", "url", upstream.String())
+		log.Error(err, "failed to reach placement API", "url", url)
 		s.upstreamRequestTimer.
 			WithLabelValues(r.Method, pattern, strconv.Itoa(http.StatusBadGateway)).
 			Observe(time.Since(start).Seconds())

--- a/internal/shim/placement/shim_e2e.go
+++ b/internal/shim/placement/shim_e2e.go
@@ -120,7 +120,8 @@ func RunE2E(ctx context.Context) error {
 		log.Info("Starting e2e test",
 			"index", i+1, "total", len(e2eTests), "name", test.name)
 		start := time.Now()
-		if err := test.run(ctx); err != nil {
+		testCtx := logf.IntoContext(ctx, log.WithName(test.name))
+		if err := test.run(testCtx); err != nil {
 			log.Error(err, "FAIL e2e test",
 				"index", i+1, "total", len(e2eTests), "name", test.name,
 				"took_ms", time.Since(start).Milliseconds())

--- a/internal/shim/placement/shim_e2e.go
+++ b/internal/shim/placement/shim_e2e.go
@@ -6,9 +6,20 @@ package placement
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+type e2eConfigRoot struct {
+	E2E e2eConfig `yaml:"e2e"`
+}
+
+type e2eConfig struct {
+	// SVCURL is the url placement shim service, e.g.
+	// "http://cortex-placement-shim-service:8080"
+	SVCURL string `json:"svcURL"`
+}
 
 // e2eTest is a named end-to-end test registered by handler e2e files.
 type e2eTest struct {
@@ -22,17 +33,24 @@ var e2eTests []e2eTest
 // RunE2E executes end-to-end tests for all placement shim handlers.
 // It stops on the first failure and returns the error.
 func RunE2E(ctx context.Context) error {
-	log.Printf("Running %d e2e test(s)", len(e2eTests))
+	log := logf.FromContext(ctx)
+	log.Info("Running e2e test(s)", "count", len(e2eTests))
 	totalStart := time.Now()
 	for i, test := range e2eTests {
-		log.Printf("[%d/%d] Starting: %s", i+1, len(e2eTests), test.name)
+		log.Info("Starting e2e test",
+			"index", i+1, "total", len(e2eTests), "name", test.name)
 		start := time.Now()
 		if err := test.run(ctx); err != nil {
-			log.Printf("[%d/%d] FAIL: %s (took: %d ms): %v", i+1, len(e2eTests), test.name, time.Since(start).Milliseconds(), err)
+			log.Error(err, "FAIL e2e test",
+				"index", i+1, "total", len(e2eTests), "name", test.name,
+				"took_ms", time.Since(start).Milliseconds())
 			return fmt.Errorf("e2e test %q failed: %w", test.name, err)
 		}
-		log.Printf("[%d/%d] Done: %s (took: %d ms)", i+1, len(e2eTests), test.name, time.Since(start).Milliseconds())
+		log.Info("PASS e2e test",
+			"index", i+1, "total", len(e2eTests), "name", test.name,
+			"took_ms", time.Since(start).Milliseconds())
 	}
-	log.Printf("All e2e tests passed (took: %d ms)", time.Since(totalStart).Milliseconds())
+	log.Info("All e2e tests passed",
+		"took_ms", time.Since(totalStart).Milliseconds())
 	return nil
 }

--- a/internal/shim/placement/shim_e2e.go
+++ b/internal/shim/placement/shim_e2e.go
@@ -6,19 +6,99 @@ package placement
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
+	"github.com/cobaltcore-dev/cortex/pkg/sso"
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-type e2eConfigRoot struct {
+type e2eRootConfig struct {
 	E2E e2eConfig `yaml:"e2e"`
+
+	// Shared with the main shim config.
+
+	// SSO is an optional configuration for the certificates the http client
+	// should use when talking to the placement API over ingress with single-sign-on.
+	SSO *sso.SSOConfig `json:"sso,omitempty"`
 }
 
 type e2eConfig struct {
 	// SVCURL is the url placement shim service, e.g.
 	// "http://cortex-placement-shim-service:8080"
 	SVCURL string `json:"svcURL"`
+	// OSKeystoneURL is the URL of the keystone service to contact for
+	// generating an authenticated openstack client token.
+	OSKeystoneURL string `json:"osKeystoneURL"`
+	// OSUsername is the OpenStack username for keystone authentication
+	// (OS_USERNAME in openstack cli).
+	OSUsername string `json:"osUsername"`
+	// OSPassword is the OpenStack password for keystone authentication
+	// (OS_PASSWORD in openstack cli).
+	OSPassword string `json:"osPassword"`
+	// OSProjectName is the OpenStack project name for keystone authentication
+	// (OS_PROJECT_NAME in openstack cli).
+	OSProjectName string `json:"osProjectName"`
+	// OSUserDomainName is the OpenStack user domain name for keystone
+	// authentication (OS_USER_DOMAIN_NAME in openstack cli).
+	OSUserDomainName string `json:"osUserDomainName"`
+	// OSProjectDomainName is the OpenStack project domain name for keystone
+	// authentication (OS_PROJECT_DOMAIN_NAME in openstack cli).
+	OSProjectDomainName string `json:"osProjectDomainName"`
+}
+
+// makeE2EServiceClient creates an authenticated openstack placement client
+// using the keystone configuration in the e2e config. It modifies the service
+// client to use the shim's svc url instead of the real placement endpoint,
+// so that the e2e tests can send authenticated requests to the shim.
+func makeE2EServiceClient(ctx context.Context, rc e2eRootConfig) (*gophercloud.ServiceClient, error) {
+	log := logf.FromContext(ctx)
+	authOpts := gophercloud.AuthOptions{
+		IdentityEndpoint: rc.E2E.OSKeystoneURL,
+		Username:         rc.E2E.OSUsername,
+		DomainName:       rc.E2E.OSUserDomainName,
+		Password:         rc.E2E.OSPassword,
+		AllowReauth:      true,
+		Scope: &gophercloud.AuthScope{
+			ProjectName: rc.E2E.OSProjectName,
+			DomainName:  rc.E2E.OSProjectDomainName,
+		},
+	}
+	log.Info("Authenticating with keystone for e2e tests",
+		"endpoint", authOpts.IdentityEndpoint,
+		"username", authOpts.Username,
+		"project", authOpts.Scope.ProjectName)
+	provider, err := openstack.NewClient(rc.E2E.OSKeystoneURL)
+	if err != nil {
+		log.Error(err, "Failed to create openstack provider client")
+		return nil, fmt.Errorf("failed to create openstack provider client: %w", err)
+	}
+	// Build the transport with optional SSO TLS credentials.
+	var transport *http.Transport
+	if rc.SSO != nil {
+		log.Info("SSO config provided, creating transport for placement API")
+		transport, err = sso.NewTransport(*rc.SSO)
+		if err != nil {
+			log.Error(err, "Failed to create transport from SSO config")
+			return nil, err
+		}
+	} else {
+		log.Info("No SSO config provided, using plain transport for placement API")
+		transport = &http.Transport{}
+	}
+	provider.HTTPClient.Transport = transport
+	if err := openstack.Authenticate(ctx, provider, authOpts); err != nil {
+		log.Error(err, "Failed to authenticate with keystone")
+		return nil, fmt.Errorf("failed to authenticate with keystone: %w", err)
+	}
+	log.Info("Successfully authenticated with keystone for e2e tests")
+	return &gophercloud.ServiceClient{
+		ProviderClient: provider,
+		Endpoint:       rc.E2E.SVCURL,
+		Type:           "placement",
+	}, nil
 }
 
 // e2eTest is a named end-to-end test registered by handler e2e files.


### PR DESCRIPTION
Implements end-to-end tests for all placement shim API endpoints. Each test
runs against a live placement instance, creates isolated test resources with
deterministic UUIDs, exercises the full CRUD lifecycle, and cleans up after
itself.

Design:

- Idempotent: every test does a pre-cleanup pass (ignoring 404s) before
  creating fixtures, so re-runs never fail due to leftover state.

- Isolated: each test uses unique deterministic UUIDs (e2e10000-...-0001
  through ...000a) and CUSTOM_CORTEX_E2E_* resource names to avoid
  collisions with real data or other tests.

- Infrastructure: shim_e2e.go provides shared config (e2eRootConfig),
  OpenStack client setup (makeE2EServiceClient), and the test runner
  (RunE2E).