### PR TITLE
Add keystone token validation middleware to shim

### DIFF
--- a/helm/bundles/cortex-placement-shim/values.yaml
+++ b/helm/bundles/cortex-placement-shim/values.yaml
@@ -34,6 +34,13 @@ cortex-shim:
     # used by the auth middleware for token introspection and by E2E tests
     # for authentication.
     keystoneURL:
+    # OpenStack credentials used by the auth middleware for Keystone token
+    # introspection and by the E2E test suite to obtain authenticated tokens.
+    osUsername:
+    osPassword:
+    osProjectName:
+    osUserDomainName:
+    osProjectDomainName:
     auth:
       tokenCacheTTL: "5m"
       policies:
@@ -56,14 +63,6 @@ cortex-shim:
             - name: cloud_compute_admin
     e2e:
       svcURL: "http://cortex-placement-shim-service:8080"
-      # Openstack credentials for e2e tests. These are not used by the shim
-      # itself, but are passed to the e2e test suite to generate an authenticated
-      # openstack client token for testing the shim's integration with openstack.
-      osUsername:
-      osPassword:
-      osProjectName:
-      osUserDomainName:
-      osProjectDomainName:
     apiservers:
       home:
         gvks:

--- a/helm/bundles/cortex-placement-shim/values.yaml
+++ b/helm/bundles/cortex-placement-shim/values.yaml
@@ -51,9 +51,11 @@ cortex-shim:
             - name: cloud_compute_admin
             - name: cloud_compute_viewer
             - name: compute_admin
-              projectScoped: true
+              projectScope:
+                from: query
             - name: compute_viewer
-              projectScoped: true
+              projectScope:
+                from: query
         - pattern: "GET /*"
           roles:
             - name: cloud_compute_admin

--- a/helm/bundles/cortex-placement-shim/values.yaml
+++ b/helm/bundles/cortex-placement-shim/values.yaml
@@ -27,12 +27,36 @@ cortex-shim:
     container:
       extraArgs: ["--placement-shim=true"]
   conf:
+    # placementURL is the URL of the OpenStack Placement service toward
+    # which the shim will proxy requests.
+    placementURL:
+    # keystoneURL is the URL of the OpenStack Keystone identity service,
+    # used by the auth middleware for token introspection and by E2E tests
+    # for authentication.
+    keystoneURL:
+    auth:
+      tokenCacheTTL: "5m"
+      policies:
+        - pattern: "GET /usages"
+          roles:
+            - name: cloud_compute_admin
+            - name: cloud_compute_viewer
+            - name: compute_admin
+              projectScoped: true
+            - name: compute_viewer
+              projectScoped: true
+        - pattern: "GET /*"
+          roles:
+            - name: cloud_compute_admin
+            - name: cloud_compute_viewer
+        - pattern: "* /*"
+          roles:
+            - name: cloud_compute_admin
     e2e:
       svcURL: "http://cortex-placement-shim-service:8080"
       # Openstack credentials for e2e tests. These are not used by the shim
       # itself, but are passed to the e2e test suite to generate an authenticated
       # openstack client token for testing the shim's integration with openstack.
-      osKeystoneURL:
       osUsername:
       osPassword:
       osProjectName:

--- a/helm/bundles/cortex-placement-shim/values.yaml
+++ b/helm/bundles/cortex-placement-shim/values.yaml
@@ -37,9 +37,8 @@ cortex-shim:
     auth:
       tokenCacheTTL: "5m"
       policies:
-        # Version endpoint is publicly accessible (no token required).
         - pattern: "GET /"
-          roles: null
+          roles: null # Version endpoint is publicly accessible (no token required).
         - pattern: "GET /usages"
           roles:
             - name: cloud_compute_admin

--- a/helm/bundles/cortex-placement-shim/values.yaml
+++ b/helm/bundles/cortex-placement-shim/values.yaml
@@ -37,6 +37,9 @@ cortex-shim:
     auth:
       tokenCacheTTL: "5m"
       policies:
+        # Version endpoint is publicly accessible (no token required).
+        - pattern: "GET /"
+          roles: null
         - pattern: "GET /usages"
           roles:
             - name: cloud_compute_admin

--- a/internal/shim/placement/auth.go
+++ b/internal/shim/placement/auth.go
@@ -1,0 +1,174 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// tokenInfo holds validated Keystone token metadata cached after a
+// successful introspection.
+type tokenInfo struct {
+	roles     []string
+	projectID string
+	expiresAt time.Time
+	cachedAt  time.Time
+}
+
+// tokenCache is a concurrency-safe cache mapping opaque token strings
+// to their validated tokenInfo. Entries are lazily evicted on lookup
+// when either the Keystone token has expired or the cache TTL has
+// elapsed.
+type tokenCache struct {
+	entries sync.Map // map[string]*tokenInfo
+	ttl     time.Duration
+}
+
+func (c *tokenCache) get(token string) (*tokenInfo, bool) {
+	v, ok := c.entries.Load(token)
+	if !ok {
+		return nil, false
+	}
+	info := v.(*tokenInfo)
+	now := time.Now()
+	if now.After(info.expiresAt) || now.After(info.cachedAt.Add(c.ttl)) {
+		c.entries.Delete(token)
+		return nil, false
+	}
+	return info, true
+}
+
+func (c *tokenCache) put(token string, info *tokenInfo) {
+	c.entries.Store(token, info)
+}
+
+// tokenIntrospector abstracts Keystone token validation so tests can
+// provide a mock without a real Keystone server.
+type tokenIntrospector interface {
+	introspect(ctx context.Context, tokenValue string) (*tokenInfo, error)
+}
+
+// compiledPolicy is an authPolicy with its pattern pre-parsed at setup
+// time for efficient request-time matching.
+type compiledPolicy struct {
+	method      string           // HTTP method or "*"
+	pathPattern string           // path with optional trailing "/*" wildcard
+	roles       []authPolicyRole // nil/empty = public (no token required)
+}
+
+// matchPath reports whether requestPath matches the pattern.
+// A trailing "/*" matches any suffix; "/*" alone matches everything.
+func matchPath(pattern, requestPath string) bool {
+	if pattern == "/*" || pattern == "*" {
+		return true
+	}
+	if prefix, ok := strings.CutSuffix(pattern, "/*"); ok {
+		return requestPath == prefix || strings.HasPrefix(requestPath, prefix+"/")
+	}
+	return pattern == requestPath
+}
+
+func matchPolicy(p *compiledPolicy, method, path string) bool {
+	if p.method != "*" && p.method != method {
+		return false
+	}
+	return matchPath(p.pathPattern, path)
+}
+
+// authError writes an OpenStack-compatible JSON error response matching
+// the format returned by the Placement API.
+func authError(w http.ResponseWriter, code int, title, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	body := fmt.Sprintf(`{"error":{"code":%d,"title":%q,"message":%q}}`,
+		code, title, message)
+	//nolint:errcheck // best-effort write; nothing useful to do on failure
+	w.Write([]byte(body))
+}
+
+// checkAuth validates the request's X-Auth-Token against the compiled
+// policy table. It returns true if the request is authorized, false if
+// a 401/403 response has already been written.
+func (s *Shim) checkAuth(w http.ResponseWriter, r *http.Request) bool {
+	if s.authPolicies == nil {
+		return true
+	}
+
+	log := logf.FromContext(r.Context())
+
+	var matched *compiledPolicy
+	for i := range s.authPolicies {
+		if matchPolicy(&s.authPolicies[i], r.Method, r.URL.Path) {
+			matched = &s.authPolicies[i]
+			break
+		}
+	}
+
+	if matched == nil {
+		log.Info("auth denied: no matching policy",
+			"method", r.Method, "path", r.URL.Path)
+		authError(w, http.StatusForbidden, "Forbidden",
+			"No policy matches the requested resource.")
+		return false
+	}
+
+	if len(matched.roles) == 0 {
+		return true
+	}
+
+	tokenValue := r.Header.Get("X-Auth-Token")
+	if tokenValue == "" {
+		authError(w, http.StatusUnauthorized, "Unauthorized",
+			"The request you have made requires authentication.")
+		return false
+	}
+
+	info, ok := s.tokenCache.get(tokenValue)
+	if !ok {
+		var err error
+		info, err = s.tokenIntrospector.introspect(r.Context(), tokenValue)
+		if err != nil {
+			log.Info("token introspection failed", "error", err)
+			authError(w, http.StatusUnauthorized, "Unauthorized",
+				"Token validation failed.")
+			return false
+		}
+		s.tokenCache.put(tokenValue, info)
+	}
+
+	if time.Now().After(info.expiresAt) {
+		s.tokenCache.entries.Delete(tokenValue)
+		authError(w, http.StatusUnauthorized, "Unauthorized",
+			"The token has expired.")
+		return false
+	}
+
+	for _, policyRole := range matched.roles {
+		for _, tokenRole := range info.roles {
+			if policyRole.Name != tokenRole {
+				continue
+			}
+			if policyRole.ProjectScoped {
+				reqProjectID := r.URL.Query().Get("project_id")
+				if reqProjectID == "" || reqProjectID != info.projectID {
+					continue
+				}
+			}
+			return true
+		}
+	}
+
+	log.Info("auth denied: insufficient roles",
+		"method", r.Method, "path", r.URL.Path)
+	authError(w, http.StatusForbidden, "Forbidden",
+		"You do not have the required role for this operation.")
+	return false
+}

--- a/internal/shim/placement/auth.go
+++ b/internal/shim/placement/auth.go
@@ -37,8 +37,6 @@ type authProjectScope struct {
 type authPolicyRole struct {
 	// Name is the OpenStack role name (e.g. "cloud_compute_admin").
 	Name string `json:"name"`
-	// ProjectScoped is deprecated; use ProjectScope instead.
-	ProjectScoped bool `json:"projectScoped,omitempty"`
 	// ProjectScope configures project-scoped authorization for this role.
 	// When non-nil, the request's project ID (extracted per the config)
 	// must match the token's project ID.
@@ -112,9 +110,6 @@ func compileRoles(roles []authPolicyRole) ([]compiledRole, error) {
 	for i, role := range roles {
 		cr := compiledRole{name: role.Name}
 		scope := role.ProjectScope
-		if scope == nil && role.ProjectScoped {
-			scope = &authProjectScope{From: "query", Param: "project_id"}
-		}
 		if scope != nil {
 			switch scope.From {
 			case "query":

--- a/internal/shim/placement/auth.go
+++ b/internal/shim/placement/auth.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -176,6 +177,7 @@ type tokenInfo struct {
 // elapsed.
 type tokenCache struct {
 	entries sync.Map // map[string]*tokenInfo
+	sf      singleflight.Group
 	ttl     time.Duration
 }
 
@@ -310,15 +312,25 @@ func (s *Shim) checkAuth(w http.ResponseWriter, r *http.Request) bool {
 
 	info, ok := s.tokenCache.get(tokenValue)
 	if !ok {
-		var err error
-		info, err = s.tokenIntrospector.introspect(r.Context(), tokenValue)
+		key := tokenCacheKey(tokenValue)
+		v, err, _ := s.tokenCache.sf.Do(key, func() (any, error) {
+			if cached, ok := s.tokenCache.get(tokenValue); ok {
+				return cached, nil
+			}
+			result, err := s.tokenIntrospector.introspect(r.Context(), tokenValue)
+			if err != nil {
+				return nil, err
+			}
+			s.tokenCache.put(tokenValue, result)
+			return result, nil
+		})
 		if err != nil {
 			log.Info("token introspection failed", "error", err)
 			authError(w, http.StatusUnauthorized, "Unauthorized",
 				"Token validation failed.")
 			return false
 		}
-		s.tokenCache.put(tokenValue, info)
+		info = v.(*tokenInfo)
 	}
 
 	if time.Now().After(info.expiresAt) {

--- a/internal/shim/placement/auth.go
+++ b/internal/shim/placement/auth.go
@@ -14,6 +14,38 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// compileAuthPolicies parses the auth config into the shim's runtime
+// policy table and token cache. Called during SetupWithManager.
+func (s *Shim) compileAuthPolicies() error {
+	if s.config.Auth == nil {
+		return nil
+	}
+	ttlStr := s.config.Auth.TokenCacheTTL
+	if ttlStr == "" {
+		ttlStr = "5m"
+	}
+	ttl, err := time.ParseDuration(ttlStr)
+	if err != nil {
+		return fmt.Errorf("invalid tokenCacheTTL %q: %w", ttlStr, err)
+	}
+	s.tokenCache = &tokenCache{ttl: ttl}
+	s.authPolicies = make([]compiledPolicy, len(s.config.Auth.Policies))
+	for i, p := range s.config.Auth.Policies {
+		method, path, ok := strings.Cut(p.Pattern, " ")
+		if !ok {
+			return fmt.Errorf("invalid auth policy pattern %q: expected \"METHOD /path\"", p.Pattern)
+		}
+		s.authPolicies[i] = compiledPolicy{
+			method:      method,
+			pathPattern: path,
+			roles:       p.Roles,
+		}
+	}
+	setupLog.Info("Auth middleware configured",
+		"policies", len(s.authPolicies), "tokenCacheTTL", ttl)
+	return nil
+}
+
 // tokenInfo holds validated Keystone token metadata cached after a
 // successful introspection.
 type tokenInfo struct {
@@ -126,6 +158,8 @@ func (s *Shim) checkAuth(w http.ResponseWriter, r *http.Request) bool {
 
 	tokenValue := r.Header.Get("X-Auth-Token")
 	if tokenValue == "" {
+		log.Info("auth denied: missing token",
+			"method", r.Method, "path", r.URL.Path)
 		authError(w, http.StatusUnauthorized, "Unauthorized",
 			"The request you have made requires authentication.")
 		return false

--- a/internal/shim/placement/auth.go
+++ b/internal/shim/placement/auth.go
@@ -4,10 +4,13 @@
 package placement
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -16,13 +19,30 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// authProjectScope configures how the project ID is extracted from the
+// request for project-scoped authorization.
+type authProjectScope struct {
+	// From selects the extraction strategy: "query" reads a URL query
+	// parameter, "body" reads a top-level JSON body field.
+	From string `json:"from"`
+	// Param is the query parameter name (used when From is "query",
+	// defaults to "project_id").
+	Param string `json:"param,omitempty"`
+	// Field is the JSON body field name (used when From is "body",
+	// defaults to "project_id").
+	Field string `json:"field,omitempty"`
+}
+
 // authPolicyRole is a role that grants access for a matching policy rule.
 type authPolicyRole struct {
 	// Name is the OpenStack role name (e.g. "cloud_compute_admin").
 	Name string `json:"name"`
-	// ProjectScoped requires the token's project_id to match the
-	// request's project_id when true (e.g. for per-project usages).
+	// ProjectScoped is deprecated; use ProjectScope instead.
 	ProjectScoped bool `json:"projectScoped,omitempty"`
+	// ProjectScope configures project-scoped authorization for this role.
+	// When non-nil, the request's project ID (extracted per the config)
+	// must match the token's project ID.
+	ProjectScope *authProjectScope `json:"projectScope,omitempty"`
 }
 
 // authPolicy maps an HTTP method + path pattern to the roles allowed to
@@ -69,15 +89,81 @@ func (s *Shim) compileAuthPolicies() error {
 		if !ok || method == "" || path == "" {
 			return fmt.Errorf("invalid auth policy pattern %q: expected \"METHOD /path\"", p.Pattern)
 		}
+		roles, err := compileRoles(p.Roles)
+		if err != nil {
+			return fmt.Errorf("policy %q: %w", p.Pattern, err)
+		}
 		s.authPolicies[i] = compiledPolicy{
 			method:      method,
 			pathPattern: path,
-			roles:       p.Roles,
+			roles:       roles,
 		}
 	}
 	setupLog.Info("Auth middleware configured",
 		"policies", len(s.authPolicies), "tokenCacheTTL", ttl)
 	return nil
+}
+
+func compileRoles(roles []authPolicyRole) ([]compiledRole, error) {
+	if len(roles) == 0 {
+		return nil, nil
+	}
+	compiled := make([]compiledRole, len(roles))
+	for i, role := range roles {
+		cr := compiledRole{name: role.Name}
+		scope := role.ProjectScope
+		if scope == nil && role.ProjectScoped {
+			scope = &authProjectScope{From: "query", Param: "project_id"}
+		}
+		if scope != nil {
+			switch scope.From {
+			case "query":
+				cr.extractor = queryParamScope
+				cr.extractParam = scope.Param
+				if cr.extractParam == "" {
+					cr.extractParam = "project_id"
+				}
+			case "body":
+				cr.extractor = bodyFieldScope
+				cr.extractParam = scope.Field
+				if cr.extractParam == "" {
+					cr.extractParam = "project_id"
+				}
+			default:
+				return nil, fmt.Errorf("role %q: invalid projectScope.from %q (must be \"query\" or \"body\")", role.Name, scope.From)
+			}
+		}
+		compiled[i] = cr
+	}
+	return compiled, nil
+}
+
+// extractBodyField reads the request body, extracts a top-level JSON
+// string field, and re-wraps r.Body so downstream handlers can still
+// read it.
+func extractBodyField(r *http.Request, field string) string {
+	if r.Body == nil || r.Body == http.NoBody {
+		return ""
+	}
+	const maxBodySize = 1 << 20 // 1 MiB
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodySize))
+	if err != nil {
+		return ""
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(body, &top); err != nil {
+		return ""
+	}
+	raw, ok := top[field]
+	if !ok {
+		return ""
+	}
+	var val string
+	if err := json.Unmarshal(raw, &val); err != nil {
+		return ""
+	}
+	return val
 }
 
 // tokenInfo holds validated Keystone token metadata cached after a
@@ -132,12 +218,30 @@ type tokenIntrospector interface {
 	introspect(ctx context.Context, tokenValue string) (*tokenInfo, error)
 }
 
+// projectIDExtractor selects how the request's project ID is obtained
+// for project-scoped authorization checks.
+type projectIDExtractor int
+
+const (
+	noProjectScope  projectIDExtractor = iota
+	queryParamScope                    // extract from URL query parameter
+	bodyFieldScope                     // extract from top-level JSON body field
+)
+
+// compiledRole is a pre-resolved role with its project-scope extraction
+// strategy ready for request-time evaluation.
+type compiledRole struct {
+	name         string
+	extractor    projectIDExtractor
+	extractParam string // query param name or body field name
+}
+
 // compiledPolicy is an authPolicy with its pattern pre-parsed at setup
 // time for efficient request-time matching.
 type compiledPolicy struct {
-	method      string           // HTTP method or "*"
-	pathPattern string           // path with optional trailing "/*" wildcard
-	roles       []authPolicyRole // nil/empty = public (no token required)
+	method      string         // HTTP method or "*"
+	pathPattern string         // path with optional trailing "/*" wildcard
+	roles       []compiledRole // nil/empty = public (no token required)
 }
 
 // matchPath reports whether requestPath matches the pattern.
@@ -229,18 +333,30 @@ func (s *Shim) checkAuth(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 
-	for _, policyRole := range matched.roles {
+	var bodyProjectID string
+	var bodyRead bool
+
+	for _, cr := range matched.roles {
 		for _, tokenRole := range info.roles {
-			if !strings.EqualFold(policyRole.Name, tokenRole) {
+			if !strings.EqualFold(cr.name, tokenRole) {
 				continue
 			}
-			if policyRole.ProjectScoped {
-				reqProjectID := r.URL.Query().Get("project_id")
-				if reqProjectID == "" || reqProjectID != info.projectID {
-					continue
+			switch cr.extractor {
+			case noProjectScope:
+				return true
+			case queryParamScope:
+				if id := r.URL.Query().Get(cr.extractParam); id != "" && id == info.projectID {
+					return true
+				}
+			case bodyFieldScope:
+				if !bodyRead {
+					bodyProjectID = extractBodyField(r, cr.extractParam)
+					bodyRead = true
+				}
+				if bodyProjectID != "" && bodyProjectID == info.projectID {
+					return true
 				}
 			}
-			return true
 		}
 	}
 

--- a/internal/shim/placement/auth.go
+++ b/internal/shim/placement/auth.go
@@ -5,6 +5,8 @@ package placement
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strings"
@@ -13,6 +15,38 @@ import (
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// authPolicyRole is a role that grants access for a matching policy rule.
+type authPolicyRole struct {
+	// Name is the OpenStack role name (e.g. "cloud_compute_admin").
+	Name string `json:"name"`
+	// ProjectScoped requires the token's project_id to match the
+	// request's project_id when true (e.g. for per-project usages).
+	ProjectScoped bool `json:"projectScoped,omitempty"`
+}
+
+// authPolicy maps an HTTP method + path pattern to the roles allowed to
+// access it. Patterns use "METHOD /path" syntax where "*" matches any
+// method and "*" in the path acts as a wildcard. Evaluation is
+// first-match; no match means deny.
+type authPolicy struct {
+	// Pattern is the method + path to match (e.g. "GET /usages", "* /*").
+	Pattern string `json:"pattern"`
+	// Roles lists the roles that grant access for this pattern.
+	// When null, the path is publicly accessible (no token required).
+	Roles []authPolicyRole `json:"roles"`
+}
+
+// authConfig configures the Keystone token-validation middleware.
+// When nil, auth is disabled and all requests are passed through.
+type authConfig struct {
+	// TokenCacheTTL is how long validated tokens are cached before
+	// re-introspection against Keystone (e.g. "5m").
+	TokenCacheTTL string `json:"tokenCacheTTL,omitempty"`
+	// Policies is the ordered list of first-match access rules evaluated
+	// against each incoming request.
+	Policies []authPolicy `json:"policies,omitempty"`
+}
 
 // compileAuthPolicies parses the auth config into the shim's runtime
 // policy table and token cache. Called during SetupWithManager.
@@ -32,7 +66,7 @@ func (s *Shim) compileAuthPolicies() error {
 	s.authPolicies = make([]compiledPolicy, len(s.config.Auth.Policies))
 	for i, p := range s.config.Auth.Policies {
 		method, path, ok := strings.Cut(p.Pattern, " ")
-		if !ok {
+		if !ok || method == "" || path == "" {
 			return fmt.Errorf("invalid auth policy pattern %q: expected \"METHOD /path\"", p.Pattern)
 		}
 		s.authPolicies[i] = compiledPolicy{
@@ -64,22 +98,32 @@ type tokenCache struct {
 	ttl     time.Duration
 }
 
+func tokenCacheKey(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
+}
+
 func (c *tokenCache) get(token string) (*tokenInfo, bool) {
-	v, ok := c.entries.Load(token)
+	key := tokenCacheKey(token)
+	v, ok := c.entries.Load(key)
 	if !ok {
 		return nil, false
 	}
 	info := v.(*tokenInfo)
 	now := time.Now()
 	if now.After(info.expiresAt) || now.After(info.cachedAt.Add(c.ttl)) {
-		c.entries.Delete(token)
+		c.entries.Delete(key)
 		return nil, false
 	}
 	return info, true
 }
 
 func (c *tokenCache) put(token string, info *tokenInfo) {
-	c.entries.Store(token, info)
+	c.entries.Store(tokenCacheKey(token), info)
+}
+
+func (c *tokenCache) delete(token string) {
+	c.entries.Delete(tokenCacheKey(token))
 }
 
 // tokenIntrospector abstracts Keystone token validation so tests can
@@ -130,7 +174,7 @@ func authError(w http.ResponseWriter, code int, title, message string) {
 // policy table. It returns true if the request is authorized, false if
 // a 401/403 response has already been written.
 func (s *Shim) checkAuth(w http.ResponseWriter, r *http.Request) bool {
-	if s.authPolicies == nil {
+	if len(s.authPolicies) == 0 {
 		return true
 	}
 
@@ -179,7 +223,7 @@ func (s *Shim) checkAuth(w http.ResponseWriter, r *http.Request) bool {
 	}
 
 	if time.Now().After(info.expiresAt) {
-		s.tokenCache.entries.Delete(tokenValue)
+		s.tokenCache.delete(tokenValue)
 		authError(w, http.StatusUnauthorized, "Unauthorized",
 			"The token has expired.")
 		return false
@@ -187,7 +231,7 @@ func (s *Shim) checkAuth(w http.ResponseWriter, r *http.Request) bool {
 
 	for _, policyRole := range matched.roles {
 		for _, tokenRole := range info.roles {
-			if policyRole.Name != tokenRole {
+			if !strings.EqualFold(policyRole.Name, tokenRole) {
 				continue
 			}
 			if policyRole.ProjectScoped {

--- a/internal/shim/placement/auth_keystone.go
+++ b/internal/shim/placement/auth_keystone.go
@@ -5,80 +5,93 @@ package placement
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"strings"
 	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
 )
 
-// keystoneIntrospector validates tokens against a real Keystone service
-// by calling GET /v3/auth/tokens with the token as both X-Auth-Token
-// (caller identity) and X-Subject-Token (token to validate). This
-// self-validation pattern avoids the need for separate service
-// credentials.
-type keystoneIntrospector struct {
-	keystoneURL string
-	httpClient  *http.Client
+// initTokenIntrospector authenticates the shim with Keystone using
+// service credentials and creates the identity v3 client used for
+// token validation. Called during Start after the HTTP client is ready.
+func (s *Shim) initTokenIntrospector(ctx context.Context) error {
+	if s.config.Auth == nil {
+		return nil
+	}
+	authOpts := gophercloud.AuthOptions{
+		IdentityEndpoint: s.config.KeystoneURL,
+		Username:         s.config.OSUsername,
+		DomainName:       s.config.OSUserDomainName,
+		Password:         s.config.OSPassword,
+		AllowReauth:      true,
+		Scope: &gophercloud.AuthScope{
+			ProjectName: s.config.OSProjectName,
+			DomainName:  s.config.OSProjectDomainName,
+		},
+	}
+	provider, err := openstack.NewClient(s.config.KeystoneURL)
+	if err != nil {
+		return fmt.Errorf("creating Keystone provider client: %w", err)
+	}
+	provider.HTTPClient = *s.httpClient
+	if err := openstack.Authenticate(ctx, provider, authOpts); err != nil {
+		return fmt.Errorf("authenticating with Keystone: %w", err)
+	}
+	identityClient, err := openstack.NewIdentityV3(provider, gophercloud.EndpointOpts{})
+	if err != nil {
+		return fmt.Errorf("creating identity v3 client: %w", err)
+	}
+	s.tokenIntrospector = &keystoneIntrospector{identityClient: identityClient}
+	setupLog.Info("Auth middleware enabled with Keystone",
+		"keystoneURL", s.config.KeystoneURL)
+	return nil
 }
 
-// keystoneTokenResponse mirrors the relevant subset of the Keystone
-// GET /v3/auth/tokens JSON response.
-type keystoneTokenResponse struct {
-	Token struct {
-		ExpiresAt string `json:"expires_at"`
-		Roles     []struct {
-			Name string `json:"name"`
-		} `json:"roles"`
-		Project *struct {
-			ID string `json:"id"`
-		} `json:"project"`
-	} `json:"token"`
+// keystoneIntrospector validates tokens against Keystone using an
+// authenticated service client. It calls GET /v3/auth/tokens with the
+// shim's own service credentials as X-Auth-Token and the subject token
+// as X-Subject-Token, then extracts roles, project, and expiry from
+// the response.
+type keystoneIntrospector struct {
+	identityClient *gophercloud.ServiceClient
 }
 
 func (k *keystoneIntrospector) introspect(ctx context.Context, tokenValue string) (*tokenInfo, error) {
-	url := strings.TrimSuffix(k.keystoneURL, "/") + "/v3/auth/tokens"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody) //nolint:gosec // URL from trusted config
+	result := tokens.Get(ctx, k.identityClient, tokenValue)
+	if result.Err != nil {
+		return nil, fmt.Errorf("keystone token introspection failed: %w", result.Err)
+	}
+
+	token, err := result.ExtractToken()
 	if err != nil {
-		return nil, fmt.Errorf("creating keystone request: %w", err)
+		return nil, fmt.Errorf("extracting token: %w", err)
 	}
-	req.Header.Set("X-Auth-Token", tokenValue)
-	req.Header.Set("X-Subject-Token", tokenValue)
 
-	resp, err := k.httpClient.Do(req) //nolint:gosec // intentional call to configured Keystone
+	roles, err := result.ExtractRoles()
 	if err != nil {
-		return nil, fmt.Errorf("keystone request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("keystone returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("extracting roles: %w", err)
 	}
 
-	var body keystoneTokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return nil, fmt.Errorf("decoding keystone response: %w", err)
-	}
-
-	expiresAt, err := time.Parse(time.RFC3339, body.Token.ExpiresAt)
-	if err != nil {
-		return nil, fmt.Errorf("parsing token expiry: %w", err)
-	}
-
-	roleNames := make([]string, len(body.Token.Roles))
-	for i, r := range body.Token.Roles {
+	roleNames := make([]string, len(roles))
+	for i, r := range roles {
 		roleNames[i] = r.Name
 	}
 
 	projectID := ""
-	if body.Token.Project != nil {
-		projectID = body.Token.Project.ID
+	project, err := result.ExtractProject()
+	if err != nil {
+		return nil, fmt.Errorf("extracting project: %w", err)
+	}
+	if project != nil {
+		projectID = project.ID
 	}
 
 	return &tokenInfo{
 		roles:     roleNames,
 		projectID: projectID,
-		expiresAt: expiresAt,
+		expiresAt: token.ExpiresAt,
 		cachedAt:  time.Now(),
 	}, nil
 }

--- a/internal/shim/placement/auth_keystone.go
+++ b/internal/shim/placement/auth_keystone.go
@@ -6,6 +6,7 @@ package placement
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -35,7 +36,12 @@ func (s *Shim) initTokenIntrospector(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("creating Keystone provider client: %w", err)
 	}
-	provider.HTTPClient = *s.httpClient
+	// Use a dedicated HTTP client for Keystone — the shim's httpClient
+	// carries the placement-API SSO transport (client certs / custom CA)
+	// which would cause TLS mismatches against Keystone.
+	provider.HTTPClient = http.Client{
+		Timeout: 30 * time.Second,
+	}
 	if err := openstack.Authenticate(ctx, provider, authOpts); err != nil {
 		return fmt.Errorf("authenticating with Keystone: %w", err)
 	}

--- a/internal/shim/placement/auth_keystone.go
+++ b/internal/shim/placement/auth_keystone.go
@@ -1,0 +1,84 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// keystoneIntrospector validates tokens against a real Keystone service
+// by calling GET /v3/auth/tokens with the token as both X-Auth-Token
+// (caller identity) and X-Subject-Token (token to validate). This
+// self-validation pattern avoids the need for separate service
+// credentials.
+type keystoneIntrospector struct {
+	keystoneURL string
+	httpClient  *http.Client
+}
+
+// keystoneTokenResponse mirrors the relevant subset of the Keystone
+// GET /v3/auth/tokens JSON response.
+type keystoneTokenResponse struct {
+	Token struct {
+		ExpiresAt string `json:"expires_at"`
+		Roles     []struct {
+			Name string `json:"name"`
+		} `json:"roles"`
+		Project *struct {
+			ID string `json:"id"`
+		} `json:"project"`
+	} `json:"token"`
+}
+
+func (k *keystoneIntrospector) introspect(ctx context.Context, tokenValue string) (*tokenInfo, error) {
+	url := strings.TrimSuffix(k.keystoneURL, "/") + "/v3/auth/tokens"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody) //nolint:gosec // URL from trusted config
+	if err != nil {
+		return nil, fmt.Errorf("creating keystone request: %w", err)
+	}
+	req.Header.Set("X-Auth-Token", tokenValue)
+	req.Header.Set("X-Subject-Token", tokenValue)
+
+	resp, err := k.httpClient.Do(req) //nolint:gosec // intentional call to configured Keystone
+	if err != nil {
+		return nil, fmt.Errorf("keystone request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("keystone returned status %d", resp.StatusCode)
+	}
+
+	var body keystoneTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decoding keystone response: %w", err)
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, body.Token.ExpiresAt)
+	if err != nil {
+		return nil, fmt.Errorf("parsing token expiry: %w", err)
+	}
+
+	roleNames := make([]string, len(body.Token.Roles))
+	for i, r := range body.Token.Roles {
+		roleNames[i] = r.Name
+	}
+
+	projectID := ""
+	if body.Token.Project != nil {
+		projectID = body.Token.Project.ID
+	}
+
+	return &tokenInfo{
+		roles:     roleNames,
+		projectID: projectID,
+		expiresAt: expiresAt,
+		cachedAt:  time.Now(),
+	}, nil
+}

--- a/internal/shim/placement/auth_keystone_test.go
+++ b/internal/shim/placement/auth_keystone_test.go
@@ -10,50 +10,50 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
 )
 
 func TestKeystoneIntrospectorSuccess(t *testing.T) {
 	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
 
 	ks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v3/auth/tokens" {
+		if r.URL.Path != "/auth/tokens" {
 			t.Errorf("unexpected path %q", r.URL.Path)
-		}
-		if r.Header.Get("X-Auth-Token") != "my-token" {
-			t.Error("missing X-Auth-Token")
 		}
 		if r.Header.Get("X-Subject-Token") != "my-token" {
 			t.Error("missing X-Subject-Token")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(keystoneTokenResponse{
-			Token: struct {
-				ExpiresAt string `json:"expires_at"`
-				Roles     []struct {
-					Name string `json:"name"`
-				} `json:"roles"`
-				Project *struct {
-					ID string `json:"id"`
-				} `json:"project"`
-			}{
-				ExpiresAt: expiry.Format(time.RFC3339),
-				Roles: []struct {
-					Name string `json:"name"`
-				}{
-					{Name: "cloud_compute_admin"},
-					{Name: "cloud_compute_viewer"},
+		resp := map[string]any{
+			"token": map[string]any{
+				"expires_at": expiry.Format(time.RFC3339),
+				"roles": []map[string]any{
+					{"name": "cloud_compute_admin"},
+					{"name": "cloud_compute_viewer"},
 				},
-				Project: &struct {
-					ID string `json:"id"`
-				}{ID: "proj-abc"},
+				"project": map[string]any{
+					"id":   "proj-abc",
+					"name": "my-project",
+					"domain": map[string]any{
+						"id":   "default",
+						"name": "Default",
+					},
+				},
 			},
-		}); err != nil {
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Fatal(err)
 		}
 	}))
 	defer ks.Close()
 
-	ki := &keystoneIntrospector{keystoneURL: ks.URL, httpClient: ks.Client()}
+	ki := &keystoneIntrospector{
+		identityClient: &gophercloud.ServiceClient{
+			ProviderClient: &gophercloud.ProviderClient{},
+			Endpoint:       ks.URL + "/",
+		},
+	}
 	info, err := ki.introspect(context.Background(), "my-token")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -78,7 +78,12 @@ func TestKeystoneIntrospectorInvalidToken(t *testing.T) {
 	}))
 	defer ks.Close()
 
-	ki := &keystoneIntrospector{keystoneURL: ks.URL, httpClient: ks.Client()}
+	ki := &keystoneIntrospector{
+		identityClient: &gophercloud.ServiceClient{
+			ProviderClient: &gophercloud.ProviderClient{},
+			Endpoint:       ks.URL + "/",
+		},
+	}
 	_, err := ki.introspect(context.Background(), "bad-token")
 	if err == nil {
 		t.Fatal("expected error for invalid token")
@@ -87,8 +92,12 @@ func TestKeystoneIntrospectorInvalidToken(t *testing.T) {
 
 func TestKeystoneIntrospectorKeystoneDown(t *testing.T) {
 	ki := &keystoneIntrospector{
-		keystoneURL: "http://127.0.0.1:1",
-		httpClient:  &http.Client{Timeout: 100 * time.Millisecond},
+		identityClient: &gophercloud.ServiceClient{
+			ProviderClient: &gophercloud.ProviderClient{
+				HTTPClient: http.Client{Timeout: 100 * time.Millisecond},
+			},
+			Endpoint: "http://127.0.0.1:1/",
+		},
 	}
 	_, err := ki.introspect(context.Background(), "token")
 	if err == nil {
@@ -101,31 +110,26 @@ func TestKeystoneIntrospectorDomainScopedToken(t *testing.T) {
 
 	ks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(keystoneTokenResponse{
-			Token: struct {
-				ExpiresAt string `json:"expires_at"`
-				Roles     []struct {
-					Name string `json:"name"`
-				} `json:"roles"`
-				Project *struct {
-					ID string `json:"id"`
-				} `json:"project"`
-			}{
-				ExpiresAt: expiry.Format(time.RFC3339),
-				Roles: []struct {
-					Name string `json:"name"`
-				}{
-					{Name: "admin"},
+		resp := map[string]any{
+			"token": map[string]any{
+				"expires_at": expiry.Format(time.RFC3339),
+				"roles": []map[string]any{
+					{"name": "admin"},
 				},
-				Project: nil, // domain-scoped, no project
 			},
-		}); err != nil {
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Fatal(err)
 		}
 	}))
 	defer ks.Close()
 
-	ki := &keystoneIntrospector{keystoneURL: ks.URL, httpClient: ks.Client()}
+	ki := &keystoneIntrospector{
+		identityClient: &gophercloud.ServiceClient{
+			ProviderClient: &gophercloud.ProviderClient{},
+			Endpoint:       ks.URL + "/",
+		},
+	}
 	info, err := ki.introspect(context.Background(), "domain-token")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/shim/placement/auth_keystone_test.go
+++ b/internal/shim/placement/auth_keystone_test.go
@@ -1,0 +1,136 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestKeystoneIntrospectorSuccess(t *testing.T) {
+	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+
+	ks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v3/auth/tokens" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.Header.Get("X-Auth-Token") != "my-token" {
+			t.Error("missing X-Auth-Token")
+		}
+		if r.Header.Get("X-Subject-Token") != "my-token" {
+			t.Error("missing X-Subject-Token")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(keystoneTokenResponse{
+			Token: struct {
+				ExpiresAt string `json:"expires_at"`
+				Roles     []struct {
+					Name string `json:"name"`
+				} `json:"roles"`
+				Project *struct {
+					ID string `json:"id"`
+				} `json:"project"`
+			}{
+				ExpiresAt: expiry.Format(time.RFC3339),
+				Roles: []struct {
+					Name string `json:"name"`
+				}{
+					{Name: "cloud_compute_admin"},
+					{Name: "cloud_compute_viewer"},
+				},
+				Project: &struct {
+					ID string `json:"id"`
+				}{ID: "proj-abc"},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer ks.Close()
+
+	ki := &keystoneIntrospector{keystoneURL: ks.URL, httpClient: ks.Client()}
+	info, err := ki.introspect(context.Background(), "my-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(info.roles) != 2 {
+		t.Fatalf("roles = %v, want 2 roles", info.roles)
+	}
+	if info.roles[0] != "cloud_compute_admin" || info.roles[1] != "cloud_compute_viewer" {
+		t.Errorf("roles = %v", info.roles)
+	}
+	if info.projectID != "proj-abc" {
+		t.Errorf("projectID = %q, want %q", info.projectID, "proj-abc")
+	}
+	if !info.expiresAt.Equal(expiry) {
+		t.Errorf("expiresAt = %v, want %v", info.expiresAt, expiry)
+	}
+}
+
+func TestKeystoneIntrospectorInvalidToken(t *testing.T) {
+	ks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ks.Close()
+
+	ki := &keystoneIntrospector{keystoneURL: ks.URL, httpClient: ks.Client()}
+	_, err := ki.introspect(context.Background(), "bad-token")
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}
+
+func TestKeystoneIntrospectorKeystoneDown(t *testing.T) {
+	ki := &keystoneIntrospector{
+		keystoneURL: "http://127.0.0.1:1",
+		httpClient:  &http.Client{Timeout: 100 * time.Millisecond},
+	}
+	_, err := ki.introspect(context.Background(), "token")
+	if err == nil {
+		t.Fatal("expected error when keystone is unreachable")
+	}
+}
+
+func TestKeystoneIntrospectorDomainScopedToken(t *testing.T) {
+	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+
+	ks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(keystoneTokenResponse{
+			Token: struct {
+				ExpiresAt string `json:"expires_at"`
+				Roles     []struct {
+					Name string `json:"name"`
+				} `json:"roles"`
+				Project *struct {
+					ID string `json:"id"`
+				} `json:"project"`
+			}{
+				ExpiresAt: expiry.Format(time.RFC3339),
+				Roles: []struct {
+					Name string `json:"name"`
+				}{
+					{Name: "admin"},
+				},
+				Project: nil, // domain-scoped, no project
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer ks.Close()
+
+	ki := &keystoneIntrospector{keystoneURL: ks.URL, httpClient: ks.Client()}
+	info, err := ki.introspect(context.Background(), "domain-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.projectID != "" {
+		t.Errorf("projectID = %q, want empty for domain-scoped token", info.projectID)
+	}
+}

--- a/internal/shim/placement/auth_test.go
+++ b/internal/shim/placement/auth_test.go
@@ -1,0 +1,425 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package placement
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockIntrospector is a test double for tokenIntrospector.
+type mockIntrospector struct {
+	info  *tokenInfo
+	err   error
+	calls atomic.Int64
+}
+
+func (m *mockIntrospector) introspect(_ context.Context, _ string) (*tokenInfo, error) {
+	m.calls.Add(1)
+	return m.info, m.err
+}
+
+func TestMatchPath(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"/usages", "/usages", true},
+		{"/usages", "/traits", false},
+		{"/resource_providers/*", "/resource_providers/abc", true},
+		{"/resource_providers/*", "/resource_providers/abc/inventories", true},
+		{"/resource_providers/*", "/resource_providers", true},
+		{"/*", "/anything", true},
+		{"/*", "/", true},
+		{"*", "/anything", true},
+		{"/", "/", true},
+		{"/", "/other", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.pattern+" vs "+tt.path, func(t *testing.T) {
+			if got := matchPath(tt.pattern, tt.path); got != tt.want {
+				t.Errorf("matchPath(%q, %q) = %v, want %v", tt.pattern, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy compiledPolicy
+		method string
+		path   string
+		want   bool
+	}{
+		{
+			name:   "wildcard method matches GET",
+			policy: compiledPolicy{method: "*", pathPattern: "/usages"},
+			method: "GET", path: "/usages", want: true,
+		},
+		{
+			name:   "wildcard method matches POST",
+			policy: compiledPolicy{method: "*", pathPattern: "/usages"},
+			method: "POST", path: "/usages", want: true,
+		},
+		{
+			name:   "specific method matches",
+			policy: compiledPolicy{method: "GET", pathPattern: "/usages"},
+			method: "GET", path: "/usages", want: true,
+		},
+		{
+			name:   "specific method does not match",
+			policy: compiledPolicy{method: "GET", pathPattern: "/usages"},
+			method: "POST", path: "/usages", want: false,
+		},
+		{
+			name:   "catch-all matches everything",
+			policy: compiledPolicy{method: "*", pathPattern: "/*"},
+			method: "DELETE", path: "/anything/here", want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchPolicy(&tt.policy, tt.method, tt.path); got != tt.want {
+				t.Errorf("matchPolicy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenCache(t *testing.T) {
+	t.Run("put and get", func(t *testing.T) {
+		c := &tokenCache{ttl: time.Minute}
+		info := &tokenInfo{
+			roles:     []string{"admin"},
+			projectID: "p1",
+			expiresAt: time.Now().Add(time.Hour),
+			cachedAt:  time.Now(),
+		}
+		c.put("tok", info)
+		got, ok := c.get("tok")
+		if !ok {
+			t.Fatal("expected cache hit")
+		}
+		if got.projectID != "p1" {
+			t.Errorf("projectID = %q, want %q", got.projectID, "p1")
+		}
+	})
+
+	t.Run("miss for unknown token", func(t *testing.T) {
+		c := &tokenCache{ttl: time.Minute}
+		if _, ok := c.get("unknown"); ok {
+			t.Fatal("expected cache miss")
+		}
+	})
+
+	t.Run("expired TTL returns miss", func(t *testing.T) {
+		c := &tokenCache{ttl: time.Millisecond}
+		info := &tokenInfo{
+			expiresAt: time.Now().Add(time.Hour),
+			cachedAt:  time.Now().Add(-time.Second),
+		}
+		c.put("tok", info)
+		if _, ok := c.get("tok"); ok {
+			t.Fatal("expected cache miss due to TTL")
+		}
+	})
+
+	t.Run("expired token returns miss", func(t *testing.T) {
+		c := &tokenCache{ttl: time.Hour}
+		info := &tokenInfo{
+			expiresAt: time.Now().Add(-time.Second),
+			cachedAt:  time.Now(),
+		}
+		c.put("tok", info)
+		if _, ok := c.get("tok"); ok {
+			t.Fatal("expected cache miss due to token expiry")
+		}
+	})
+}
+
+func TestCheckAuthDisabled(t *testing.T) {
+	s := &Shim{} // authPolicies is nil
+	req := httptest.NewRequest(http.MethodGet, "/anything", http.NoBody)
+	w := httptest.NewRecorder()
+	if !s.checkAuth(w, req) {
+		t.Fatal("expected passthrough when auth disabled")
+	}
+}
+
+func TestCheckAuthNoMatchingPolicy(t *testing.T) {
+	s := &Shim{
+		authPolicies: []compiledPolicy{
+			{method: "GET", pathPattern: "/usages", roles: []authPolicyRole{{Name: "admin"}}},
+		},
+		tokenCache:        &tokenCache{ttl: time.Minute},
+		tokenIntrospector: &mockIntrospector{},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/no-such-path", http.NoBody)
+	w := httptest.NewRecorder()
+	if s.checkAuth(w, req) {
+		t.Fatal("expected deny for unmatched path")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestCheckAuthPublicEndpoint(t *testing.T) {
+	t.Run("nil roles", func(t *testing.T) {
+		s := &Shim{
+			authPolicies: []compiledPolicy{
+				{method: "GET", pathPattern: "/", roles: nil},
+			},
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{},
+		}
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		w := httptest.NewRecorder()
+		if !s.checkAuth(w, req) {
+			t.Fatal("expected passthrough for public endpoint (nil roles)")
+		}
+	})
+	t.Run("empty roles", func(t *testing.T) {
+		s := &Shim{
+			authPolicies: []compiledPolicy{
+				{method: "GET", pathPattern: "/", roles: []authPolicyRole{}},
+			},
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{},
+		}
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		w := httptest.NewRecorder()
+		if !s.checkAuth(w, req) {
+			t.Fatal("expected passthrough for public endpoint (empty roles)")
+		}
+	})
+}
+
+func TestCheckAuthMissingToken(t *testing.T) {
+	s := &Shim{
+		authPolicies: []compiledPolicy{
+			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "admin"}}},
+		},
+		tokenCache:        &tokenCache{ttl: time.Minute},
+		tokenIntrospector: &mockIntrospector{},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/resource_providers", http.NoBody)
+	w := httptest.NewRecorder()
+	if s.checkAuth(w, req) {
+		t.Fatal("expected deny for missing token")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestCheckAuthInvalidToken(t *testing.T) {
+	s := &Shim{
+		authPolicies: []compiledPolicy{
+			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "admin"}}},
+		},
+		tokenCache:        &tokenCache{ttl: time.Minute},
+		tokenIntrospector: &mockIntrospector{err: errors.New("invalid token")},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/traits", http.NoBody)
+	req.Header.Set("X-Auth-Token", "bad-token")
+	w := httptest.NewRecorder()
+	if s.checkAuth(w, req) {
+		t.Fatal("expected deny for invalid token")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestCheckAuthValidToken(t *testing.T) {
+	s := &Shim{
+		authPolicies: []compiledPolicy{
+			{method: "GET", pathPattern: "/*", roles: []authPolicyRole{
+				{Name: "cloud_compute_admin"},
+				{Name: "cloud_compute_viewer"},
+			}},
+		},
+		tokenCache: &tokenCache{ttl: time.Minute},
+		tokenIntrospector: &mockIntrospector{info: &tokenInfo{
+			roles:     []string{"cloud_compute_viewer"},
+			expiresAt: time.Now().Add(time.Hour),
+			cachedAt:  time.Now(),
+		}},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/resource_providers", http.NoBody)
+	req.Header.Set("X-Auth-Token", "good-token")
+	w := httptest.NewRecorder()
+	if !s.checkAuth(w, req) {
+		t.Fatal("expected authorized")
+	}
+}
+
+func TestCheckAuthInsufficientRoles(t *testing.T) {
+	s := &Shim{
+		authPolicies: []compiledPolicy{
+			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "cloud_compute_admin"}}},
+		},
+		tokenCache: &tokenCache{ttl: time.Minute},
+		tokenIntrospector: &mockIntrospector{info: &tokenInfo{
+			roles:     []string{"some_other_role"},
+			expiresAt: time.Now().Add(time.Hour),
+			cachedAt:  time.Now(),
+		}},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/traits", http.NoBody)
+	req.Header.Set("X-Auth-Token", "token")
+	w := httptest.NewRecorder()
+	if s.checkAuth(w, req) {
+		t.Fatal("expected deny for insufficient roles")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestCheckAuthProjectScoped(t *testing.T) {
+	policies := []compiledPolicy{
+		{method: "GET", pathPattern: "/usages", roles: []authPolicyRole{
+			{Name: "compute_viewer", ProjectScoped: true},
+		}},
+	}
+	info := &tokenInfo{
+		roles:     []string{"compute_viewer"},
+		projectID: "proj-123",
+		expiresAt: time.Now().Add(time.Hour),
+		cachedAt:  time.Now(),
+	}
+
+	t.Run("matching project_id", func(t *testing.T) {
+		s := &Shim{
+			authPolicies:      policies,
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{info: info},
+		}
+		req := httptest.NewRequest(http.MethodGet, "/usages?project_id=proj-123", http.NoBody)
+		req.Header.Set("X-Auth-Token", "token")
+		w := httptest.NewRecorder()
+		if !s.checkAuth(w, req) {
+			t.Fatal("expected authorized with matching project_id")
+		}
+	})
+
+	t.Run("mismatched project_id", func(t *testing.T) {
+		s := &Shim{
+			authPolicies:      policies,
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{info: info},
+		}
+		req := httptest.NewRequest(http.MethodGet, "/usages?project_id=other", http.NoBody)
+		req.Header.Set("X-Auth-Token", "token")
+		w := httptest.NewRecorder()
+		if s.checkAuth(w, req) {
+			t.Fatal("expected deny for mismatched project_id")
+		}
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+		}
+	})
+
+	t.Run("missing project_id", func(t *testing.T) {
+		s := &Shim{
+			authPolicies:      policies,
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{info: info},
+		}
+		req := httptest.NewRequest(http.MethodGet, "/usages", http.NoBody)
+		req.Header.Set("X-Auth-Token", "token")
+		w := httptest.NewRecorder()
+		if s.checkAuth(w, req) {
+			t.Fatal("expected deny for missing project_id")
+		}
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+		}
+	})
+}
+
+func TestCheckAuthFirstMatchWins(t *testing.T) {
+	s := &Shim{
+		authPolicies: []compiledPolicy{
+			{method: "GET", pathPattern: "/usages", roles: nil}, // public
+			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "admin"}}},
+		},
+		tokenCache:        &tokenCache{ttl: time.Minute},
+		tokenIntrospector: &mockIntrospector{},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/usages", http.NoBody)
+	// No token set — should still pass because first match is public.
+	w := httptest.NewRecorder()
+	if !s.checkAuth(w, req) {
+		t.Fatal("expected first-match (public) to win")
+	}
+}
+
+func TestCheckAuthCachesToken(t *testing.T) {
+	mock := &mockIntrospector{info: &tokenInfo{
+		roles:     []string{"admin"},
+		expiresAt: time.Now().Add(time.Hour),
+		cachedAt:  time.Now(),
+	}}
+	s := &Shim{
+		authPolicies: []compiledPolicy{
+			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "admin"}}},
+		},
+		tokenCache:        &tokenCache{ttl: time.Minute},
+		tokenIntrospector: mock,
+	}
+	for i := range 5 {
+		req := httptest.NewRequest(http.MethodGet, "/traits", http.NoBody)
+		req.Header.Set("X-Auth-Token", "same-token")
+		w := httptest.NewRecorder()
+		if !s.checkAuth(w, req) {
+			t.Fatalf("request %d: expected authorized", i)
+		}
+	}
+	if n := mock.calls.Load(); n != 1 {
+		t.Errorf("introspect called %d times, want 1", n)
+	}
+}
+
+func TestAuthErrorFormat(t *testing.T) {
+	w := httptest.NewRecorder()
+	authError(w, http.StatusUnauthorized, "Unauthorized",
+		"The request you have made requires authentication.")
+
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	var body struct {
+		Error struct {
+			Code    int    `json:"code"`
+			Title   string `json:"title"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to parse response body: %v", err)
+	}
+	if body.Error.Code != 401 {
+		t.Errorf("error code = %d, want 401", body.Error.Code)
+	}
+	if body.Error.Title != "Unauthorized" {
+		t.Errorf("error title = %q, want %q", body.Error.Title, "Unauthorized")
+	}
+	if body.Error.Message != "The request you have made requires authentication." {
+		t.Errorf("error message = %q", body.Error.Message)
+	}
+}

--- a/internal/shim/placement/auth_test.go
+++ b/internal/shim/placement/auth_test.go
@@ -585,30 +585,6 @@ func TestCompileRoles(t *testing.T) {
 		}
 	})
 
-	t.Run("backward compat projectScoped bool", func(t *testing.T) {
-		roles, err := compileRoles([]authPolicyRole{
-			{Name: "viewer", ProjectScoped: true},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if roles[0].extractor != queryParamScope || roles[0].extractParam != "project_id" {
-			t.Errorf("backward compat: got extractor=%d param=%q", roles[0].extractor, roles[0].extractParam)
-		}
-	})
-
-	t.Run("projectScope takes precedence over projectScoped", func(t *testing.T) {
-		roles, err := compileRoles([]authPolicyRole{
-			{Name: "admin", ProjectScoped: true, ProjectScope: &authProjectScope{From: "body", Field: "proj"}},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if roles[0].extractor != bodyFieldScope || roles[0].extractParam != "proj" {
-			t.Errorf("precedence: got extractor=%d param=%q", roles[0].extractor, roles[0].extractParam)
-		}
-	})
-
 	t.Run("no project scope", func(t *testing.T) {
 		roles, err := compileRoles([]authPolicyRole{
 			{Name: "admin"},

--- a/internal/shim/placement/auth_test.go
+++ b/internal/shim/placement/auth_test.go
@@ -4,11 +4,14 @@
 package placement
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -158,7 +161,7 @@ func TestCheckAuthDisabled(t *testing.T) {
 func TestCheckAuthNoMatchingPolicy(t *testing.T) {
 	s := &Shim{
 		authPolicies: []compiledPolicy{
-			{method: "GET", pathPattern: "/usages", roles: []authPolicyRole{{Name: "admin"}}},
+			{method: "GET", pathPattern: "/usages", roles: []compiledRole{{name: "admin"}}},
 		},
 		tokenCache:        &tokenCache{ttl: time.Minute},
 		tokenIntrospector: &mockIntrospector{},
@@ -191,7 +194,7 @@ func TestCheckAuthPublicEndpoint(t *testing.T) {
 	t.Run("empty roles", func(t *testing.T) {
 		s := &Shim{
 			authPolicies: []compiledPolicy{
-				{method: "GET", pathPattern: "/", roles: []authPolicyRole{}},
+				{method: "GET", pathPattern: "/", roles: []compiledRole{}},
 			},
 			tokenCache:        &tokenCache{ttl: time.Minute},
 			tokenIntrospector: &mockIntrospector{},
@@ -207,7 +210,7 @@ func TestCheckAuthPublicEndpoint(t *testing.T) {
 func TestCheckAuthMissingToken(t *testing.T) {
 	s := &Shim{
 		authPolicies: []compiledPolicy{
-			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "admin"}}},
+			{method: "*", pathPattern: "/*", roles: []compiledRole{{name: "admin"}}},
 		},
 		tokenCache:        &tokenCache{ttl: time.Minute},
 		tokenIntrospector: &mockIntrospector{},
@@ -225,7 +228,7 @@ func TestCheckAuthMissingToken(t *testing.T) {
 func TestCheckAuthInvalidToken(t *testing.T) {
 	s := &Shim{
 		authPolicies: []compiledPolicy{
-			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "admin"}}},
+			{method: "*", pathPattern: "/*", roles: []compiledRole{{name: "admin"}}},
 		},
 		tokenCache:        &tokenCache{ttl: time.Minute},
 		tokenIntrospector: &mockIntrospector{err: errors.New("invalid token")},
@@ -244,9 +247,9 @@ func TestCheckAuthInvalidToken(t *testing.T) {
 func TestCheckAuthValidToken(t *testing.T) {
 	s := &Shim{
 		authPolicies: []compiledPolicy{
-			{method: "GET", pathPattern: "/*", roles: []authPolicyRole{
-				{Name: "cloud_compute_admin"},
-				{Name: "cloud_compute_viewer"},
+			{method: "GET", pathPattern: "/*", roles: []compiledRole{
+				{name: "cloud_compute_admin"},
+				{name: "cloud_compute_viewer"},
 			}},
 		},
 		tokenCache: &tokenCache{ttl: time.Minute},
@@ -267,7 +270,7 @@ func TestCheckAuthValidToken(t *testing.T) {
 func TestCheckAuthInsufficientRoles(t *testing.T) {
 	s := &Shim{
 		authPolicies: []compiledPolicy{
-			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "cloud_compute_admin"}}},
+			{method: "*", pathPattern: "/*", roles: []compiledRole{{name: "cloud_compute_admin"}}},
 		},
 		tokenCache: &tokenCache{ttl: time.Minute},
 		tokenIntrospector: &mockIntrospector{info: &tokenInfo{
@@ -289,8 +292,8 @@ func TestCheckAuthInsufficientRoles(t *testing.T) {
 
 func TestCheckAuthProjectScoped(t *testing.T) {
 	policies := []compiledPolicy{
-		{method: "GET", pathPattern: "/usages", roles: []authPolicyRole{
-			{Name: "compute_viewer", ProjectScoped: true},
+		{method: "GET", pathPattern: "/usages", roles: []compiledRole{
+			{name: "compute_viewer", extractor: queryParamScope, extractParam: "project_id"},
 		}},
 	}
 	info := &tokenInfo{
@@ -353,7 +356,7 @@ func TestCheckAuthFirstMatchWins(t *testing.T) {
 	s := &Shim{
 		authPolicies: []compiledPolicy{
 			{method: "GET", pathPattern: "/usages", roles: nil}, // public
-			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "admin"}}},
+			{method: "*", pathPattern: "/*", roles: []compiledRole{{name: "admin"}}},
 		},
 		tokenCache:        &tokenCache{ttl: time.Minute},
 		tokenIntrospector: &mockIntrospector{},
@@ -374,7 +377,7 @@ func TestCheckAuthCachesToken(t *testing.T) {
 	}}
 	s := &Shim{
 		authPolicies: []compiledPolicy{
-			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "admin"}}},
+			{method: "*", pathPattern: "/*", roles: []compiledRole{{name: "admin"}}},
 		},
 		tokenCache:        &tokenCache{ttl: time.Minute},
 		tokenIntrospector: mock,
@@ -422,4 +425,269 @@ func TestAuthErrorFormat(t *testing.T) {
 	if body.Error.Message != "The request you have made requires authentication." {
 		t.Errorf("error message = %q", body.Error.Message)
 	}
+}
+
+func TestCheckAuthProjectScopedBody(t *testing.T) {
+	policies := []compiledPolicy{
+		{method: "PUT", pathPattern: "/allocations/*", roles: []compiledRole{
+			{name: "compute_admin", extractor: bodyFieldScope, extractParam: "project_id"},
+		}},
+	}
+	info := &tokenInfo{
+		roles:     []string{"compute_admin"},
+		projectID: "proj-123",
+		expiresAt: time.Now().Add(time.Hour),
+		cachedAt:  time.Now(),
+	}
+
+	t.Run("matching project_id from body", func(t *testing.T) {
+		s := &Shim{
+			authPolicies:      policies,
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{info: info},
+		}
+		body := `{"project_id":"proj-123","user_id":"u1","allocations":{}}`
+		req := httptest.NewRequest(http.MethodPut, "/allocations/consumer-1", strings.NewReader(body))
+		req.Header.Set("X-Auth-Token", "token")
+		w := httptest.NewRecorder()
+		if !s.checkAuth(w, req) {
+			t.Fatal("expected authorized with matching project_id in body")
+		}
+	})
+
+	t.Run("mismatched project_id from body", func(t *testing.T) {
+		s := &Shim{
+			authPolicies:      policies,
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{info: info},
+		}
+		body := `{"project_id":"other-proj","user_id":"u1"}`
+		req := httptest.NewRequest(http.MethodPut, "/allocations/consumer-1", strings.NewReader(body))
+		req.Header.Set("X-Auth-Token", "token")
+		w := httptest.NewRecorder()
+		if s.checkAuth(w, req) {
+			t.Fatal("expected deny for mismatched project_id in body")
+		}
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+		}
+	})
+
+	t.Run("missing project_id field in body", func(t *testing.T) {
+		s := &Shim{
+			authPolicies:      policies,
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{info: info},
+		}
+		body := `{"user_id":"u1","allocations":{}}`
+		req := httptest.NewRequest(http.MethodPut, "/allocations/consumer-1", strings.NewReader(body))
+		req.Header.Set("X-Auth-Token", "token")
+		w := httptest.NewRecorder()
+		if s.checkAuth(w, req) {
+			t.Fatal("expected deny for missing project_id in body")
+		}
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		s := &Shim{
+			authPolicies:      policies,
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{info: info},
+		}
+		req := httptest.NewRequest(http.MethodPut, "/allocations/consumer-1", http.NoBody)
+		req.Header.Set("X-Auth-Token", "token")
+		w := httptest.NewRecorder()
+		if s.checkAuth(w, req) {
+			t.Fatal("expected deny for empty body")
+		}
+	})
+
+	t.Run("malformed JSON body", func(t *testing.T) {
+		s := &Shim{
+			authPolicies:      policies,
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{info: info},
+		}
+		req := httptest.NewRequest(http.MethodPut, "/allocations/consumer-1", strings.NewReader("not json"))
+		req.Header.Set("X-Auth-Token", "token")
+		w := httptest.NewRecorder()
+		if s.checkAuth(w, req) {
+			t.Fatal("expected deny for malformed JSON body")
+		}
+	})
+
+	t.Run("body still readable after auth", func(t *testing.T) {
+		s := &Shim{
+			authPolicies:      policies,
+			tokenCache:        &tokenCache{ttl: time.Minute},
+			tokenIntrospector: &mockIntrospector{info: info},
+		}
+		body := `{"project_id":"proj-123","user_id":"u1"}`
+		req := httptest.NewRequest(http.MethodPut, "/allocations/consumer-1", strings.NewReader(body))
+		req.Header.Set("X-Auth-Token", "token")
+		w := httptest.NewRecorder()
+		if !s.checkAuth(w, req) {
+			t.Fatal("expected authorized")
+		}
+		remaining, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("failed to read body after auth: %v", err)
+		}
+		if string(remaining) != body {
+			t.Errorf("body after auth = %q, want %q", remaining, body)
+		}
+	})
+}
+
+func TestCompileRoles(t *testing.T) {
+	t.Run("projectScope from query", func(t *testing.T) {
+		roles, err := compileRoles([]authPolicyRole{
+			{Name: "admin", ProjectScope: &authProjectScope{From: "query", Param: "proj"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if roles[0].extractor != queryParamScope || roles[0].extractParam != "proj" {
+			t.Errorf("got extractor=%d param=%q", roles[0].extractor, roles[0].extractParam)
+		}
+	})
+
+	t.Run("projectScope from body", func(t *testing.T) {
+		roles, err := compileRoles([]authPolicyRole{
+			{Name: "admin", ProjectScope: &authProjectScope{From: "body", Field: "project_id"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if roles[0].extractor != bodyFieldScope || roles[0].extractParam != "project_id" {
+			t.Errorf("got extractor=%d param=%q", roles[0].extractor, roles[0].extractParam)
+		}
+	})
+
+	t.Run("projectScope defaults", func(t *testing.T) {
+		roles, err := compileRoles([]authPolicyRole{
+			{Name: "admin", ProjectScope: &authProjectScope{From: "query"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if roles[0].extractParam != "project_id" {
+			t.Errorf("default param = %q, want %q", roles[0].extractParam, "project_id")
+		}
+	})
+
+	t.Run("invalid from value", func(t *testing.T) {
+		_, err := compileRoles([]authPolicyRole{
+			{Name: "admin", ProjectScope: &authProjectScope{From: "header"}},
+		})
+		if err == nil {
+			t.Fatal("expected error for invalid from value")
+		}
+	})
+
+	t.Run("backward compat projectScoped bool", func(t *testing.T) {
+		roles, err := compileRoles([]authPolicyRole{
+			{Name: "viewer", ProjectScoped: true},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if roles[0].extractor != queryParamScope || roles[0].extractParam != "project_id" {
+			t.Errorf("backward compat: got extractor=%d param=%q", roles[0].extractor, roles[0].extractParam)
+		}
+	})
+
+	t.Run("projectScope takes precedence over projectScoped", func(t *testing.T) {
+		roles, err := compileRoles([]authPolicyRole{
+			{Name: "admin", ProjectScoped: true, ProjectScope: &authProjectScope{From: "body", Field: "proj"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if roles[0].extractor != bodyFieldScope || roles[0].extractParam != "proj" {
+			t.Errorf("precedence: got extractor=%d param=%q", roles[0].extractor, roles[0].extractParam)
+		}
+	})
+
+	t.Run("no project scope", func(t *testing.T) {
+		roles, err := compileRoles([]authPolicyRole{
+			{Name: "admin"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if roles[0].extractor != noProjectScope {
+			t.Errorf("got extractor=%d, want noProjectScope", roles[0].extractor)
+		}
+	})
+
+	t.Run("nil roles returns nil", func(t *testing.T) {
+		roles, err := compileRoles(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if roles != nil {
+			t.Errorf("expected nil, got %v", roles)
+		}
+	})
+}
+
+func TestExtractBodyField(t *testing.T) {
+	t.Run("valid JSON with string field", func(t *testing.T) {
+		body := `{"project_id":"abc-123","other":"val"}`
+		req := httptest.NewRequest(http.MethodPut, "/test", strings.NewReader(body))
+		if got := extractBodyField(req, "project_id"); got != "abc-123" {
+			t.Errorf("got %q, want %q", got, "abc-123")
+		}
+	})
+
+	t.Run("missing field", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/test", strings.NewReader(`{"other":"val"}`))
+		if got := extractBodyField(req, "project_id"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("non-string field", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/test", strings.NewReader(`{"project_id":42}`))
+		if got := extractBodyField(req, "project_id"); got != "" {
+			t.Errorf("got %q, want empty for non-string", got)
+		}
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/test", strings.NewReader("not json"))
+		if got := extractBodyField(req, "project_id"); got != "" {
+			t.Errorf("got %q, want empty for bad JSON", got)
+		}
+	})
+
+	t.Run("nil body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/test", http.NoBody)
+		if got := extractBodyField(req, "project_id"); got != "" {
+			t.Errorf("got %q, want empty for nil body", got)
+		}
+	})
+
+	t.Run("body re-readable after extraction", func(t *testing.T) {
+		body := `{"project_id":"abc-123"}`
+		req := httptest.NewRequest(http.MethodPut, "/test", strings.NewReader(body))
+		extractBodyField(req, "project_id")
+		remaining, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(remaining) != body {
+			t.Errorf("re-read body = %q, want %q", remaining, body)
+		}
+	})
+
+	t.Run("large body is capped", func(t *testing.T) {
+		huge := `{"project_id":"` + strings.Repeat("x", 2<<20) + `"}`
+		req := httptest.NewRequest(http.MethodPut, "/test", bytes.NewReader([]byte(huge)))
+		got := extractBodyField(req, "project_id")
+		if got != "" {
+			t.Errorf("expected empty for body exceeding limit, got %q", got)
+		}
+	})
 }

--- a/internal/shim/placement/auth_test.go
+++ b/internal/shim/placement/auth_test.go
@@ -29,6 +29,20 @@ func (m *mockIntrospector) introspect(_ context.Context, _ string) (*tokenInfo, 
 	return m.info, m.err
 }
 
+// slowIntrospector is like mockIntrospector but adds a small delay,
+// making singleflight deduplication observable under concurrent load.
+type slowIntrospector struct {
+	info  *tokenInfo
+	err   error
+	calls atomic.Int64
+}
+
+func (s *slowIntrospector) introspect(_ context.Context, _ string) (*tokenInfo, error) {
+	s.calls.Add(1)
+	time.Sleep(50 * time.Millisecond)
+	return s.info, s.err
+}
+
 func TestMatchPath(t *testing.T) {
 	tests := []struct {
 		pattern string
@@ -392,6 +406,39 @@ func TestCheckAuthCachesToken(t *testing.T) {
 	}
 	if n := mock.calls.Load(); n != 1 {
 		t.Errorf("introspect called %d times, want 1", n)
+	}
+}
+
+func TestCheckAuthSingleflight(t *testing.T) {
+	slow := &slowIntrospector{info: &tokenInfo{
+		roles:     []string{"admin"},
+		expiresAt: time.Now().Add(time.Hour),
+		cachedAt:  time.Now(),
+	}}
+	s := &Shim{
+		authPolicies: []compiledPolicy{
+			{method: "*", pathPattern: "/*", roles: []compiledRole{{name: "admin"}}},
+		},
+		tokenCache:        &tokenCache{ttl: time.Minute},
+		tokenIntrospector: slow,
+	}
+	const n = 10
+	results := make(chan bool, n)
+	for range n {
+		go func() {
+			req := httptest.NewRequest(http.MethodGet, "/traits", http.NoBody)
+			req.Header.Set("X-Auth-Token", "same-token")
+			w := httptest.NewRecorder()
+			results <- s.checkAuth(w, req)
+		}()
+	}
+	for range n {
+		if !<-results {
+			t.Fatal("expected all concurrent requests to be authorized")
+		}
+	}
+	if c := slow.calls.Load(); c != 1 {
+		t.Errorf("introspect called %d times, want 1 (singleflight should deduplicate)", c)
 	}
 }
 

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -65,6 +65,7 @@ type authPolicy struct {
 	// Pattern is the method + path to match (e.g. "GET /usages", "* /*").
 	Pattern string `json:"pattern"`
 	// Roles lists the roles that grant access for this pattern.
+	// When null, the path is publicly accessible (no token required).
 	Roles []authPolicyRole `json:"roles"`
 }
 

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -48,6 +48,37 @@ type requestIDContextKey struct{}
 // header value through the request lifecycle for tracing.
 var requestIDKey = requestIDContextKey{}
 
+// authPolicyRole is a role that grants access for a matching policy rule.
+type authPolicyRole struct {
+	// Name is the OpenStack role name (e.g. "cloud_compute_admin").
+	Name string `json:"name"`
+	// ProjectScoped requires the token's project_id to match the
+	// request's project_id when true (e.g. for per-project usages).
+	ProjectScoped bool `json:"projectScoped,omitempty"`
+}
+
+// authPolicy maps an HTTP method + path pattern to the roles allowed to
+// access it. Patterns use "METHOD /path" syntax where "*" matches any
+// method and "*" in the path acts as a wildcard. Evaluation is
+// first-match; no match means deny.
+type authPolicy struct {
+	// Pattern is the method + path to match (e.g. "GET /usages", "* /*").
+	Pattern string `json:"pattern"`
+	// Roles lists the roles that grant access for this pattern.
+	Roles []authPolicyRole `json:"roles"`
+}
+
+// authConfig configures the Keystone token-validation middleware.
+// When nil, auth is disabled and all requests are passed through.
+type authConfig struct {
+	// TokenCacheTTL is how long validated tokens are cached before
+	// re-introspection against Keystone (e.g. "5m").
+	TokenCacheTTL string `json:"tokenCacheTTL,omitempty"`
+	// Policies is the ordered list of first-match access rules evaluated
+	// against each incoming request.
+	Policies []authPolicy `json:"policies,omitempty"`
+}
+
 // config holds configuration for the placement shim.
 type config struct {
 	// SSO is an optional configuration for the certificates the http client
@@ -56,6 +87,13 @@ type config struct {
 	// PlacementURL is the URL of the OpenStack Placement API the shim
 	// should forward requests to.
 	PlacementURL string `json:"placementURL,omitempty"`
+	// KeystoneURL is the URL of the OpenStack Keystone identity service
+	// used for token introspection by the auth middleware and for E2E
+	// test authentication.
+	KeystoneURL string `json:"keystoneURL,omitempty"`
+	// Auth configures Keystone token validation. When nil, auth is
+	// disabled and requests pass through without access checks.
+	Auth *authConfig `json:"auth,omitempty"`
 	// MaxBodyLogSize is the maximum number of bytes of request/response
 	// bodies to include in debug-level log lines, specified as a
 	// Kubernetes resource.Quantity string (e.g. "4Ki"). Defaults to "4Ki"

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
@@ -108,6 +109,9 @@ func (c *config) validate() error {
 	if c.PlacementURL == "" {
 		return errors.New("placement URL is required")
 	}
+	if c.Auth != nil && c.KeystoneURL == "" {
+		return errors.New("keystoneURL is required when auth is configured")
+	}
 	return nil
 }
 
@@ -132,6 +136,15 @@ type Shim struct {
 	// upstreamRequestTimer is a prometheus histogram to measure the duration
 	// (and count) of requests to the upstream placement API by route and method.
 	upstreamRequestTimer *prometheus.HistogramVec
+
+	// authPolicies is the pre-compiled policy table. Nil when auth is
+	// disabled (config.Auth is nil).
+	authPolicies []compiledPolicy
+	// tokenCache caches validated token info to avoid repeated Keystone
+	// introspection.
+	tokenCache *tokenCache
+	// tokenIntrospector validates tokens against Keystone.
+	tokenIntrospector tokenIntrospector
 }
 
 // Describe implements prometheus.Collector.
@@ -198,6 +211,18 @@ func (s *Shim) Start(ctx context.Context) (err error) {
 		return err
 	}
 	setupLog.Info("Successfully connected to placement API")
+
+	// Create the Keystone introspector when auth is configured. This
+	// reuses the shim's HTTP client (and its TLS/SSO transport).
+	if s.config.Auth != nil {
+		s.tokenIntrospector = &keystoneIntrospector{
+			keystoneURL: s.config.KeystoneURL,
+			httpClient:  s.httpClient,
+		}
+		setupLog.Info("Auth middleware enabled with Keystone",
+			"keystoneURL", s.config.KeystoneURL)
+	}
+
 	return nil
 }
 
@@ -255,6 +280,33 @@ func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err erro
 		return fmt.Errorf("invalid maxBodyLogSize %q: %w", bodyLogQty, err)
 	}
 	s.maxBodyLogSize = qty.Value()
+
+	// Compile auth policies when auth is configured.
+	if s.config.Auth != nil {
+		ttlStr := s.config.Auth.TokenCacheTTL
+		if ttlStr == "" {
+			ttlStr = "5m"
+		}
+		ttl, err := time.ParseDuration(ttlStr)
+		if err != nil {
+			return fmt.Errorf("invalid tokenCacheTTL %q: %w", ttlStr, err)
+		}
+		s.tokenCache = &tokenCache{ttl: ttl}
+		s.authPolicies = make([]compiledPolicy, len(s.config.Auth.Policies))
+		for i, p := range s.config.Auth.Policies {
+			method, path, ok := strings.Cut(p.Pattern, " ")
+			if !ok {
+				return fmt.Errorf("invalid auth policy pattern %q: expected \"METHOD /path\"", p.Pattern)
+			}
+			s.authPolicies[i] = compiledPolicy{
+				method:      method,
+				pathPattern: path,
+				roles:       p.Roles,
+			}
+		}
+		setupLog.Info("Auth middleware configured",
+			"policies", len(s.authPolicies), "tokenCacheTTL", ttl)
+	}
 
 	// Initialize Prometheus histogram timers for request monitoring.
 	s.downstreamRequestTimer = prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
@@ -93,6 +92,23 @@ type config struct {
 	// used for token introspection by the auth middleware and for E2E
 	// test authentication.
 	KeystoneURL string `json:"keystoneURL,omitempty"`
+	// OSUsername is the OpenStack username for Keystone authentication
+	// (OS_USERNAME). Required when auth is configured.
+	OSUsername string `json:"osUsername,omitempty"`
+	// OSPassword is the OpenStack password for Keystone authentication
+	// (OS_PASSWORD). Required when auth is configured.
+	OSPassword string `json:"osPassword,omitempty"`
+	// OSProjectName is the OpenStack project name for Keystone
+	// authentication (OS_PROJECT_NAME). Required when auth is configured.
+	OSProjectName string `json:"osProjectName,omitempty"`
+	// OSUserDomainName is the OpenStack user domain name for Keystone
+	// authentication (OS_USER_DOMAIN_NAME). Required when auth is
+	// configured.
+	OSUserDomainName string `json:"osUserDomainName,omitempty"`
+	// OSProjectDomainName is the OpenStack project domain name for
+	// Keystone authentication (OS_PROJECT_DOMAIN_NAME). Required when
+	// auth is configured.
+	OSProjectDomainName string `json:"osProjectDomainName,omitempty"`
 	// Auth configures Keystone token validation. When nil, auth is
 	// disabled and requests pass through without access checks.
 	Auth *authConfig `json:"auth,omitempty"`
@@ -111,6 +127,12 @@ func (c *config) validate() error {
 	}
 	if c.Auth != nil && c.KeystoneURL == "" {
 		return errors.New("keystoneURL is required when auth is configured")
+	}
+	if c.Auth != nil && c.OSUsername == "" {
+		return errors.New("osUsername is required when auth is configured")
+	}
+	if c.Auth != nil && c.OSPassword == "" {
+		return errors.New("osPassword is required when auth is configured")
 	}
 	return nil
 }
@@ -159,13 +181,11 @@ func (s *Shim) Collect(ch chan<- prometheus.Metric) {
 	s.upstreamRequestTimer.Collect(ch)
 }
 
-// Start is called after the manager has started and the cache is running.
-// It can be used to perform any initialization that requires the cache to be
-// running.
-func (s *Shim) Start(ctx context.Context) (err error) {
-	setupLog.Info("Starting placement shim")
-	// Build the transport with optional SSO TLS credentials.
+// initHTTPClient builds the HTTP transport (with optional SSO TLS) and
+// verifies connectivity to the upstream placement API. Called during Start.
+func (s *Shim) initHTTPClient(ctx context.Context) error {
 	var transport *http.Transport
+	var err error
 	if s.config.SSO != nil {
 		setupLog.Info("SSO config provided, creating transport for placement API")
 		transport, err = sso.NewTransport(*s.config.SSO)
@@ -191,8 +211,7 @@ func (s *Shim) Start(ctx context.Context) (err error) {
 	transport.ExpectContinueTimeout = 1 * time.Second
 	transport.IdleConnTimeout = 90 * time.Second
 	s.httpClient = &http.Client{Transport: transport, Timeout: 60 * time.Second}
-	// Try establish a connection to the placement API to fail fast if the
-	// configuration is invalid. Directly call the root endpoint for that.
+
 	setupLog.Info("Testing connection to placement API", "url", s.config.PlacementURL)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.config.PlacementURL, http.NoBody)
 	if err != nil {
@@ -211,19 +230,16 @@ func (s *Shim) Start(ctx context.Context) (err error) {
 		return err
 	}
 	setupLog.Info("Successfully connected to placement API")
-
-	// Create the Keystone introspector when auth is configured. This
-	// reuses the shim's HTTP client (and its TLS/SSO transport).
-	if s.config.Auth != nil {
-		s.tokenIntrospector = &keystoneIntrospector{
-			keystoneURL: s.config.KeystoneURL,
-			httpClient:  s.httpClient,
-		}
-		setupLog.Info("Auth middleware enabled with Keystone",
-			"keystoneURL", s.config.KeystoneURL)
-	}
-
 	return nil
+}
+
+// Start is called after the manager has started and the cache is running.
+func (s *Shim) Start(ctx context.Context) error {
+	setupLog.Info("Starting placement shim")
+	if err := s.initHTTPClient(ctx); err != nil {
+		return err
+	}
+	return s.initTokenIntrospector(ctx)
 }
 
 // Reconcile is not used by the shim, but must be implemented to satisfy the
@@ -255,7 +271,6 @@ func (s *Shim) predicateRemoteHypervisor() predicate.Predicate {
 func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err error) {
 	setupLog.Info("Setting up placement shim with manager")
 
-	// Bind the Start method to the manager.
 	if err := mgr.Add(s); err != nil {
 		return err
 	}
@@ -265,7 +280,6 @@ func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err erro
 		setupLog.Error(err, "Failed to load placement shim config")
 		return err
 	}
-	// Validate we don't have any weird values in the config.
 	if err := s.config.validate(); err != nil {
 		return err
 	}
@@ -281,31 +295,8 @@ func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err erro
 	}
 	s.maxBodyLogSize = qty.Value()
 
-	// Compile auth policies when auth is configured.
-	if s.config.Auth != nil {
-		ttlStr := s.config.Auth.TokenCacheTTL
-		if ttlStr == "" {
-			ttlStr = "5m"
-		}
-		ttl, err := time.ParseDuration(ttlStr)
-		if err != nil {
-			return fmt.Errorf("invalid tokenCacheTTL %q: %w", ttlStr, err)
-		}
-		s.tokenCache = &tokenCache{ttl: ttl}
-		s.authPolicies = make([]compiledPolicy, len(s.config.Auth.Policies))
-		for i, p := range s.config.Auth.Policies {
-			method, path, ok := strings.Cut(p.Pattern, " ")
-			if !ok {
-				return fmt.Errorf("invalid auth policy pattern %q: expected \"METHOD /path\"", p.Pattern)
-			}
-			s.authPolicies[i] = compiledPolicy{
-				method:      method,
-				pathPattern: path,
-				roles:       p.Roles,
-			}
-		}
-		setupLog.Info("Auth middleware configured",
-			"policies", len(s.authPolicies), "tokenCacheTTL", ttl)
+	if err := s.compileAuthPolicies(); err != nil {
+		return err
 	}
 
 	// Initialize Prometheus histogram timers for request monitoring.
@@ -326,12 +317,10 @@ func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err erro
 	if !ok {
 		return errors.New("provided client must be a multicluster client")
 	}
-	// Bind all indexes that will help make fast lookups.
 	if err := indexFields(ctx, mcl); err != nil {
 		return fmt.Errorf("failed to set up indexes: %w", err)
 	}
 	bldr := multicluster.BuildController(mcl, mgr)
-	// The hypervisor crd may be distributed across multiple remote clusters.
 	bldr, err = bldr.WatchesMulticluster(&hv1.Hypervisor{},
 		s.handleRemoteHypervisor(),
 		s.predicateRemoteHypervisor(),

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -48,38 +48,6 @@ type requestIDContextKey struct{}
 // header value through the request lifecycle for tracing.
 var requestIDKey = requestIDContextKey{}
 
-// authPolicyRole is a role that grants access for a matching policy rule.
-type authPolicyRole struct {
-	// Name is the OpenStack role name (e.g. "cloud_compute_admin").
-	Name string `json:"name"`
-	// ProjectScoped requires the token's project_id to match the
-	// request's project_id when true (e.g. for per-project usages).
-	ProjectScoped bool `json:"projectScoped,omitempty"`
-}
-
-// authPolicy maps an HTTP method + path pattern to the roles allowed to
-// access it. Patterns use "METHOD /path" syntax where "*" matches any
-// method and "*" in the path acts as a wildcard. Evaluation is
-// first-match; no match means deny.
-type authPolicy struct {
-	// Pattern is the method + path to match (e.g. "GET /usages", "* /*").
-	Pattern string `json:"pattern"`
-	// Roles lists the roles that grant access for this pattern.
-	// When null, the path is publicly accessible (no token required).
-	Roles []authPolicyRole `json:"roles"`
-}
-
-// authConfig configures the Keystone token-validation middleware.
-// When nil, auth is disabled and all requests are passed through.
-type authConfig struct {
-	// TokenCacheTTL is how long validated tokens are cached before
-	// re-introspection against Keystone (e.g. "5m").
-	TokenCacheTTL string `json:"tokenCacheTTL,omitempty"`
-	// Policies is the ordered list of first-match access rules evaluated
-	// against each incoming request.
-	Policies []authPolicy `json:"policies,omitempty"`
-}
-
 // config holds configuration for the placement shim.
 type config struct {
 	// SSO is an optional configuration for the certificates the http client
@@ -133,6 +101,9 @@ func (c *config) validate() error {
 	}
 	if c.Auth != nil && c.OSPassword == "" {
 		return errors.New("osPassword is required when auth is configured")
+	}
+	if c.Auth != nil && len(c.Auth.Policies) == 0 {
+		return errors.New("auth.policies must not be empty when auth is configured")
 	}
 	return nil
 }

--- a/internal/shim/placement/shim_e2e.go
+++ b/internal/shim/placement/shim_e2e.go
@@ -23,15 +23,15 @@ type e2eRootConfig struct {
 	// SSO is an optional configuration for the certificates the http client
 	// should use when talking to the placement API over ingress with single-sign-on.
 	SSO *sso.SSOConfig `json:"sso,omitempty"`
+	// KeystoneURL is the URL of the OpenStack Keystone identity service,
+	// shared with the main shim config.
+	KeystoneURL string `json:"keystoneURL,omitempty"`
 }
 
 type e2eConfig struct {
 	// SVCURL is the url placement shim service, e.g.
 	// "http://cortex-placement-shim-service:8080"
 	SVCURL string `json:"svcURL"`
-	// OSKeystoneURL is the URL of the keystone service to contact for
-	// generating an authenticated openstack client token.
-	OSKeystoneURL string `json:"osKeystoneURL"`
 	// OSUsername is the OpenStack username for keystone authentication
 	// (OS_USERNAME in openstack cli).
 	OSUsername string `json:"osUsername"`
@@ -56,7 +56,7 @@ type e2eConfig struct {
 func makeE2EServiceClient(ctx context.Context, rc e2eRootConfig) (*gophercloud.ServiceClient, error) {
 	log := logf.FromContext(ctx)
 	authOpts := gophercloud.AuthOptions{
-		IdentityEndpoint: rc.E2E.OSKeystoneURL,
+		IdentityEndpoint: rc.KeystoneURL,
 		Username:         rc.E2E.OSUsername,
 		DomainName:       rc.E2E.OSUserDomainName,
 		Password:         rc.E2E.OSPassword,
@@ -70,7 +70,7 @@ func makeE2EServiceClient(ctx context.Context, rc e2eRootConfig) (*gophercloud.S
 		"endpoint", authOpts.IdentityEndpoint,
 		"username", authOpts.Username,
 		"project", authOpts.Scope.ProjectName)
-	provider, err := openstack.NewClient(rc.E2E.OSKeystoneURL)
+	provider, err := openstack.NewClient(rc.KeystoneURL)
 	if err != nil {
 		log.Error(err, "Failed to create openstack provider client")
 		return nil, fmt.Errorf("failed to create openstack provider client: %w", err)

--- a/internal/shim/placement/shim_e2e.go
+++ b/internal/shim/placement/shim_e2e.go
@@ -16,37 +16,14 @@ import (
 )
 
 type e2eRootConfig struct {
-	E2E e2eConfig `yaml:"e2e"`
-
-	// Shared with the main shim config.
-
-	// SSO is an optional configuration for the certificates the http client
-	// should use when talking to the placement API over ingress with single-sign-on.
-	SSO *sso.SSOConfig `json:"sso,omitempty"`
-	// KeystoneURL is the URL of the OpenStack Keystone identity service,
-	// shared with the main shim config.
-	KeystoneURL string `json:"keystoneURL,omitempty"`
+	config
+	E2E e2eConfig `json:"e2e"`
 }
 
 type e2eConfig struct {
 	// SVCURL is the url placement shim service, e.g.
 	// "http://cortex-placement-shim-service:8080"
 	SVCURL string `json:"svcURL"`
-	// OSUsername is the OpenStack username for keystone authentication
-	// (OS_USERNAME in openstack cli).
-	OSUsername string `json:"osUsername"`
-	// OSPassword is the OpenStack password for keystone authentication
-	// (OS_PASSWORD in openstack cli).
-	OSPassword string `json:"osPassword"`
-	// OSProjectName is the OpenStack project name for keystone authentication
-	// (OS_PROJECT_NAME in openstack cli).
-	OSProjectName string `json:"osProjectName"`
-	// OSUserDomainName is the OpenStack user domain name for keystone
-	// authentication (OS_USER_DOMAIN_NAME in openstack cli).
-	OSUserDomainName string `json:"osUserDomainName"`
-	// OSProjectDomainName is the OpenStack project domain name for keystone
-	// authentication (OS_PROJECT_DOMAIN_NAME in openstack cli).
-	OSProjectDomainName string `json:"osProjectDomainName"`
 }
 
 // makeE2EServiceClient creates an authenticated openstack placement client
@@ -57,13 +34,13 @@ func makeE2EServiceClient(ctx context.Context, rc e2eRootConfig) (*gophercloud.S
 	log := logf.FromContext(ctx)
 	authOpts := gophercloud.AuthOptions{
 		IdentityEndpoint: rc.KeystoneURL,
-		Username:         rc.E2E.OSUsername,
-		DomainName:       rc.E2E.OSUserDomainName,
-		Password:         rc.E2E.OSPassword,
+		Username:         rc.OSUsername,
+		DomainName:       rc.OSUserDomainName,
+		Password:         rc.OSPassword,
 		AllowReauth:      true,
 		Scope: &gophercloud.AuthScope{
-			ProjectName: rc.E2E.OSProjectName,
-			DomainName:  rc.E2E.OSProjectDomainName,
+			ProjectName: rc.OSProjectName,
+			DomainName:  rc.OSProjectDomainName,
 		},
 	}
 	log.Info("Authenticating with keystone for e2e tests",

--- a/internal/shim/placement/shim_io.go
+++ b/internal/shim/placement/shim_io.go
@@ -123,7 +123,9 @@ func (s *Shim) wrapHandler(pattern string, next http.HandlerFunc) http.HandlerFu
 		}
 
 		start := time.Now()
-		next.ServeHTTP(sw, r)
+		if s.checkAuth(sw, r) {
+			next.ServeHTTP(sw, r)
+		}
 		latencyMs := time.Since(start).Milliseconds()
 
 		// NOTE: We intentionally never log HTTP headers to avoid

--- a/internal/shim/placement/shim_test.go
+++ b/internal/shim/placement/shim_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -396,4 +397,98 @@ func TestRequestIDInContext(t *testing.T) {
 	if gotHeader != wantID {
 		t.Errorf("upstream received X-OpenStack-Request-Id = %q, want %q", gotHeader, wantID)
 	}
+}
+
+func TestConfigValidateAuthRequiresKeystoneURL(t *testing.T) {
+	c := config{
+		PlacementURL: "http://placement:8778",
+		Auth:         &authConfig{TokenCacheTTL: "5m"},
+	}
+	if err := c.validate(); err == nil {
+		t.Fatal("expected error when auth configured without keystoneURL")
+	}
+	c.KeystoneURL = "http://keystone:5000"
+	if err := c.validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWrapHandlerWithAuth(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	info := &tokenInfo{
+		roles:     []string{"cloud_compute_admin"},
+		expiresAt: time.Now().Add(time.Hour),
+		cachedAt:  time.Now(),
+	}
+
+	down, up := newTestTimers()
+	s := &Shim{
+		config:                 config{PlacementURL: upstream.URL},
+		httpClient:             upstream.Client(),
+		maxBodyLogSize:         4096,
+		downstreamRequestTimer: down,
+		upstreamRequestTimer:   up,
+		authPolicies: []compiledPolicy{
+			{method: "GET", pathPattern: "/", roles: nil}, // public
+			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "cloud_compute_admin"}}},
+		},
+		tokenCache:        &tokenCache{ttl: time.Minute},
+		tokenIntrospector: &mockIntrospector{info: info},
+	}
+
+	t.Run("authorized request succeeds", func(t *testing.T) {
+		wrapped := s.wrapHandler("/test", func(w http.ResponseWriter, r *http.Request) {
+			s.forward(w, r)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+		req.Header.Set("X-Auth-Token", "good-token")
+		w := httptest.NewRecorder()
+		wrapped(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+		}
+		if n := histSampleCount(t, down, "GET", "/test", "200"); n != 1 {
+			t.Errorf("downstream 200 count = %d, want 1", n)
+		}
+	})
+
+	t.Run("missing token returns 401", func(t *testing.T) {
+		down2, _ := newTestTimers()
+		s2 := *s
+		s2.downstreamRequestTimer = down2
+		wrapped := s2.wrapHandler("/test", func(w http.ResponseWriter, r *http.Request) {
+			s2.forward(w, r)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+		w := httptest.NewRecorder()
+		wrapped(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+		if n := histSampleCount(t, down2, "GET", "/test", "401"); n != 1 {
+			t.Errorf("downstream 401 count = %d, want 1", n)
+		}
+	})
+
+	t.Run("public endpoint without token succeeds", func(t *testing.T) {
+		down3, _ := newTestTimers()
+		s3 := *s
+		s3.downstreamRequestTimer = down3
+		wrapped := s3.wrapHandler("/", func(w http.ResponseWriter, r *http.Request) {
+			s3.forward(w, r)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		w := httptest.NewRecorder()
+		wrapped(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+		}
+	})
 }

--- a/internal/shim/placement/shim_test.go
+++ b/internal/shim/placement/shim_test.go
@@ -445,7 +445,7 @@ func TestWrapHandlerWithAuth(t *testing.T) {
 		upstreamRequestTimer:   up,
 		authPolicies: []compiledPolicy{
 			{method: "GET", pathPattern: "/", roles: nil}, // public
-			{method: "*", pathPattern: "/*", roles: []authPolicyRole{{Name: "cloud_compute_admin"}}},
+			{method: "*", pathPattern: "/*", roles: []compiledRole{{name: "cloud_compute_admin"}}},
 		},
 		tokenCache:        &tokenCache{ttl: time.Minute},
 		tokenIntrospector: &mockIntrospector{info: info},

--- a/internal/shim/placement/shim_test.go
+++ b/internal/shim/placement/shim_test.go
@@ -408,6 +408,14 @@ func TestConfigValidateAuthRequiresKeystoneURL(t *testing.T) {
 		t.Fatal("expected error when auth configured without keystoneURL")
 	}
 	c.KeystoneURL = "http://keystone:5000"
+	if err := c.validate(); err == nil {
+		t.Fatal("expected error when auth configured without osUsername")
+	}
+	c.OSUsername = "admin"
+	if err := c.validate(); err == nil {
+		t.Fatal("expected error when auth configured without osPassword")
+	}
+	c.OSPassword = "secret"
 	if err := c.validate(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/shim/placement/shim_test.go
+++ b/internal/shim/placement/shim_test.go
@@ -402,7 +402,7 @@ func TestRequestIDInContext(t *testing.T) {
 func TestConfigValidateAuthRequiresKeystoneURL(t *testing.T) {
 	c := config{
 		PlacementURL: "http://placement:8778",
-		Auth:         &authConfig{TokenCacheTTL: "5m"},
+		Auth:         &authConfig{TokenCacheTTL: "5m", Policies: []authPolicy{{Pattern: "GET /", Roles: nil}}},
 	}
 	if err := c.validate(); err == nil {
 		t.Fatal("expected error when auth configured without keystoneURL")


### PR DESCRIPTION
Adds Keystone token validation middleware to the placement API shim. Incoming requests are matched against a configurable first-match policy table that maps HTTP method + path patterns to required OpenStack roles. Tokens are validated via the Keystone GET /v3/auth/tokens endpoint using the shim's own service credentials and cached (with configurable TTL) to avoid repeated introspection. Cache keys are SHA-256 hashes of the raw tokens. Role comparison is case-insensitive to match Keystone's case-preserving behavior. Public endpoints (e.g. GET /) can be configured with null roles to skip authentication entirely. Project-scoped roles use a pluggable extraction strategy: the project ID can be read from a URL query parameter (from: query) or a top-level JSON body field (from: body), configurable per role. The Helm values are restructured to centralize OpenStack credentials (keystoneURL, osUsername, osPassword, etc.) at the top level since they are now shared between the auth middleware and the E2E test suite.