### PR TITLE
Implement placement shim /traits APIs

### DIFF
--- a/helm/bundles/cortex-placement-shim/templates/clusterrole.yaml
+++ b/helm/bundles/cortex-placement-shim/templates/clusterrole.yaml
@@ -37,6 +37,8 @@ rules:
   - leases
   verbs:
   - get
+  - list
+  - watch
   - create
   - update
   - delete

--- a/helm/bundles/cortex-placement-shim/templates/clusterrole.yaml
+++ b/helm/bundles/cortex-placement-shim/templates/clusterrole.yaml
@@ -21,3 +21,22 @@ rules:
   - hypervisors/status
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+  - delete

--- a/helm/bundles/cortex-placement-shim/templates/configmap-traits.yaml
+++ b/helm/bundles/cortex-placement-shim/templates/configmap-traits.yaml
@@ -1,0 +1,11 @@
+{{- if (index .Values "cortex-shim").conf.features.enableTraits }}
+{{- $cmName := (index .Values "cortex-shim").conf.traits.configMapName }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $cmName }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+data:
+  traits: {{ (index .Values "cortex-shim").conf.traits.static | toJson | quote }}
+{{- end }}

--- a/helm/bundles/cortex-placement-shim/values.yaml
+++ b/helm/bundles/cortex-placement-shim/values.yaml
@@ -44,6 +44,7 @@ cortex-shim:
     features:
       enableResourceProviders: false
       enableRoot: false
+      enableTraits: false
     # The shim will return this as a static version discovery document for
     # GET / instead of forwarding to upstream placement.
     versioning:
@@ -51,6 +52,11 @@ cortex-shim:
       minVersion: "1.0"
       maxVersion: "1.39"
       status: "CURRENT"
+    traits:
+      configMapName: "cortex-placement-global"
+      # Static traits included in every Helm install/upgrade. The shim
+      # merges them with dynamic CUSTOM_* traits at request time.
+      static: []
     auth:
       tokenCacheTTL: "5m"
       policies:
@@ -80,6 +86,10 @@ cortex-shim:
         gvks:
           - kvm.cloud.sap/v1/Hypervisor
           - kvm.cloud.sap/v1/HypervisorList
+          - v1/ConfigMap
+          - v1/ConfigMapList
+          - coordination.k8s.io/v1/Lease
+          - coordination.k8s.io/v1/LeaseList
     monitoring:
       labels:
         github_org: cobaltcore-dev

--- a/helm/bundles/cortex-placement-shim/values.yaml
+++ b/helm/bundles/cortex-placement-shim/values.yaml
@@ -53,7 +53,7 @@ cortex-shim:
       maxVersion: "1.39"
       status: "CURRENT"
     traits:
-      configMapName: "cortex-placement-global"
+      configMapName: "cortex-placement-shim-traits"
       # Static traits included in every Helm install/upgrade. The shim
       # merges them with dynamic CUSTOM_* traits at request time.
       static: []

--- a/helm/library/cortex-shim/templates/deployment.yaml
+++ b/helm/library/cortex-shim/templates/deployment.yaml
@@ -46,15 +46,16 @@ spec:
           imagePullPolicy: {{ .Values.deployment.container.image.pullPolicy }}
           {{- end }}
           env:
+            {{- $env := .Values.deployment.container.env | default dict }}
+            {{- if not (hasKey $env "POD_NAMESPACE") }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if .Values.deployment.container.env }}
-            {{- range $key, $value := .Values.deployment.container.env }}
+            {{- end }}
+            {{- range $key, $value := $env }}
             - name: {{ $key }}
               value: {{ $value }}
-            {{- end }}
             {{- end }}
           livenessProbe:
             {{- toYaml .Values.deployment.container.livenessProbe | nindent 12 }}

--- a/helm/library/cortex-shim/templates/deployment.yaml
+++ b/helm/library/cortex-shim/templates/deployment.yaml
@@ -45,13 +45,17 @@ spec:
           {{- if .Values.deployment.container.image.pullPolicy }}
           imagePullPolicy: {{ .Values.deployment.container.image.pullPolicy }}
           {{- end }}
-          {{- if .Values.deployment.container.env }}
           env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- if .Values.deployment.container.env }}
             {{- range $key, $value := .Values.deployment.container.env }}
             - name: {{ $key }}
               value: {{ $value }}
             {{- end }}
-          {{- end }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.deployment.container.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/internal/shim/placement/handle_traits.go
+++ b/internal/shim/placement/handle_traits.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -218,6 +219,7 @@ func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		log.Info("created custom traits configmap with new trait", "trait", name)
+		s.syncTraitToUpstream(ctx, name)
 		w.WriteHeader(http.StatusCreated)
 		return
 	}
@@ -250,6 +252,7 @@ func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Info("added custom trait to configmap", "trait", name)
+	s.syncTraitToUpstream(ctx, name)
 	w.WriteHeader(http.StatusCreated)
 }
 
@@ -410,4 +413,38 @@ func (s *Shim) writeTraits(cm *corev1.ConfigMap, traitSet map[string]struct{}) e
 	}
 	cm.Data[configMapKeyTraits] = string(data)
 	return nil
+}
+
+// syncTraitToUpstream best-effort creates the trait in upstream placement so
+// that endpoints forwarded to upstream (e.g. PUT /resource_providers/{uuid}/traits)
+// can reference locally-created custom traits. Errors are logged but never
+// propagated — upstream may be unreachable and that is acceptable.
+func (s *Shim) syncTraitToUpstream(ctx context.Context, name string) {
+	log := logf.FromContext(ctx)
+	if s.httpClient == nil {
+		log.V(1).Info("skipping upstream trait sync, no http client configured", "trait", name)
+		return
+	}
+	u, err := url.Parse(s.config.PlacementURL)
+	if err != nil {
+		log.Error(err, "failed to parse placement URL for trait sync", "trait", name)
+		return
+	}
+	u.Path, err = url.JoinPath(u.Path, "/traits/"+name)
+	if err != nil {
+		log.Error(err, "failed to build upstream trait URL", "trait", name)
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), http.NoBody)
+	if err != nil {
+		log.Error(err, "failed to create upstream trait request", "trait", name)
+		return
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		log.Info("best-effort upstream trait sync failed, upstream may be down", "trait", name, "error", err.Error())
+		return
+	}
+	defer resp.Body.Close()
+	log.Info("synced custom trait to upstream placement", "trait", name, "status", resp.StatusCode)
 }

--- a/internal/shim/placement/handle_traits.go
+++ b/internal/shim/placement/handle_traits.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,17 +20,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const (
-	configMapKeyTraits       = "traits"
-	traitsLeaseDuration      = 15
-	traitsLeaseRetryInterval = 500 * time.Millisecond
-	traitsLeaseRetryTimeout  = 5 * time.Second
-)
-
-// traitsListResponse matches the OpenStack Placement GET /traits response.
-type traitsListResponse struct {
-	Traits []string `json:"traits"`
-}
+const configMapKeyTraits = "traits"
 
 func (s *Shim) staticTraitsConfigMapKey() client.ObjectKey {
 	return client.ObjectKey{
@@ -47,19 +36,34 @@ func (s *Shim) customTraitsConfigMapKey() client.ObjectKey {
 	}
 }
 
+func (s *Shim) traitsLockName() string {
+	return s.config.Traits.ConfigMapName + "-custom-lock"
+}
+
+// traitsListResponse matches the OpenStack Placement GET /traits response.
+type traitsListResponse struct {
+	Traits []string `json:"traits"`
+}
+
 // HandleListTraits handles GET /traits requests.
 //
 // Returns a sorted list of trait strings merged from the static (Helm-managed)
 // and dynamic (CUSTOM_*) ConfigMaps. Supports optional query parameter "name"
 // for filtering: "in:TRAIT_A,TRAIT_B" returns only named traits,
 // "startswith:CUSTOM_" returns prefix matches.
+//
+// See: https://docs.openstack.org/api-ref/placement/#list-traits
 func (s *Shim) HandleListTraits(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logf.FromContext(ctx)
+
 	if !s.config.Features.EnableTraits {
 		s.forward(w, r)
 		return
 	}
-	traitSet, err := s.getAllTraits(r.Context())
+	traitSet, err := s.getAllTraits(ctx)
 	if err != nil {
+		log.Error(err, "failed to list traits from configmaps")
 		http.Error(w, "failed to list traits", http.StatusInternalServerError)
 		return
 	}
@@ -72,6 +76,7 @@ func (s *Shim) HandleListTraits(w http.ResponseWriter, r *http.Request) {
 
 	nameFilter := r.URL.Query().Get("name")
 	if nameFilter == "" {
+		log.Info("listing all traits", "count", len(all))
 		s.writeJSON(w, http.StatusOK, traitsListResponse{Traits: all})
 		return
 	}
@@ -86,6 +91,7 @@ func (s *Shim) HandleListTraits(w http.ResponseWriter, r *http.Request) {
 				filtered = append(filtered, t)
 			}
 		}
+		log.Info("listing traits with in: filter", "filter", nameFilter, "count", len(filtered))
 		s.writeJSON(w, http.StatusOK, traitsListResponse{Traits: filtered})
 		return
 	}
@@ -96,9 +102,11 @@ func (s *Shim) HandleListTraits(w http.ResponseWriter, r *http.Request) {
 				filtered = append(filtered, t)
 			}
 		}
+		log.Info("listing traits with startswith: filter", "filter", nameFilter, "count", len(filtered))
 		s.writeJSON(w, http.StatusOK, traitsListResponse{Traits: filtered})
 		return
 	}
+	log.Info("listing all traits, unrecognized filter ignored", "filter", nameFilter, "count", len(all))
 	s.writeJSON(w, http.StatusOK, traitsListResponse{Traits: all})
 }
 
@@ -106,7 +114,12 @@ func (s *Shim) HandleListTraits(w http.ResponseWriter, r *http.Request) {
 //
 // Checks whether a trait with the given name exists in either the static
 // or dynamic ConfigMap. Returns 200 OK if found, 404 Not Found otherwise.
+//
+// See: https://docs.openstack.org/api-ref/placement/#show-traits
 func (s *Shim) HandleShowTrait(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logf.FromContext(ctx)
+
 	if !s.config.Features.EnableTraits {
 		s.forward(w, r)
 		return
@@ -115,15 +128,18 @@ func (s *Shim) HandleShowTrait(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	found, err := s.hasTrait(r.Context(), name)
+	found, err := s.hasTrait(ctx, name)
 	if err != nil {
+		log.Error(err, "failed to check trait", "trait", name)
 		http.Error(w, "failed to check trait", http.StatusInternalServerError)
 		return
 	}
 	if !found {
+		log.Info("trait not found", "trait", name)
 		http.Error(w, "trait not found", http.StatusNotFound)
 		return
 	}
+	log.Info("trait found", "trait", name)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -133,7 +149,12 @@ func (s *Shim) HandleShowTrait(w http.ResponseWriter, r *http.Request) {
 // with CUSTOM_ may be created. Returns 201 Created if the trait is newly
 // inserted, or 204 No Content if it already exists (in either ConfigMap).
 // Returns 400 Bad Request if the name does not carry the CUSTOM_ prefix.
+//
+// See: https://docs.openstack.org/api-ref/placement/#update-trait
 func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logf.FromContext(ctx)
+
 	if !s.config.Features.EnableTraits {
 		s.forward(w, r)
 		return
@@ -143,37 +164,41 @@ func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !strings.HasPrefix(name, "CUSTOM_") {
+		log.Info("rejected trait without CUSTOM_ prefix", "trait", name)
 		http.Error(w, "trait name must start with CUSTOM_", http.StatusBadRequest)
 		return
 	}
-	ctx := r.Context()
 
 	// Fast path: trait already exists in either ConfigMap (no lock needed).
 	allTraits, err := s.getAllTraits(ctx)
 	if err != nil {
+		log.Error(err, "failed to read traits for existence check", "trait", name)
 		http.Error(w, "failed to create trait", http.StatusInternalServerError)
 		return
 	}
 	if _, exists := allTraits[name]; exists {
+		log.Info("trait already exists, nothing to do", "trait", name)
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 
 	// Slow path: acquire lock, read/create dynamic ConfigMap, add trait.
-	if err := s.acquireTraitsLease(ctx); err != nil {
+	lockerID := fmt.Sprintf("shim-%d", time.Now().UnixNano())
+	if err := s.resourceLocker.AcquireLock(ctx, s.traitsLockName(), lockerID); err != nil {
+		log.Error(err, "failed to acquire traits lock", "trait", name)
 		http.Error(w, "failed to create trait", http.StatusInternalServerError)
 		return
 	}
 	defer func() {
-		if err := s.releaseTraitsLease(ctx); err != nil {
-			logf.FromContext(ctx).Error(err, "Failed to release traits lease")
+		if err := s.resourceLocker.ReleaseLock(ctx, s.traitsLockName(), lockerID); err != nil {
+			log.Error(err, "failed to release traits lock")
 		}
 	}()
 
 	cm := &corev1.ConfigMap{}
 	err = s.Get(ctx, s.customTraitsConfigMapKey(), cm)
 	if apierrors.IsNotFound(err) {
-		// Dynamic ConfigMap doesn't exist yet — create it with the new trait.
+		// Dynamic ConfigMap does not exist yet — create it with the new trait.
 		cm = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      s.customTraitsConfigMapKey().Name,
@@ -183,39 +208,48 @@ func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
 		}
 		current := map[string]struct{}{name: {}}
 		if err := s.writeTraits(cm, current); err != nil {
+			log.Error(err, "failed to serialize traits", "trait", name)
 			http.Error(w, "failed to create trait", http.StatusInternalServerError)
 			return
 		}
 		if err := s.Create(ctx, cm); err != nil {
+			log.Error(err, "failed to create custom traits configmap", "trait", name)
 			http.Error(w, "failed to create trait", http.StatusInternalServerError)
 			return
 		}
+		log.Info("created custom traits configmap with new trait", "trait", name)
 		w.WriteHeader(http.StatusCreated)
 		return
 	}
 	if err != nil {
+		log.Error(err, "failed to get custom traits configmap", "trait", name)
 		http.Error(w, "failed to create trait", http.StatusInternalServerError)
 		return
 	}
 
 	current, err := parseTraits(cm)
 	if err != nil {
+		log.Error(err, "failed to parse custom traits configmap", "trait", name)
 		http.Error(w, "failed to create trait", http.StatusInternalServerError)
 		return
 	}
 	if _, exists := current[name]; exists {
+		log.Info("trait already exists in custom configmap after lock acquisition", "trait", name)
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	current[name] = struct{}{}
 	if err := s.writeTraits(cm, current); err != nil {
+		log.Error(err, "failed to serialize traits", "trait", name)
 		http.Error(w, "failed to create trait", http.StatusInternalServerError)
 		return
 	}
 	if err := s.Update(ctx, cm); err != nil {
+		log.Error(err, "failed to update custom traits configmap", "trait", name)
 		http.Error(w, "failed to create trait", http.StatusInternalServerError)
 		return
 	}
+	log.Info("added custom trait to configmap", "trait", name)
 	w.WriteHeader(http.StatusCreated)
 }
 
@@ -224,7 +258,12 @@ func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
 // Deletes a custom trait from the dynamic ConfigMap. Standard traits (those
 // without the CUSTOM_ prefix) cannot be deleted and return 400 Bad Request.
 // Returns 404 if the trait does not exist. Returns 204 No Content on success.
+//
+// See: https://docs.openstack.org/api-ref/placement/#delete-traits
 func (s *Shim) HandleDeleteTrait(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logf.FromContext(ctx)
+
 	if !s.config.Features.EnableTraits {
 		s.forward(w, r)
 		return
@@ -234,49 +273,58 @@ func (s *Shim) HandleDeleteTrait(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !strings.HasPrefix(name, "CUSTOM_") {
+		log.Info("rejected deletion of standard trait", "trait", name)
 		http.Error(w, "cannot delete standard traits", http.StatusBadRequest)
 		return
 	}
-	ctx := r.Context()
 
-	if err := s.acquireTraitsLease(ctx); err != nil {
+	lockerID := fmt.Sprintf("shim-%d", time.Now().UnixNano())
+	if err := s.resourceLocker.AcquireLock(ctx, s.traitsLockName(), lockerID); err != nil {
+		log.Error(err, "failed to acquire traits lock", "trait", name)
 		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
 		return
 	}
 	defer func() {
-		if err := s.releaseTraitsLease(ctx); err != nil {
-			logf.FromContext(ctx).Error(err, "Failed to release traits lease")
+		if err := s.resourceLocker.ReleaseLock(ctx, s.traitsLockName(), lockerID); err != nil {
+			log.Error(err, "failed to release traits lock")
 		}
 	}()
 
 	cm := &corev1.ConfigMap{}
 	err := s.Get(ctx, s.customTraitsConfigMapKey(), cm)
 	if apierrors.IsNotFound(err) {
+		log.Info("custom traits configmap not found, trait does not exist", "trait", name)
 		http.Error(w, "trait not found", http.StatusNotFound)
 		return
 	}
 	if err != nil {
+		log.Error(err, "failed to get custom traits configmap", "trait", name)
 		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
 		return
 	}
 	current, err := parseTraits(cm)
 	if err != nil {
+		log.Error(err, "failed to parse custom traits configmap", "trait", name)
 		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
 		return
 	}
 	if _, exists := current[name]; !exists {
+		log.Info("trait not found in custom configmap", "trait", name)
 		http.Error(w, "trait not found", http.StatusNotFound)
 		return
 	}
 	delete(current, name)
 	if err := s.writeTraits(cm, current); err != nil {
+		log.Error(err, "failed to serialize traits", "trait", name)
 		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
 		return
 	}
 	if err := s.Update(ctx, cm); err != nil {
+		log.Error(err, "failed to update custom traits configmap", "trait", name)
 		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
 		return
 	}
+	log.Info("deleted custom trait from configmap", "trait", name)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -361,103 +409,5 @@ func (s *Shim) writeTraits(cm *corev1.ConfigMap, traitSet map[string]struct{}) e
 		cm.Data = make(map[string]string)
 	}
 	cm.Data[configMapKeyTraits] = string(data)
-	return nil
-}
-
-// traitsLeaseName returns the Lease resource name used for locking writes.
-func (s *Shim) traitsLeaseName() string {
-	return s.config.Traits.ConfigMapName + "-lock"
-}
-
-// acquireTraitsLease attempts to acquire a Kubernetes Lease for serializing
-// ConfigMap writes. It retries with backoff until the lease is acquired or
-// the timeout expires.
-func (s *Shim) acquireTraitsLease(ctx context.Context) error {
-	log := logf.FromContext(ctx)
-	name := s.traitsLeaseName()
-	ns := os.Getenv("POD_NAMESPACE")
-	holderID := fmt.Sprintf("shim-%d", time.Now().UnixNano())
-	leaseDuration := int32(traitsLeaseDuration)
-
-	deadline := time.Now().Add(traitsLeaseRetryTimeout)
-	for {
-		now := metav1.NewMicroTime(time.Now())
-		lease := &coordinationv1.Lease{}
-		err := s.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, lease)
-
-		if apierrors.IsNotFound(err) {
-			lease = &coordinationv1.Lease{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: ns,
-				},
-				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       &holderID,
-					LeaseDurationSeconds: &leaseDuration,
-					AcquireTime:          &now,
-					RenewTime:            &now,
-				},
-			}
-			if err := s.Create(ctx, lease); err != nil {
-				if apierrors.IsAlreadyExists(err) {
-					if time.Now().After(deadline) {
-						return fmt.Errorf("timeout acquiring traits lease %s", name)
-					}
-					time.Sleep(traitsLeaseRetryInterval)
-					continue
-				}
-				return fmt.Errorf("create lease %s: %w", name, err)
-			}
-			log.V(2).Info("Acquired traits lease", "lease", name)
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("get lease %s: %w", name, err)
-		}
-
-		// Check if the existing lease has expired.
-		if lease.Spec.RenewTime != nil && lease.Spec.LeaseDurationSeconds != nil {
-			expiry := lease.Spec.RenewTime.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second)
-			if time.Now().Before(expiry) {
-				if time.Now().After(deadline) {
-					return fmt.Errorf("timeout acquiring traits lease %s", name)
-				}
-				time.Sleep(traitsLeaseRetryInterval)
-				continue
-			}
-		}
-
-		// Lease expired — claim it.
-		lease.Spec.HolderIdentity = &holderID
-		lease.Spec.LeaseDurationSeconds = &leaseDuration
-		lease.Spec.AcquireTime = &now
-		lease.Spec.RenewTime = &now
-		if err := s.Update(ctx, lease); err != nil {
-			if apierrors.IsConflict(err) {
-				if time.Now().After(deadline) {
-					return fmt.Errorf("timeout acquiring traits lease %s", name)
-				}
-				time.Sleep(traitsLeaseRetryInterval)
-				continue
-			}
-			return fmt.Errorf("update lease %s: %w", name, err)
-		}
-		log.V(2).Info("Acquired expired traits lease", "lease", name)
-		return nil
-	}
-}
-
-// releaseTraitsLease deletes the Lease resource to allow other replicas to proceed.
-func (s *Shim) releaseTraitsLease(ctx context.Context) error {
-	ns := os.Getenv("POD_NAMESPACE")
-	lease := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.traitsLeaseName(),
-			Namespace: ns,
-		},
-	}
-	if err := s.Delete(ctx, lease); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("delete lease %s: %w", s.traitsLeaseName(), err)
-	}
 	return nil
 }

--- a/internal/shim/placement/handle_traits.go
+++ b/internal/shim/placement/handle_traits.go
@@ -219,7 +219,7 @@ func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		log.Info("created custom traits configmap with new trait", "trait", name)
-		s.syncTraitToUpstream(ctx, name)
+		s.syncTraitToUpstream(ctx, name, r.Header)
 		w.WriteHeader(http.StatusCreated)
 		return
 	}
@@ -252,7 +252,7 @@ func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Info("added custom trait to configmap", "trait", name)
-	s.syncTraitToUpstream(ctx, name)
+	s.syncTraitToUpstream(ctx, name, r.Header)
 	w.WriteHeader(http.StatusCreated)
 }
 
@@ -419,7 +419,7 @@ func (s *Shim) writeTraits(cm *corev1.ConfigMap, traitSet map[string]struct{}) e
 // that endpoints forwarded to upstream (e.g. PUT /resource_providers/{uuid}/traits)
 // can reference locally-created custom traits. Errors are logged but never
 // propagated — upstream may be unreachable and that is acceptable.
-func (s *Shim) syncTraitToUpstream(ctx context.Context, name string) {
+func (s *Shim) syncTraitToUpstream(ctx context.Context, name string, incomingHeader http.Header) {
 	log := logf.FromContext(ctx)
 	if s.httpClient == nil {
 		log.V(1).Info("skipping upstream trait sync, no http client configured", "trait", name)
@@ -440,6 +440,8 @@ func (s *Shim) syncTraitToUpstream(ctx context.Context, name string) {
 		log.Error(err, "failed to create upstream trait request", "trait", name)
 		return
 	}
+	// Forward authentication headers so upstream placement accepts the request.
+	req.Header = incomingHeader.Clone()
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		log.Info("best-effort upstream trait sync failed, upstream may be down", "trait", name, "error", err.Error())

--- a/internal/shim/placement/handle_traits.go
+++ b/internal/shim/placement/handle_traits.go
@@ -4,57 +4,460 @@
 package placement
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+const (
+	configMapKeyTraits       = "traits"
+	traitsLeaseDuration      = 15
+	traitsLeaseRetryInterval = 500 * time.Millisecond
+	traitsLeaseRetryTimeout  = 5 * time.Second
+)
+
+// traitsListResponse matches the OpenStack Placement GET /traits response.
+type traitsListResponse struct {
+	Traits []string `json:"traits"`
+}
+
+func (s *Shim) staticTraitsConfigMapKey() client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: os.Getenv("POD_NAMESPACE"),
+		Name:      s.config.Traits.ConfigMapName,
+	}
+}
+
+func (s *Shim) customTraitsConfigMapKey() client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: os.Getenv("POD_NAMESPACE"),
+		Name:      s.config.Traits.ConfigMapName + "-custom",
+	}
+}
 
 // HandleListTraits handles GET /traits requests.
 //
-// Returns a list of valid trait strings. Traits describe qualitative aspects
-// of a resource provider (e.g. HW_CPU_X86_AVX2, STORAGE_DISK_SSD). The list
-// includes both standard traits from the os-traits library and custom traits
-// prefixed with CUSTOM_.
-//
-// Supports optional query parameters: name allows filtering by prefix
-// (startswith:CUSTOM) or by an explicit list (in:TRAIT1,TRAIT2), and
-// associated filters to only traits that are or are not associated with at
-// least one resource provider.
+// Returns a sorted list of trait strings merged from the static (Helm-managed)
+// and dynamic (CUSTOM_*) ConfigMaps. Supports optional query parameter "name"
+// for filtering: "in:TRAIT_A,TRAIT_B" returns only named traits,
+// "startswith:CUSTOM_" returns prefix matches.
 func (s *Shim) HandleListTraits(w http.ResponseWriter, r *http.Request) {
-	s.forward(w, r)
+	if !s.config.Features.EnableTraits {
+		s.forward(w, r)
+		return
+	}
+	traitSet, err := s.getAllTraits(r.Context())
+	if err != nil {
+		http.Error(w, "failed to list traits", http.StatusInternalServerError)
+		return
+	}
+
+	all := make([]string, 0, len(traitSet))
+	for t := range traitSet {
+		all = append(all, t)
+	}
+	sort.Strings(all)
+
+	nameFilter := r.URL.Query().Get("name")
+	if nameFilter == "" {
+		s.writeJSON(w, http.StatusOK, traitsListResponse{Traits: all})
+		return
+	}
+	if after, ok := strings.CutPrefix(nameFilter, "in:"); ok {
+		wanted := make(map[string]struct{})
+		for n := range strings.SplitSeq(after, ",") {
+			wanted[n] = struct{}{}
+		}
+		filtered := make([]string, 0, len(wanted))
+		for _, t := range all {
+			if _, ok := wanted[t]; ok {
+				filtered = append(filtered, t)
+			}
+		}
+		s.writeJSON(w, http.StatusOK, traitsListResponse{Traits: filtered})
+		return
+	}
+	if after, ok := strings.CutPrefix(nameFilter, "startswith:"); ok {
+		filtered := make([]string, 0)
+		for _, t := range all {
+			if strings.HasPrefix(t, after) {
+				filtered = append(filtered, t)
+			}
+		}
+		s.writeJSON(w, http.StatusOK, traitsListResponse{Traits: filtered})
+		return
+	}
+	s.writeJSON(w, http.StatusOK, traitsListResponse{Traits: all})
 }
 
 // HandleShowTrait handles GET /traits/{name} requests.
 //
-// Checks whether a trait with the given name exists. Returns 204 No Content
-// (with no response body) if the trait is found, or 404 Not Found otherwise.
+// Checks whether a trait with the given name exists in either the static
+// or dynamic ConfigMap. Returns 200 OK if found, 404 Not Found otherwise.
 func (s *Shim) HandleShowTrait(w http.ResponseWriter, r *http.Request) {
-	if _, ok := requiredPathParam(w, r, "name"); !ok {
+	if !s.config.Features.EnableTraits {
+		s.forward(w, r)
 		return
 	}
-	s.forward(w, r)
+	name, ok := requiredPathParam(w, r, "name")
+	if !ok {
+		return
+	}
+	found, err := s.hasTrait(r.Context(), name)
+	if err != nil {
+		http.Error(w, "failed to check trait", http.StatusInternalServerError)
+		return
+	}
+	if !found {
+		http.Error(w, "trait not found", http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 // HandleUpdateTrait handles PUT /traits/{name} requests.
 //
-// Creates a new custom trait. Only traits prefixed with CUSTOM_ may be
-// created; standard traits are read-only. Returns 201 Created if the trait
-// is newly inserted, or 204 No Content if it already exists. Returns 400
-// Bad Request if the name does not carry the CUSTOM_ prefix.
+// Creates a new custom trait in the dynamic ConfigMap. Only traits prefixed
+// with CUSTOM_ may be created. Returns 201 Created if the trait is newly
+// inserted, or 204 No Content if it already exists (in either ConfigMap).
+// Returns 400 Bad Request if the name does not carry the CUSTOM_ prefix.
 func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
-	if _, ok := requiredPathParam(w, r, "name"); !ok {
+	if !s.config.Features.EnableTraits {
+		s.forward(w, r)
 		return
 	}
-	s.forward(w, r)
+	name, ok := requiredPathParam(w, r, "name")
+	if !ok {
+		return
+	}
+	if !strings.HasPrefix(name, "CUSTOM_") {
+		http.Error(w, "trait name must start with CUSTOM_", http.StatusBadRequest)
+		return
+	}
+	ctx := r.Context()
+
+	// Fast path: trait already exists in either ConfigMap (no lock needed).
+	allTraits, err := s.getAllTraits(ctx)
+	if err != nil {
+		http.Error(w, "failed to create trait", http.StatusInternalServerError)
+		return
+	}
+	if _, exists := allTraits[name]; exists {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// Slow path: acquire lock, read/create dynamic ConfigMap, add trait.
+	if err := s.acquireTraitsLease(ctx); err != nil {
+		http.Error(w, "failed to create trait", http.StatusInternalServerError)
+		return
+	}
+	defer func() {
+		if err := s.releaseTraitsLease(ctx); err != nil {
+			logf.FromContext(ctx).Error(err, "Failed to release traits lease")
+		}
+	}()
+
+	cm := &corev1.ConfigMap{}
+	err = s.Get(ctx, s.customTraitsConfigMapKey(), cm)
+	if apierrors.IsNotFound(err) {
+		// Dynamic ConfigMap doesn't exist yet — create it with the new trait.
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      s.customTraitsConfigMapKey().Name,
+				Namespace: s.customTraitsConfigMapKey().Namespace,
+			},
+			Data: map[string]string{configMapKeyTraits: "[]"},
+		}
+		current := map[string]struct{}{name: {}}
+		if err := s.writeTraits(cm, current); err != nil {
+			http.Error(w, "failed to create trait", http.StatusInternalServerError)
+			return
+		}
+		if err := s.Create(ctx, cm); err != nil {
+			http.Error(w, "failed to create trait", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		return
+	}
+	if err != nil {
+		http.Error(w, "failed to create trait", http.StatusInternalServerError)
+		return
+	}
+
+	current, err := parseTraits(cm)
+	if err != nil {
+		http.Error(w, "failed to create trait", http.StatusInternalServerError)
+		return
+	}
+	if _, exists := current[name]; exists {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	current[name] = struct{}{}
+	if err := s.writeTraits(cm, current); err != nil {
+		http.Error(w, "failed to create trait", http.StatusInternalServerError)
+		return
+	}
+	if err := s.Update(ctx, cm); err != nil {
+		http.Error(w, "failed to create trait", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
 }
 
 // HandleDeleteTrait handles DELETE /traits/{name} requests.
 //
-// Deletes a custom trait. Standard traits (those without the CUSTOM_ prefix)
-// cannot be deleted and will return 400 Bad Request. Returns 409 Conflict if
-// the trait is still associated with any resource provider. Returns 404 if
-// the trait does not exist. Returns 204 No Content on success.
+// Deletes a custom trait from the dynamic ConfigMap. Standard traits (those
+// without the CUSTOM_ prefix) cannot be deleted and return 400 Bad Request.
+// Returns 404 if the trait does not exist. Returns 204 No Content on success.
 func (s *Shim) HandleDeleteTrait(w http.ResponseWriter, r *http.Request) {
-	if _, ok := requiredPathParam(w, r, "name"); !ok {
+	if !s.config.Features.EnableTraits {
+		s.forward(w, r)
 		return
 	}
-	s.forward(w, r)
+	name, ok := requiredPathParam(w, r, "name")
+	if !ok {
+		return
+	}
+	if !strings.HasPrefix(name, "CUSTOM_") {
+		http.Error(w, "cannot delete standard traits", http.StatusBadRequest)
+		return
+	}
+	ctx := r.Context()
+
+	if err := s.acquireTraitsLease(ctx); err != nil {
+		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
+		return
+	}
+	defer func() {
+		if err := s.releaseTraitsLease(ctx); err != nil {
+			logf.FromContext(ctx).Error(err, "Failed to release traits lease")
+		}
+	}()
+
+	cm := &corev1.ConfigMap{}
+	err := s.Get(ctx, s.customTraitsConfigMapKey(), cm)
+	if apierrors.IsNotFound(err) {
+		http.Error(w, "trait not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
+		return
+	}
+	current, err := parseTraits(cm)
+	if err != nil {
+		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
+		return
+	}
+	if _, exists := current[name]; !exists {
+		http.Error(w, "trait not found", http.StatusNotFound)
+		return
+	}
+	delete(current, name)
+	if err := s.writeTraits(cm, current); err != nil {
+		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
+		return
+	}
+	if err := s.Update(ctx, cm); err != nil {
+		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// getStaticTraits reads traits from the Helm-managed static ConfigMap.
+func (s *Shim) getStaticTraits(ctx context.Context) (map[string]struct{}, error) {
+	cm := &corev1.ConfigMap{}
+	if err := s.Get(ctx, s.staticTraitsConfigMapKey(), cm); err != nil {
+		return nil, fmt.Errorf("get static configmap %s: %w", s.config.Traits.ConfigMapName, err)
+	}
+	return parseTraits(cm)
+}
+
+// getCustomTraits reads traits from the dynamic ConfigMap created by the shim.
+// Returns an empty set if the ConfigMap does not exist yet.
+func (s *Shim) getCustomTraits(ctx context.Context) (map[string]struct{}, error) {
+	cm := &corev1.ConfigMap{}
+	err := s.Get(ctx, s.customTraitsConfigMapKey(), cm)
+	if apierrors.IsNotFound(err) {
+		return make(map[string]struct{}), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get custom configmap %s-custom: %w", s.config.Traits.ConfigMapName, err)
+	}
+	return parseTraits(cm)
+}
+
+// getAllTraits merges static and custom traits into a single set.
+func (s *Shim) getAllTraits(ctx context.Context) (map[string]struct{}, error) {
+	static, err := s.getStaticTraits(ctx)
+	if err != nil {
+		return nil, err
+	}
+	custom, err := s.getCustomTraits(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for t := range custom {
+		static[t] = struct{}{}
+	}
+	return static, nil
+}
+
+// parseTraits extracts the trait set from a ConfigMap.
+func parseTraits(cm *corev1.ConfigMap) (map[string]struct{}, error) {
+	raw, ok := cm.Data[configMapKeyTraits]
+	if !ok || raw == "" {
+		return make(map[string]struct{}), nil
+	}
+	var traits []string
+	if err := json.Unmarshal([]byte(raw), &traits); err != nil {
+		return nil, fmt.Errorf("unmarshal traits from configmap: %w", err)
+	}
+	m := make(map[string]struct{}, len(traits))
+	for _, t := range traits {
+		m[t] = struct{}{}
+	}
+	return m, nil
+}
+
+func (s *Shim) hasTrait(ctx context.Context, name string) (bool, error) {
+	traits, err := s.getAllTraits(ctx)
+	if err != nil {
+		return false, err
+	}
+	_, ok := traits[name]
+	return ok, nil
+}
+
+// writeTraits serializes the trait set into the ConfigMap's data field.
+func (s *Shim) writeTraits(cm *corev1.ConfigMap, traitSet map[string]struct{}) error {
+	traits := make([]string, 0, len(traitSet))
+	for t := range traitSet {
+		traits = append(traits, t)
+	}
+	sort.Strings(traits)
+
+	data, err := json.Marshal(traits)
+	if err != nil {
+		return fmt.Errorf("marshal traits: %w", err)
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[configMapKeyTraits] = string(data)
+	return nil
+}
+
+// traitsLeaseName returns the Lease resource name used for locking writes.
+func (s *Shim) traitsLeaseName() string {
+	return s.config.Traits.ConfigMapName + "-lock"
+}
+
+// acquireTraitsLease attempts to acquire a Kubernetes Lease for serializing
+// ConfigMap writes. It retries with backoff until the lease is acquired or
+// the timeout expires.
+func (s *Shim) acquireTraitsLease(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	name := s.traitsLeaseName()
+	ns := os.Getenv("POD_NAMESPACE")
+	holderID := fmt.Sprintf("shim-%d", time.Now().UnixNano())
+	leaseDuration := int32(traitsLeaseDuration)
+
+	deadline := time.Now().Add(traitsLeaseRetryTimeout)
+	for {
+		now := metav1.NewMicroTime(time.Now())
+		lease := &coordinationv1.Lease{}
+		err := s.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, lease)
+
+		if apierrors.IsNotFound(err) {
+			lease = &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity:       &holderID,
+					LeaseDurationSeconds: &leaseDuration,
+					AcquireTime:          &now,
+					RenewTime:            &now,
+				},
+			}
+			if err := s.Create(ctx, lease); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					if time.Now().After(deadline) {
+						return fmt.Errorf("timeout acquiring traits lease %s", name)
+					}
+					time.Sleep(traitsLeaseRetryInterval)
+					continue
+				}
+				return fmt.Errorf("create lease %s: %w", name, err)
+			}
+			log.V(2).Info("Acquired traits lease", "lease", name)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("get lease %s: %w", name, err)
+		}
+
+		// Check if the existing lease has expired.
+		if lease.Spec.RenewTime != nil && lease.Spec.LeaseDurationSeconds != nil {
+			expiry := lease.Spec.RenewTime.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second)
+			if time.Now().Before(expiry) {
+				if time.Now().After(deadline) {
+					return fmt.Errorf("timeout acquiring traits lease %s", name)
+				}
+				time.Sleep(traitsLeaseRetryInterval)
+				continue
+			}
+		}
+
+		// Lease expired — claim it.
+		lease.Spec.HolderIdentity = &holderID
+		lease.Spec.LeaseDurationSeconds = &leaseDuration
+		lease.Spec.AcquireTime = &now
+		lease.Spec.RenewTime = &now
+		if err := s.Update(ctx, lease); err != nil {
+			if apierrors.IsConflict(err) {
+				if time.Now().After(deadline) {
+					return fmt.Errorf("timeout acquiring traits lease %s", name)
+				}
+				time.Sleep(traitsLeaseRetryInterval)
+				continue
+			}
+			return fmt.Errorf("update lease %s: %w", name, err)
+		}
+		log.V(2).Info("Acquired expired traits lease", "lease", name)
+		return nil
+	}
+}
+
+// releaseTraitsLease deletes the Lease resource to allow other replicas to proceed.
+func (s *Shim) releaseTraitsLease(ctx context.Context) error {
+	ns := os.Getenv("POD_NAMESPACE")
+	lease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.traitsLeaseName(),
+			Namespace: ns,
+		},
+	}
+	if err := s.Delete(ctx, lease); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete lease %s: %w", s.traitsLeaseName(), err)
+	}
+	return nil
 }

--- a/internal/shim/placement/handle_traits.go
+++ b/internal/shim/placement/handle_traits.go
@@ -114,7 +114,7 @@ func (s *Shim) HandleListTraits(w http.ResponseWriter, r *http.Request) {
 // HandleShowTrait handles GET /traits/{name} requests.
 //
 // Checks whether a trait with the given name exists in either the static
-// or dynamic ConfigMap. Returns 200 OK if found, 404 Not Found otherwise.
+// or dynamic ConfigMap. Returns 204 No Content if found, 404 Not Found otherwise.
 //
 // See: https://docs.openstack.org/api-ref/placement/#show-traits
 func (s *Shim) HandleShowTrait(w http.ResponseWriter, r *http.Request) {
@@ -141,7 +141,7 @@ func (s *Shim) HandleShowTrait(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Info("trait found", "trait", name)
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // HandleUpdateTrait handles PUT /traits/{name} requests.
@@ -184,14 +184,20 @@ func (s *Shim) HandleUpdateTrait(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Slow path: acquire lock, read/create dynamic ConfigMap, add trait.
-	lockerID := fmt.Sprintf("shim-%d", time.Now().UnixNano())
+	host, err := os.Hostname()
+	if err != nil {
+		host = "unknown"
+	}
+	lockerID := fmt.Sprintf("shim-%s-%d", host, time.Now().UnixNano())
 	if err := s.resourceLocker.AcquireLock(ctx, s.traitsLockName(), lockerID); err != nil {
 		log.Error(err, "failed to acquire traits lock", "trait", name)
 		http.Error(w, "failed to create trait", http.StatusInternalServerError)
 		return
 	}
 	defer func() {
-		if err := s.resourceLocker.ReleaseLock(ctx, s.traitsLockName(), lockerID); err != nil {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.resourceLocker.ReleaseLock(releaseCtx, s.traitsLockName(), lockerID); err != nil {
 			log.Error(err, "failed to release traits lock")
 		}
 	}()
@@ -281,20 +287,26 @@ func (s *Shim) HandleDeleteTrait(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lockerID := fmt.Sprintf("shim-%d", time.Now().UnixNano())
+	host, err := os.Hostname()
+	if err != nil {
+		host = "unknown"
+	}
+	lockerID := fmt.Sprintf("shim-%s-%d", host, time.Now().UnixNano())
 	if err := s.resourceLocker.AcquireLock(ctx, s.traitsLockName(), lockerID); err != nil {
 		log.Error(err, "failed to acquire traits lock", "trait", name)
 		http.Error(w, "failed to delete trait", http.StatusInternalServerError)
 		return
 	}
 	defer func() {
-		if err := s.resourceLocker.ReleaseLock(ctx, s.traitsLockName(), lockerID); err != nil {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.resourceLocker.ReleaseLock(releaseCtx, s.traitsLockName(), lockerID); err != nil {
 			log.Error(err, "failed to release traits lock")
 		}
 	}()
 
 	cm := &corev1.ConfigMap{}
-	err := s.Get(ctx, s.customTraitsConfigMapKey(), cm)
+	err = s.Get(ctx, s.customTraitsConfigMapKey(), cm)
 	if apierrors.IsNotFound(err) {
 		log.Info("custom traits configmap not found, trait does not exist", "trait", name)
 		http.Error(w, "trait not found", http.StatusNotFound)

--- a/internal/shim/placement/handle_traits_e2e.go
+++ b/internal/shim/placement/handle_traits_e2e.go
@@ -6,6 +6,7 @@ package placement
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -16,11 +17,24 @@ import (
 
 // e2eTestTraits tests the /traits and /traits/{name} endpoints.
 //
-//  1. Pre-cleanup: DELETE any leftover custom test trait (ignore 404).
-//  2. GET /traits — list all traits and verify a successful response.
-//  3. GET /traits/{name} — retrieve 5 individual existing traits by name.
-//  4. PUT /traits/{name} — create a custom test trait (CUSTOM_CORTEX_...).
-//  5. DELETE /traits/{name} — remove the custom test trait to clean up.
+// Phase 1 — read-only (always runs):
+//
+//  1. GET /traits — list all traits and verify the response contains at least
+//     one trait.
+//  2. GET /traits/{name} — show a known trait from the list and verify 200.
+//  3. GET /traits/{name} — show a nonexistent trait and verify 404.
+//
+// Phase 2 — CRUD (only when enableTraits is true):
+//
+//  1. Pre-cleanup: DELETE any leftover test trait (ignore 404).
+//  2. PUT /traits/{name} — create a custom test trait → 201.
+//  3. PUT /traits/{name} — idempotent create → 204.
+//  4. GET /traits/{name} — verify the custom trait exists → 200.
+//  5. GET /traits?name=in:{name} — verify the trait appears in filtered list.
+//  6. DELETE /traits/{name} — remove the custom trait → 204.
+//  7. GET /traits/{name} — confirm deletion → 404.
+//  8. PUT /traits/{name} — bad prefix → 400.
+//  9. DELETE /traits/{name} — bad prefix → 400.
 func e2eTestTraits(ctx context.Context, _ client.Client) error {
 	log := logf.FromContext(ctx)
 	log.Info("Running traits endpoint e2e test")
@@ -37,151 +51,271 @@ func e2eTestTraits(ctx context.Context, _ client.Client) error {
 	}
 	log.Info("Successfully created openstack client for traits e2e test")
 
-	const testTrait = "CUSTOM_CORTEX_PLACEMENT_SHIM_E2E_TEST_TRAIT"
-	const apiVersion = "placement 1.6"
+	// ==================== Phase 1: read-only tests ====================
 
-	// Pre-cleanup: delete leftover test trait from a prior run.
-	log.Info("Pre-cleanup: deleting leftover test trait", "trait", testTrait)
-	req, err := http.NewRequestWithContext(ctx,
-		http.MethodDelete, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
-	if err != nil {
-		log.Error(err, "failed to create pre-cleanup request")
-		return err
-	}
-	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", apiVersion)
-	resp, err := sc.HTTPClient.Do(req)
-	if err != nil {
-		log.Error(err, "failed to send pre-cleanup request")
-		return err
-	}
-	defer resp.Body.Close()
-	log.Info("Pre-cleanup completed", "status", resp.StatusCode)
+	log.Info("=== Phase 1: read-only trait tests ===")
 
 	// Test GET /traits
-	log.Info("Testing GET /traits endpoint of placement shim")
-	req, err = http.NewRequestWithContext(ctx,
+	log.Info("Testing GET /traits endpoint")
+	req, err := http.NewRequestWithContext(ctx,
 		http.MethodGet, sc.Endpoint+"/traits", http.NoBody)
 	if err != nil {
-		log.Error(err, "failed to create request for traits endpoint")
-		return err
+		return fmt.Errorf("failed to create GET /traits request: %w", err)
 	}
 	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
 	req.Header.Set("Accept", "application/json")
-	resp, err = sc.HTTPClient.Do(req)
+	resp, err := sc.HTTPClient.Do(req)
 	if err != nil {
-		log.Error(err, "failed to send request to placement shim /traits endpoint")
-		return err
+		return fmt.Errorf("failed to send GET /traits request: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		log.Error(err, "placement shim /traits endpoint returned an error")
-		return err
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET /traits: expected 200, got %d", resp.StatusCode)
 	}
-	var list struct {
+	var listResp struct {
 		Traits []string `json:"traits"`
 	}
-	err = json.NewDecoder(resp.Body).Decode(&list)
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+		return fmt.Errorf("failed to decode GET /traits response: %w", err)
+	}
+	if len(listResp.Traits) == 0 {
+		return errors.New("GET /traits: expected at least one trait, got 0")
+	}
+	log.Info("Successfully retrieved traits", "count", len(listResp.Traits))
+
+	// Test GET /traits/{name} for a known trait.
+	knownTrait := listResp.Traits[0]
+	log.Info("Testing GET /traits/{name} for known trait", "trait", knownTrait)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/traits/"+knownTrait, http.NoBody)
 	if err != nil {
-		log.Error(err, "failed to decode response from placement shim /traits endpoint")
-		return err
+		return fmt.Errorf("failed to create GET request for trait %s: %w", knownTrait, err)
 	}
-	log.Info("Successfully retrieved traits from placement shim",
-		"traits", len(list.Traits))
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send GET request for trait %s: %w", knownTrait, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET /traits/%s: expected 200, got %d", knownTrait, resp.StatusCode)
+	}
+	log.Info("Successfully verified known trait exists", "trait", knownTrait)
 
-	// Test GET /traits/{name}
-	log.Info("Testing GET /traits/{name} endpoint of placement shim")
-	traitsToTest := list.Traits
-	if len(traitsToTest) > 5 {
-		traitsToTest = traitsToTest[:5]
+	// Test GET /traits/{name} for a nonexistent trait.
+	log.Info("Testing GET /traits/{name} for nonexistent trait")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/traits/CUSTOM_CORTEX_E2E_NONEXISTENT", http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create GET request for nonexistent trait: %w", err)
 	}
-	for _, trait := range traitsToTest { // Test only the first 5 traits to save time.
-		log.Info("Testing trait", "trait", trait)
-		traitReq, err := http.NewRequestWithContext(ctx,
-			http.MethodGet, sc.Endpoint+"/traits/"+trait, http.NoBody)
-		if err != nil {
-			log.Error(err, "failed to create request for traits/{name} endpoint",
-				"trait", trait)
-			return err
-		}
-		traitReq.Header.Set("X-Auth-Token", sc.TokenID)
-		traitReq.Header.Set("OpenStack-API-Version", apiVersion)
-		traitReq.Header.Set("Accept", "application/json")
-		traitResp, err := sc.HTTPClient.Do(traitReq)
-		if err != nil {
-			log.Error(err, "failed to send request to placement shim /traits/{name} endpoint",
-				"trait", trait)
-			return err
-		}
-		if traitResp.StatusCode < 200 || traitResp.StatusCode >= 300 {
-			traitResp.Body.Close()
-			err := fmt.Errorf("unexpected status code: %d", traitResp.StatusCode)
-			log.Error(err, "placement shim /traits/{name} endpoint returned an error",
-				"trait", trait)
-			return err
-		}
-		traitResp.Body.Close()
-		log.Info("Successfully retrieved trait from placement shim /traits/{name} endpoint",
-			"trait", trait)
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send GET request for nonexistent trait: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("GET /traits/CUSTOM_CORTEX_E2E_NONEXISTENT: expected 404, got %d", resp.StatusCode)
+	}
+	log.Info("Correctly received 404 for nonexistent trait")
+
+	// ==================== Phase 2: CRUD tests (feature-gated) ====================
+
+	if !config.Features.EnableTraits {
+		log.Info("Skipping trait CRUD e2e tests because enableTraits is false")
+		return nil
 	}
 
-	// Test PUT /traits/{name}
-	log.Info("Testing PUT /traits/{name} endpoint of placement shim", "testTrait", testTrait)
+	log.Info("=== Phase 2: CRUD trait tests (enableTraits=true) ===")
+
+	const testTrait = "CUSTOM_CORTEX_E2E_TRAIT"
+
+	// Pre-cleanup: delete any leftover test trait from a prior run.
+	log.Info("Pre-cleanup: deleting leftover test trait", "trait", testTrait)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create pre-cleanup request: %w", err)
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send pre-cleanup request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("pre-cleanup DELETE /traits/%s: unexpected status %d", testTrait, resp.StatusCode)
+	}
+	log.Info("Pre-cleanup completed", "status", resp.StatusCode)
+
+	// Test PUT /traits/{name} — create → 201.
+	log.Info("Testing PUT /traits/{name} to create custom trait", "trait", testTrait)
 	req, err = http.NewRequestWithContext(ctx,
 		http.MethodPut, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
 	if err != nil {
-		log.Error(err, "failed to create request for traits/{name} endpoint",
-			"trait", testTrait)
-		return err
+		return fmt.Errorf("failed to create PUT request for trait %s: %w", testTrait, err)
 	}
 	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", apiVersion)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send PUT request for trait %s: %w", testTrait, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("PUT /traits/%s (create): expected 201, got %d", testTrait, resp.StatusCode)
+	}
+	log.Info("Successfully created custom trait", "trait", testTrait)
+
+	// Test PUT /traits/{name} — idempotent → 204.
+	log.Info("Testing PUT /traits/{name} idempotent create", "trait", testTrait)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create idempotent PUT request: %w", err)
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send idempotent PUT request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("PUT /traits/%s (idempotent): expected 204, got %d", testTrait, resp.StatusCode)
+	}
+	log.Info("Successfully verified idempotent PUT", "trait", testTrait)
+
+	// Test GET /traits/{name} — verify exists → 200.
+	log.Info("Testing GET /traits/{name} for custom trait", "trait", testTrait)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create GET request for trait %s: %w", testTrait, err)
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send GET request for trait %s: %w", testTrait, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET /traits/%s: expected 200, got %d", testTrait, resp.StatusCode)
+	}
+	log.Info("Successfully verified custom trait exists", "trait", testTrait)
+
+	// Test GET /traits?name=in:{name} — filtered list.
+	log.Info("Testing GET /traits with in: filter", "trait", testTrait)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/traits?name=in:"+testTrait, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create filtered GET request: %w", err)
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
 	req.Header.Set("Accept", "application/json")
 	resp, err = sc.HTTPClient.Do(req)
 	if err != nil {
-		log.Error(err, "failed to send request to placement shim /traits/{name} endpoint",
-			"trait", testTrait)
-		return err
+		return fmt.Errorf("failed to send filtered GET request: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		log.Error(err, "placement shim /traits/{name} endpoint returned an error",
-			"trait", testTrait)
-		return err
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET /traits?name=in:%s: expected 200, got %d", testTrait, resp.StatusCode)
 	}
-	log.Info("Successfully created trait with placement shim /traits/{name} endpoint",
-		"trait", testTrait)
+	var filteredResp struct {
+		Traits []string `json:"traits"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&filteredResp); err != nil {
+		return fmt.Errorf("failed to decode filtered traits response: %w", err)
+	}
+	if len(filteredResp.Traits) != 1 || filteredResp.Traits[0] != testTrait {
+		return fmt.Errorf("GET /traits?name=in:%s: expected [%s], got %v",
+			testTrait, testTrait, filteredResp.Traits)
+	}
+	log.Info("Successfully verified trait in filtered list", "trait", testTrait)
 
-	// Test DELETE /traits/{name}
-	log.Info("Cleaning up test trait from placement shim", "testTrait", testTrait)
+	// Cleanup: DELETE /traits/{name} → 204.
+	log.Info("Cleaning up test trait", "trait", testTrait)
 	req, err = http.NewRequestWithContext(ctx,
 		http.MethodDelete, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
 	if err != nil {
-		log.Error(err, "failed to create request for traits/{name} endpoint",
-			"trait", testTrait)
-		return err
+		return fmt.Errorf("failed to create DELETE request for trait %s: %w", testTrait, err)
 	}
 	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", apiVersion)
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
 	resp, err = sc.HTTPClient.Do(req)
 	if err != nil {
-		log.Error(err, "failed to send request to placement shim /traits/{name} endpoint",
-			"trait", testTrait)
-		return err
+		return fmt.Errorf("failed to send DELETE request for trait %s: %w", testTrait, err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		err := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		log.Error(err, "placement shim /traits/{name} endpoint returned an error",
-			"trait", testTrait)
-		return err
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("DELETE /traits/%s: expected 204, got %d", testTrait, resp.StatusCode)
 	}
-	log.Info("Successfully deleted test trait with placement shim /traits/{name} endpoint",
-		"trait", testTrait)
+	log.Info("Successfully deleted test trait", "trait", testTrait)
+
+	// Verify deletion: GET → 404.
+	log.Info("Verifying test trait was deleted", "trait", testTrait)
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodGet, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create verification GET request: %w", err)
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send verification GET request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("GET /traits/%s after deletion: expected 404, got %d",
+			testTrait, resp.StatusCode)
+	}
+	log.Info("Verified test trait was deleted", "trait", testTrait)
+
+	// Test PUT /traits/{name} with bad prefix → 400.
+	log.Info("Testing PUT /traits/{name} with non-CUSTOM_ prefix")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodPut, sc.Endpoint+"/traits/HW_CORTEX_E2E_BAD", http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create bad-prefix PUT request: %w", err)
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send bad-prefix PUT request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		return fmt.Errorf("PUT /traits/HW_CORTEX_E2E_BAD: expected 400, got %d", resp.StatusCode)
+	}
+	log.Info("Correctly received 400 for PUT with non-CUSTOM_ prefix")
+
+	// Test DELETE /traits/{name} with bad prefix → 400.
+	log.Info("Testing DELETE /traits/{name} with non-CUSTOM_ prefix")
+	req, err = http.NewRequestWithContext(ctx,
+		http.MethodDelete, sc.Endpoint+"/traits/HW_CORTEX_E2E_BAD", http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create bad-prefix DELETE request: %w", err)
+	}
+	req.Header.Set("X-Auth-Token", sc.TokenID)
+	req.Header.Set("OpenStack-API-Version", "placement 1.6")
+	resp, err = sc.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send bad-prefix DELETE request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		return fmt.Errorf("DELETE /traits/HW_CORTEX_E2E_BAD: expected 400, got %d", resp.StatusCode)
+	}
+	log.Info("Correctly received 400 for DELETE with non-CUSTOM_ prefix")
 
 	return nil
 }

--- a/internal/shim/placement/handle_traits_e2e.go
+++ b/internal/shim/placement/handle_traits_e2e.go
@@ -104,8 +104,8 @@ func e2eTestTraits(ctx context.Context, _ client.Client) error {
 			return fmt.Errorf("failed to send GET request for trait %s: %w", knownTrait, err)
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("GET /traits/%s: expected 200, got %d", knownTrait, resp.StatusCode)
+		if resp.StatusCode != http.StatusNoContent {
+			return fmt.Errorf("GET /traits/%s: expected 204, got %d", knownTrait, resp.StatusCode)
 		}
 		log.Info("Successfully verified known trait exists", "trait", knownTrait)
 	} else {
@@ -199,7 +199,7 @@ func e2eTestTraits(ctx context.Context, _ client.Client) error {
 	}
 	log.Info("Successfully verified idempotent PUT", "trait", testTrait)
 
-	// Test GET /traits/{name} — verify exists → 200.
+	// Test GET /traits/{name} — verify exists → 204.
 	log.Info("Testing GET /traits/{name} for custom trait", "trait", testTrait)
 	req, err = http.NewRequestWithContext(ctx,
 		http.MethodGet, sc.Endpoint+"/traits/"+testTrait, http.NoBody)
@@ -213,8 +213,8 @@ func e2eTestTraits(ctx context.Context, _ client.Client) error {
 		return fmt.Errorf("failed to send GET request for trait %s: %w", testTrait, err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("GET /traits/%s: expected 200, got %d", testTrait, resp.StatusCode)
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("GET /traits/%s: expected 204, got %d", testTrait, resp.StatusCode)
 	}
 	log.Info("Successfully verified custom trait exists", "trait", testTrait)
 

--- a/internal/shim/placement/handle_traits_e2e.go
+++ b/internal/shim/placement/handle_traits_e2e.go
@@ -19,9 +19,10 @@ import (
 //
 // Phase 1 — read-only (always runs):
 //
-//  1. GET /traits — list all traits and verify the response contains at least
-//     one trait.
-//  2. GET /traits/{name} — show a known trait from the list and verify 200.
+//  1. GET /traits — list all traits; when forwarding to upstream (enableTraits
+//     is false) verify at least one trait exists.
+//  2. GET /traits/{name} — show a known trait from the list and verify 200
+//     (skipped when the trait list is empty).
 //  3. GET /traits/{name} — show a nonexistent trait and verify 404.
 //
 // Phase 2 — CRUD (only when enableTraits is true):
@@ -79,30 +80,37 @@ func e2eTestTraits(ctx context.Context, _ client.Client) error {
 	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
 		return fmt.Errorf("failed to decode GET /traits response: %w", err)
 	}
-	if len(listResp.Traits) == 0 {
+	// When traits are served locally (enableTraits=true) the static list may
+	// be empty. Only require at least one trait when forwarding to upstream
+	// placement, which always has standard traits.
+	if !config.Features.EnableTraits && len(listResp.Traits) == 0 {
 		return errors.New("GET /traits: expected at least one trait, got 0")
 	}
 	log.Info("Successfully retrieved traits", "count", len(listResp.Traits))
 
-	// Test GET /traits/{name} for a known trait.
-	knownTrait := listResp.Traits[0]
-	log.Info("Testing GET /traits/{name} for known trait", "trait", knownTrait)
-	req, err = http.NewRequestWithContext(ctx,
-		http.MethodGet, sc.Endpoint+"/traits/"+knownTrait, http.NoBody)
-	if err != nil {
-		return fmt.Errorf("failed to create GET request for trait %s: %w", knownTrait, err)
+	// Test GET /traits/{name} for a known trait (skip when the list is empty).
+	if len(listResp.Traits) > 0 {
+		knownTrait := listResp.Traits[0]
+		log.Info("Testing GET /traits/{name} for known trait", "trait", knownTrait)
+		req, err = http.NewRequestWithContext(ctx,
+			http.MethodGet, sc.Endpoint+"/traits/"+knownTrait, http.NoBody)
+		if err != nil {
+			return fmt.Errorf("failed to create GET request for trait %s: %w", knownTrait, err)
+		}
+		req.Header.Set("X-Auth-Token", sc.TokenID)
+		req.Header.Set("OpenStack-API-Version", "placement 1.6")
+		resp, err = sc.HTTPClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to send GET request for trait %s: %w", knownTrait, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("GET /traits/%s: expected 200, got %d", knownTrait, resp.StatusCode)
+		}
+		log.Info("Successfully verified known trait exists", "trait", knownTrait)
+	} else {
+		log.Info("Skipping GET /traits/{name} for known trait, trait list is empty")
 	}
-	req.Header.Set("X-Auth-Token", sc.TokenID)
-	req.Header.Set("OpenStack-API-Version", "placement 1.6")
-	resp, err = sc.HTTPClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to send GET request for trait %s: %w", knownTrait, err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("GET /traits/%s: expected 200, got %d", knownTrait, resp.StatusCode)
-	}
-	log.Info("Successfully verified known trait exists", "trait", knownTrait)
 
 	// Test GET /traits/{name} for a nonexistent trait.
 	log.Info("Testing GET /traits/{name} for nonexistent trait")

--- a/internal/shim/placement/handle_traits_test.go
+++ b/internal/shim/placement/handle_traits_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/cobaltcore-dev/cortex/pkg/resourcelock"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,6 +61,7 @@ func newTraitShim(t *testing.T, staticTraits []string, customTraits ...string) *
 		maxBodyLogSize:         4096,
 		downstreamRequestTimer: down,
 		upstreamRequestTimer:   up,
+		resourceLocker:         resourcelock.NewResourceLocker(cl, "default"),
 	}
 }
 
@@ -305,37 +307,5 @@ func TestHandleDeleteTraitLocalBadPrefix(t *testing.T) {
 	w := serveHandler(t, "DELETE", "/traits/{name}", s.HandleDeleteTrait, "/traits/HW_CPU")
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
-	}
-}
-
-func TestLeaseAcquireRelease(t *testing.T) {
-	t.Setenv("POD_NAMESPACE", "default")
-	cm := newTestConfigMap("default", "test-cm", nil)
-	cl := newFakeClientWithScheme(t, cm)
-	s := &Shim{
-		Client: cl,
-		config: config{Traits: &traitsConfig{ConfigMapName: "test-cm"}},
-	}
-	ctx := context.Background()
-
-	if err := s.acquireTraitsLease(ctx); err != nil {
-		t.Fatalf("acquireTraitsLease: %v", err)
-	}
-
-	lease := &coordinationv1.Lease{}
-	if err := cl.Get(ctx, client.ObjectKey{Namespace: "default", Name: s.traitsLeaseName()}, lease); err != nil {
-		t.Fatalf("get lease: %v", err)
-	}
-	if lease.Spec.HolderIdentity == nil {
-		t.Fatal("expected holder identity to be set")
-	}
-
-	if err := s.releaseTraitsLease(ctx); err != nil {
-		t.Fatalf("releaseTraitsLease: %v", err)
-	}
-
-	err := cl.Get(ctx, client.ObjectKey{Namespace: "default", Name: s.traitsLeaseName()}, lease)
-	if err == nil {
-		t.Fatal("expected lease to be deleted")
 	}
 }

--- a/internal/shim/placement/handle_traits_test.go
+++ b/internal/shim/placement/handle_traits_test.go
@@ -264,9 +264,12 @@ func TestHandleUpdateTraitLocalBadPrefix(t *testing.T) {
 	}
 }
 
-func TestHandleUpdateTraitLocalDoesNotCallUpstream(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("upstream should not be called when enableTraits is true")
+func TestHandleUpdateTraitLocalSyncsToUpstream(t *testing.T) {
+	var gotMethod, gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(upstream.Close)
 	s := newTraitShim(t, nil)
@@ -276,6 +279,24 @@ func TestHandleUpdateTraitLocalDoesNotCallUpstream(t *testing.T) {
 	w := serveHandler(t, "PUT", "/traits/{name}", s.HandleUpdateTrait, "/traits/CUSTOM_NEW")
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusCreated)
+	}
+	if gotMethod != "PUT" || gotPath != "/traits/CUSTOM_NEW" {
+		t.Fatalf("upstream got %s %s, want PUT /traits/CUSTOM_NEW", gotMethod, gotPath)
+	}
+}
+
+func TestHandleUpdateTraitLocalUpstreamDown(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(upstream.Close)
+	s := newTraitShim(t, nil)
+	s.config.PlacementURL = upstream.URL
+	s.httpClient = upstream.Client()
+
+	w := serveHandler(t, "PUT", "/traits/{name}", s.HandleUpdateTrait, "/traits/CUSTOM_NEW")
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; upstream failure should not block local creation", w.Code, http.StatusCreated)
 	}
 }
 

--- a/internal/shim/placement/handle_traits_test.go
+++ b/internal/shim/placement/handle_traits_test.go
@@ -4,11 +4,68 @@
 package placement
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestHandleListTraits(t *testing.T) {
+func newFakeClientWithScheme(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := coordinationv1.AddToScheme(s); err != nil {
+		t.Fatalf("add coordination scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+}
+
+func newTestConfigMap(namespace, name string, traits []string) *corev1.ConfigMap {
+	b, err := json.Marshal(traits)
+	if err != nil {
+		panic("marshal traits: " + err.Error())
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data:       map[string]string{configMapKeyTraits: string(b)},
+	}
+}
+
+func newTraitShim(t *testing.T, staticTraits []string, customTraits ...string) *Shim {
+	t.Helper()
+	t.Setenv("POD_NAMESPACE", "default")
+	objs := []client.Object{newTestConfigMap("default", "test-cm", staticTraits)}
+	if len(customTraits) > 0 {
+		objs = append(objs, newTestConfigMap("default", "test-cm-custom", customTraits))
+	}
+	cl := newFakeClientWithScheme(t, objs...)
+	down, up := newTestTimers()
+	return &Shim{
+		Client: cl,
+		config: config{
+			PlacementURL: "http://should-not-be-called:1234",
+			Features:     featuresConfig{EnableTraits: true},
+			Traits:       &traitsConfig{ConfigMapName: "test-cm"},
+		},
+		maxBodyLogSize:         4096,
+		downstreamRequestTimer: down,
+		upstreamRequestTimer:   up,
+	}
+}
+
+// --- Passthrough tests (enableTraits=false) ---
+
+func TestHandleListTraitsPassthrough(t *testing.T) {
 	var gotPath string
 	s := newTestShim(t, http.StatusOK, `{"traits":[]}`, &gotPath)
 	w := serveHandler(t, "GET", "/traits", s.HandleListTraits, "/traits")
@@ -20,7 +77,7 @@ func TestHandleListTraits(t *testing.T) {
 	}
 }
 
-func TestHandleShowTrait(t *testing.T) {
+func TestHandleShowTraitPassthrough(t *testing.T) {
 	var gotPath string
 	s := newTestShim(t, http.StatusNoContent, "", &gotPath)
 	w := serveHandler(t, "GET", "/traits/{name}", s.HandleShowTrait, "/traits/HW_CPU_X86_AVX2")
@@ -32,7 +89,7 @@ func TestHandleShowTrait(t *testing.T) {
 	}
 }
 
-func TestHandleUpdateTrait(t *testing.T) {
+func TestHandleUpdateTraitPassthrough(t *testing.T) {
 	s := newTestShim(t, http.StatusCreated, "", nil)
 	w := serveHandler(t, "PUT", "/traits/{name}", s.HandleUpdateTrait, "/traits/CUSTOM_TRAIT")
 	if w.Code != http.StatusCreated {
@@ -40,10 +97,245 @@ func TestHandleUpdateTrait(t *testing.T) {
 	}
 }
 
-func TestHandleDeleteTrait(t *testing.T) {
+func TestHandleDeleteTraitPassthrough(t *testing.T) {
 	s := newTestShim(t, http.StatusNoContent, "", nil)
 	w := serveHandler(t, "DELETE", "/traits/{name}", s.HandleDeleteTrait, "/traits/CUSTOM_TRAIT")
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
+// --- Handler tests (enableTraits=true) ---
+
+func TestHandleListTraitsLocal(t *testing.T) {
+	s := newTraitShim(t, []string{"CUSTOM_FOO", "HW_CPU_X86_AVX2", "STORAGE_DISK_SSD"})
+
+	w := serveHandler(t, "GET", "/traits", s.HandleListTraits, "/traits")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp traitsListResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Traits) != 3 {
+		t.Fatalf("got %d traits, want 3: %v", len(resp.Traits), resp.Traits)
+	}
+	want := []string{"CUSTOM_FOO", "HW_CPU_X86_AVX2", "STORAGE_DISK_SSD"}
+	for i, g := range resp.Traits {
+		if g != want[i] {
+			t.Errorf("trait[%d] = %q, want %q", i, g, want[i])
+		}
+	}
+}
+
+func TestHandleListTraitsLocalMerged(t *testing.T) {
+	s := newTraitShim(t, []string{"HW_CPU_X86_AVX2"}, "CUSTOM_FOO")
+
+	w := serveHandler(t, "GET", "/traits", s.HandleListTraits, "/traits")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp traitsListResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := []string{"CUSTOM_FOO", "HW_CPU_X86_AVX2"}
+	if len(resp.Traits) != len(want) {
+		t.Fatalf("got %d traits, want %d: %v", len(resp.Traits), len(want), resp.Traits)
+	}
+	for i, g := range resp.Traits {
+		if g != want[i] {
+			t.Errorf("trait[%d] = %q, want %q", i, g, want[i])
+		}
+	}
+}
+
+func TestHandleListTraitsLocalFiltered(t *testing.T) {
+	s := newTraitShim(t, []string{"CUSTOM_A", "CUSTOM_B", "HW_CPU_X86_AVX2"})
+
+	w := serveHandler(t, "GET", "/traits", s.HandleListTraits, "/traits?name=in:CUSTOM_A,HW_CPU_X86_AVX2")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp traitsListResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Traits) != 2 {
+		t.Fatalf("got %d traits, want 2: %v", len(resp.Traits), resp.Traits)
+	}
+}
+
+func TestHandleListTraitsLocalStartsWith(t *testing.T) {
+	s := newTraitShim(t, []string{"CUSTOM_A", "CUSTOM_B", "HW_CPU_X86_AVX2"})
+
+	w := serveHandler(t, "GET", "/traits", s.HandleListTraits, "/traits?name=startswith:CUSTOM_")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp traitsListResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Traits) != 2 {
+		t.Fatalf("got %d traits, want 2: %v", len(resp.Traits), resp.Traits)
+	}
+}
+
+func TestHandleListTraitsLocalFilterUnknown(t *testing.T) {
+	s := newTraitShim(t, []string{"CUSTOM_A"})
+
+	w := serveHandler(t, "GET", "/traits", s.HandleListTraits, "/traits?name=in:UNKNOWN_TRAIT")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp traitsListResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Traits) != 0 {
+		t.Fatalf("got %v, want empty", resp.Traits)
+	}
+}
+
+func TestHandleShowTraitLocalFound(t *testing.T) {
+	s := newTraitShim(t, []string{"HW_CPU_X86_AVX2"})
+	w := serveHandler(t, "GET", "/traits/{name}", s.HandleShowTrait, "/traits/HW_CPU_X86_AVX2")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestHandleShowTraitLocalFoundCustom(t *testing.T) {
+	s := newTraitShim(t, nil, "CUSTOM_FOO")
+	w := serveHandler(t, "GET", "/traits/{name}", s.HandleShowTrait, "/traits/CUSTOM_FOO")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestHandleShowTraitLocalNotFound(t *testing.T) {
+	s := newTraitShim(t, []string{"HW_CPU_X86_AVX2"})
+	w := serveHandler(t, "GET", "/traits/{name}", s.HandleShowTrait, "/traits/NONEXISTENT")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleUpdateTraitLocalCreated(t *testing.T) {
+	s := newTraitShim(t, nil)
+	w := serveHandler(t, "PUT", "/traits/{name}", s.HandleUpdateTrait, "/traits/CUSTOM_NEW")
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusCreated)
+	}
+	found, err := s.hasTrait(context.Background(), "CUSTOM_NEW")
+	if err != nil {
+		t.Fatalf("hasTrait: %v", err)
+	}
+	if !found {
+		t.Error("expected trait to be in store")
+	}
+}
+
+func TestHandleUpdateTraitLocalAlreadyExistsCustom(t *testing.T) {
+	s := newTraitShim(t, nil, "CUSTOM_EXISTING")
+	w := serveHandler(t, "PUT", "/traits/{name}", s.HandleUpdateTrait, "/traits/CUSTOM_EXISTING")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
+func TestHandleUpdateTraitLocalAlreadyExistsStatic(t *testing.T) {
+	s := newTraitShim(t, []string{"HW_CPU_X86_AVX2"})
+	w := serveHandler(t, "PUT", "/traits/{name}", s.HandleUpdateTrait, "/traits/HW_CPU_X86_AVX2")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleUpdateTraitLocalBadPrefix(t *testing.T) {
+	s := newTraitShim(t, nil)
+	w := serveHandler(t, "PUT", "/traits/{name}", s.HandleUpdateTrait, "/traits/HW_NOT_CUSTOM")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleUpdateTraitLocalDoesNotCallUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("upstream should not be called when enableTraits is true")
+	}))
+	t.Cleanup(upstream.Close)
+	s := newTraitShim(t, nil)
+	s.config.PlacementURL = upstream.URL
+	s.httpClient = upstream.Client()
+
+	w := serveHandler(t, "PUT", "/traits/{name}", s.HandleUpdateTrait, "/traits/CUSTOM_NEW")
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusCreated)
+	}
+}
+
+func TestHandleDeleteTraitLocal(t *testing.T) {
+	s := newTraitShim(t, nil, "CUSTOM_DEL")
+	w := serveHandler(t, "DELETE", "/traits/{name}", s.HandleDeleteTrait, "/traits/CUSTOM_DEL")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+	found, err := s.hasTrait(context.Background(), "CUSTOM_DEL")
+	if err != nil {
+		t.Fatalf("hasTrait: %v", err)
+	}
+	if found {
+		t.Error("expected trait to be deleted")
+	}
+}
+
+func TestHandleDeleteTraitLocalNotFound(t *testing.T) {
+	s := newTraitShim(t, nil)
+	w := serveHandler(t, "DELETE", "/traits/{name}", s.HandleDeleteTrait, "/traits/CUSTOM_GONE")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleDeleteTraitLocalBadPrefix(t *testing.T) {
+	s := newTraitShim(t, []string{"HW_CPU"})
+	w := serveHandler(t, "DELETE", "/traits/{name}", s.HandleDeleteTrait, "/traits/HW_CPU")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestLeaseAcquireRelease(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "default")
+	cm := newTestConfigMap("default", "test-cm", nil)
+	cl := newFakeClientWithScheme(t, cm)
+	s := &Shim{
+		Client: cl,
+		config: config{Traits: &traitsConfig{ConfigMapName: "test-cm"}},
+	}
+	ctx := context.Background()
+
+	if err := s.acquireTraitsLease(ctx); err != nil {
+		t.Fatalf("acquireTraitsLease: %v", err)
+	}
+
+	lease := &coordinationv1.Lease{}
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: "default", Name: s.traitsLeaseName()}, lease); err != nil {
+		t.Fatalf("get lease: %v", err)
+	}
+	if lease.Spec.HolderIdentity == nil {
+		t.Fatal("expected holder identity to be set")
+	}
+
+	if err := s.releaseTraitsLease(ctx); err != nil {
+		t.Fatalf("releaseTraitsLease: %v", err)
+	}
+
+	err := cl.Get(ctx, client.ObjectKey{Namespace: "default", Name: s.traitsLeaseName()}, lease)
+	if err == nil {
+		t.Fatal("expected lease to be deleted")
 	}
 }

--- a/internal/shim/placement/handle_traits_test.go
+++ b/internal/shim/placement/handle_traits_test.go
@@ -204,16 +204,16 @@ func TestHandleListTraitsLocalFilterUnknown(t *testing.T) {
 func TestHandleShowTraitLocalFound(t *testing.T) {
 	s := newTraitShim(t, []string{"HW_CPU_X86_AVX2"})
 	w := serveHandler(t, "GET", "/traits/{name}", s.HandleShowTrait, "/traits/HW_CPU_X86_AVX2")
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
 	}
 }
 
 func TestHandleShowTraitLocalFoundCustom(t *testing.T) {
 	s := newTraitShim(t, nil, "CUSTOM_FOO")
 	w := serveHandler(t, "GET", "/traits/{name}", s.HandleShowTrait, "/traits/CUSTOM_FOO")
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
 	}
 }
 

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"time"
 
@@ -60,6 +61,11 @@ type featuresConfig struct {
 	// document from the Versioning config instead of forwarding to
 	// upstream placement. When false, GET / is forwarded as-is.
 	EnableRoot bool `json:"enableRoot,omitempty"`
+	// EnableTraits makes the trait handlers (GET /traits, GET /traits/{name},
+	// PUT /traits/{name}, DELETE /traits/{name}) serve from a local ConfigMap
+	// instead of forwarding to upstream placement. When false, all trait
+	// requests are forwarded as-is.
+	EnableTraits bool `json:"enableTraits,omitempty"`
 }
 
 // versioningConfig describes the Placement API version advertised by the
@@ -69,6 +75,14 @@ type versioningConfig struct {
 	MinVersion string `json:"minVersion"`
 	MaxVersion string `json:"maxVersion"`
 	Status     string `json:"status"`
+}
+
+// traitsConfig configures the local trait store used when
+// features.enableTraits is true.
+type traitsConfig struct {
+	// ConfigMapName is the name of the ConfigMap used to persist traits.
+	// Must exist in the same namespace as the shim pod.
+	ConfigMapName string `json:"configMapName"`
 }
 
 // config holds configuration for the placement shim.
@@ -114,6 +128,9 @@ type config struct {
 	// Versioning configures the static version discovery document returned
 	// by GET / when features.enableRoot is true.
 	Versioning *versioningConfig `json:"versioning,omitempty"`
+	// Traits configures the local trait store used when
+	// features.enableTraits is true.
+	Traits *traitsConfig `json:"traits,omitempty"`
 }
 
 // validate checks the config for required fields and returns an error if the
@@ -128,6 +145,17 @@ func (c *config) validate() error {
 		}
 		if c.Versioning.ID == "" || c.Versioning.MinVersion == "" || c.Versioning.MaxVersion == "" || c.Versioning.Status == "" {
 			return errors.New("versioning id, minVersion, maxVersion, and status are required when features.enableRoot is true")
+		}
+	}
+	if c.Features.EnableTraits {
+		if c.Traits == nil {
+			return errors.New("traits config is required when features.enableTraits is true")
+		}
+		if c.Traits.ConfigMapName == "" {
+			return errors.New("traits.configMapName is required when features.enableTraits is true")
+		}
+		if os.Getenv("POD_NAMESPACE") == "" {
+			return errors.New("POD_NAMESPACE environment variable is required when features.enableTraits is true")
 		}
 	}
 	if c.Auth != nil && c.KeystoneURL == "" {

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -156,7 +156,7 @@ func (c *config) validate() error {
 			return errors.New("traits.configMapName is required when features.enableTraits is true")
 		}
 		if os.Getenv("POD_NAMESPACE") == "" {
-			return errors.New("POD_NAMESPACE environment variable is required when features.enableTraits is true")
+			return errors.New("pod namespace (POD_NAMESPACE) is required when features.enableTraits is true")
 		}
 	}
 	if c.Auth != nil && c.KeystoneURL == "" {

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
 	"github.com/cobaltcore-dev/cortex/pkg/multicluster"
+	"github.com/cobaltcore-dev/cortex/pkg/resourcelock"
 	"github.com/cobaltcore-dev/cortex/pkg/sso"
 	hv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
 	"github.com/prometheus/client_golang/prometheus"
@@ -203,6 +204,9 @@ type Shim struct {
 	tokenCache *tokenCache
 	// tokenIntrospector validates tokens against Keystone.
 	tokenIntrospector tokenIntrospector
+	// resourceLocker serializes writes to the custom traits ConfigMap
+	// across replicas using a Kubernetes Lease.
+	resourceLocker *resourcelock.ResourceLocker
 }
 
 // Describe implements prometheus.Collector.
@@ -345,6 +349,13 @@ func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err erro
 		Help:    "Duration of upstream requests from the placement shim to the placement API.",
 		Buckets: prometheus.DefBuckets,
 	}, []string{"method", "pattern", "responsecode"})
+
+	if s.config.Features.EnableTraits {
+		s.resourceLocker = resourcelock.NewResourceLocker(
+			s.Client,
+			os.Getenv("POD_NAMESPACE"),
+		)
+	}
 
 	// Check that the provided client is a multicluster client, since we need
 	// that to watch for hypervisors across clusters.

--- a/internal/shim/placement/shim_test.go
+++ b/internal/shim/placement/shim_test.go
@@ -470,7 +470,7 @@ func TestConfigValidateEnableTraitsRequiresConfig(t *testing.T) {
 	if err := c.validate(); err == nil {
 		t.Fatal("expected error when traits.configMapName is empty")
 	}
-	c.Traits.ConfigMapName = "cortex-placement-global"
+	c.Traits.ConfigMapName = "cortex-placement-shim-traits"
 	if err := c.validate(); err == nil {
 		t.Fatal("expected error when POD_NAMESPACE is not set")
 	}

--- a/internal/shim/placement/shim_test.go
+++ b/internal/shim/placement/shim_test.go
@@ -458,6 +458,28 @@ func TestConfigValidateEnableRootRequiresVersioning(t *testing.T) {
 	}
 }
 
+func TestConfigValidateEnableTraitsRequiresConfig(t *testing.T) {
+	c := config{
+		PlacementURL: "http://placement:8778",
+		Features:     featuresConfig{EnableTraits: true},
+	}
+	if err := c.validate(); err == nil {
+		t.Fatal("expected error when enableTraits is true without traits config")
+	}
+	c.Traits = &traitsConfig{}
+	if err := c.validate(); err == nil {
+		t.Fatal("expected error when traits.configMapName is empty")
+	}
+	c.Traits.ConfigMapName = "cortex-placement-global"
+	if err := c.validate(); err == nil {
+		t.Fatal("expected error when POD_NAMESPACE is not set")
+	}
+	t.Setenv("POD_NAMESPACE", "default")
+	if err := c.validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestWrapHandlerWithAuth(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/shim/placement/shim_test.go
+++ b/internal/shim/placement/shim_test.go
@@ -459,6 +459,8 @@ func TestConfigValidateEnableRootRequiresVersioning(t *testing.T) {
 }
 
 func TestConfigValidateEnableTraitsRequiresConfig(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+
 	c := config{
 		PlacementURL: "http://placement:8778",
 		Features:     featuresConfig{EnableTraits: true},

--- a/pkg/resourcelock/resourcelock.go
+++ b/pkg/resourcelock/resourcelock.go
@@ -17,8 +17,10 @@
 package resourcelock
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -26,8 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	"context"
 )
 
 // ErrLockHeld is returned when a lock cannot be acquired within the retry
@@ -50,8 +50,24 @@ type ResourceLocker struct {
 type Option func(*ResourceLocker)
 
 // WithLeaseDuration sets the lease duration. Default is 15 seconds.
+// Sub-second values are rounded up to 1 second; non-positive values are ignored.
 func WithLeaseDuration(d time.Duration) Option {
-	return func(rl *ResourceLocker) { rl.leaseDuration = int32(d.Seconds()) }
+	return func(rl *ResourceLocker) {
+		if d <= 0 {
+			return
+		}
+		secs := int64(d / time.Second)
+		if d%time.Second != 0 {
+			secs++
+		}
+		if secs < 1 {
+			secs = 1
+		}
+		if secs > math.MaxInt32 {
+			secs = math.MaxInt32
+		}
+		rl.leaseDuration = int32(secs) // #nosec G115 -- clamped above
+	}
 }
 
 // WithRetryInterval sets the interval between acquire retries. Default is 500ms.
@@ -86,11 +102,13 @@ func NewResourceLocker(c client.Client, namespace string, opts ...Option) *Resou
 // The algorithm has three cases:
 //  1. Lease does not exist — create it and return (lock acquired).
 //  2. Lease exists but is expired — update it to claim ownership.
-//  3. Lease exists and is still valid — sleep and retry until the timeout,
+//  3. Lease exists and is still valid — wait and retry until the timeout,
 //     then return ErrLockHeld.
 //
 // Create and Update conflicts (another replica raced us) are retried
-// transparently within the timeout window.
+// transparently within the timeout window. The wait between retries is
+// context-aware: if ctx is cancelled, AcquireLock returns ctx.Err()
+// immediately instead of blocking.
 func (rl *ResourceLocker) AcquireLock(ctx context.Context, name, lockerID string) error {
 	log := logf.FromContext(ctx).WithValues("namespace", rl.namespace, "lease", name, "locker", lockerID)
 
@@ -117,10 +135,9 @@ func (rl *ResourceLocker) AcquireLock(ctx context.Context, name, lockerID string
 			if err := rl.client.Create(ctx, lease); err != nil {
 				// Another replica created it between our Get and Create.
 				if apierrors.IsAlreadyExists(err) {
-					if time.Now().After(deadline) {
-						return ErrLockHeld
+					if err := rl.waitForRetry(ctx, deadline); err != nil {
+						return err
 					}
-					time.Sleep(rl.retryInterval)
 					continue
 				}
 				return fmt.Errorf("resourcelock: create lease %s: %w", name, err)
@@ -136,10 +153,9 @@ func (rl *ResourceLocker) AcquireLock(ctx context.Context, name, lockerID string
 		if lease.Spec.RenewTime != nil && lease.Spec.LeaseDurationSeconds != nil {
 			expiry := lease.Spec.RenewTime.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second)
 			if time.Now().Before(expiry) {
-				if time.Now().After(deadline) {
-					return ErrLockHeld
+				if err := rl.waitForRetry(ctx, deadline); err != nil {
+					return err
 				}
-				time.Sleep(rl.retryInterval)
 				continue
 			}
 		}
@@ -156,15 +172,33 @@ func (rl *ResourceLocker) AcquireLock(ctx context.Context, name, lockerID string
 		if err := rl.client.Update(ctx, lease); err != nil {
 			// Another replica claimed the expired lease first.
 			if apierrors.IsConflict(err) {
-				if time.Now().After(deadline) {
-					return ErrLockHeld
+				if err := rl.waitForRetry(ctx, deadline); err != nil {
+					return err
 				}
-				time.Sleep(rl.retryInterval)
 				continue
 			}
 			return fmt.Errorf("resourcelock: update lease %s: %w", name, err)
 		}
 		log.V(2).Info("Lock acquired, claimed expired lease", "previousHolder", previousHolder)
+		return nil
+	}
+}
+
+// waitForRetry pauses until retryInterval elapses, the deadline is reached, or
+// ctx is cancelled — whichever comes first. Returns ErrLockHeld when the
+// deadline has passed, or ctx.Err() on cancellation.
+func (rl *ResourceLocker) waitForRetry(ctx context.Context, deadline time.Time) error {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return ErrLockHeld
+	}
+	wait := min(rl.retryInterval, remaining)
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
 		return nil
 	}
 }

--- a/pkg/resourcelock/resourcelock.go
+++ b/pkg/resourcelock/resourcelock.go
@@ -1,0 +1,193 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+// Package resourcelock provides distributed locking for Kubernetes resources
+// using coordination.k8s.io/v1 Lease objects.
+//
+// Locks are short-lived (held for milliseconds during a single write) and are
+// not renewed in the background. This makes the implementation simpler than a
+// full leader-election library while still being safe for serializing
+// concurrent access to a shared resource (e.g. a ConfigMap) across replicas.
+//
+// Usage:
+//
+//	rl := resourcelock.NewResourceLocker(client, "my-namespace")
+//	if err := rl.AcquireLock(ctx, "my-lock", "holder-abc"); err != nil { ... }
+//	defer rl.ReleaseLock(ctx, "my-lock", "holder-abc")
+package resourcelock
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"context"
+)
+
+// ErrLockHeld is returned when a lock cannot be acquired within the retry
+// timeout because another locker holds it.
+var ErrLockHeld = errors.New("resourcelock: lock is held by another locker")
+
+// ResourceLocker acquires and releases distributed locks backed by Kubernetes
+// Lease resources. Each lock is a single Lease object in the configured
+// namespace. The locker creates the Lease on acquire and deletes it on release,
+// so no Lease resources linger after normal operation.
+type ResourceLocker struct {
+	client        client.Client
+	namespace     string
+	leaseDuration int32         // seconds; how long a lease is valid before it expires
+	retryInterval time.Duration // pause between acquire attempts when the lease is held
+	retryTimeout  time.Duration // total time to keep retrying before returning ErrLockHeld
+}
+
+// Option configures a ResourceLocker.
+type Option func(*ResourceLocker)
+
+// WithLeaseDuration sets the lease duration. Default is 15 seconds.
+func WithLeaseDuration(d time.Duration) Option {
+	return func(rl *ResourceLocker) { rl.leaseDuration = int32(d.Seconds()) }
+}
+
+// WithRetryInterval sets the interval between acquire retries. Default is 500ms.
+func WithRetryInterval(d time.Duration) Option {
+	return func(rl *ResourceLocker) { rl.retryInterval = d }
+}
+
+// WithRetryTimeout sets the total time to retry acquiring a held lock. Default is 5s.
+func WithRetryTimeout(d time.Duration) Option {
+	return func(rl *ResourceLocker) { rl.retryTimeout = d }
+}
+
+// NewResourceLocker creates a ResourceLocker that manages Lease resources in
+// the given namespace. Configure behaviour with functional options; the
+// defaults are tuned for short-lived locks that protect a single API call.
+func NewResourceLocker(c client.Client, namespace string, opts ...Option) *ResourceLocker {
+	rl := &ResourceLocker{
+		client:        c,
+		namespace:     namespace,
+		leaseDuration: 15,
+		retryInterval: 500 * time.Millisecond,
+		retryTimeout:  5 * time.Second,
+	}
+	for _, o := range opts {
+		o(rl)
+	}
+	return rl
+}
+
+// AcquireLock tries to acquire a Lease-backed lock identified by name.
+//
+// The algorithm has three cases:
+//  1. Lease does not exist — create it and return (lock acquired).
+//  2. Lease exists but is expired — update it to claim ownership.
+//  3. Lease exists and is still valid — sleep and retry until the timeout,
+//     then return ErrLockHeld.
+//
+// Create and Update conflicts (another replica raced us) are retried
+// transparently within the timeout window.
+func (rl *ResourceLocker) AcquireLock(ctx context.Context, name, lockerID string) error {
+	log := logf.FromContext(ctx).WithValues("namespace", rl.namespace, "lease", name, "locker", lockerID)
+
+	deadline := time.Now().Add(rl.retryTimeout)
+	for {
+		now := metav1.NewMicroTime(time.Now())
+		lease := &coordinationv1.Lease{}
+		err := rl.client.Get(ctx, client.ObjectKey{Namespace: rl.namespace, Name: name}, lease)
+
+		// Case 1: Lease does not exist — create it to acquire the lock.
+		if apierrors.IsNotFound(err) {
+			lease = &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: rl.namespace,
+				},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity:       &lockerID,
+					LeaseDurationSeconds: &rl.leaseDuration,
+					AcquireTime:          &now,
+					RenewTime:            &now,
+				},
+			}
+			if err := rl.client.Create(ctx, lease); err != nil {
+				// Another replica created it between our Get and Create.
+				if apierrors.IsAlreadyExists(err) {
+					if time.Now().After(deadline) {
+						return ErrLockHeld
+					}
+					time.Sleep(rl.retryInterval)
+					continue
+				}
+				return fmt.Errorf("resourcelock: create lease %s: %w", name, err)
+			}
+			log.V(2).Info("Lock acquired, lease created")
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("resourcelock: get lease %s: %w", name, err)
+		}
+
+		// Case 3: Lease is still valid — wait and retry.
+		if lease.Spec.RenewTime != nil && lease.Spec.LeaseDurationSeconds != nil {
+			expiry := lease.Spec.RenewTime.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second)
+			if time.Now().Before(expiry) {
+				if time.Now().After(deadline) {
+					return ErrLockHeld
+				}
+				time.Sleep(rl.retryInterval)
+				continue
+			}
+		}
+
+		// Case 2: Lease expired — claim it by updating the holder.
+		previousHolder := ""
+		if lease.Spec.HolderIdentity != nil {
+			previousHolder = *lease.Spec.HolderIdentity
+		}
+		lease.Spec.HolderIdentity = &lockerID
+		lease.Spec.LeaseDurationSeconds = &rl.leaseDuration
+		lease.Spec.AcquireTime = &now
+		lease.Spec.RenewTime = &now
+		if err := rl.client.Update(ctx, lease); err != nil {
+			// Another replica claimed the expired lease first.
+			if apierrors.IsConflict(err) {
+				if time.Now().After(deadline) {
+					return ErrLockHeld
+				}
+				time.Sleep(rl.retryInterval)
+				continue
+			}
+			return fmt.Errorf("resourcelock: update lease %s: %w", name, err)
+		}
+		log.V(2).Info("Lock acquired, claimed expired lease", "previousHolder", previousHolder)
+		return nil
+	}
+}
+
+// ReleaseLock deletes the Lease if it is held by the given lockerID. If the
+// Lease does not exist or is held by a different locker, this is a no-op.
+// The holder check prevents a slow replica from accidentally releasing a lock
+// that was already re-acquired by someone else.
+func (rl *ResourceLocker) ReleaseLock(ctx context.Context, name, lockerID string) error {
+	lease := &coordinationv1.Lease{}
+	if err := rl.client.Get(ctx, client.ObjectKey{Namespace: rl.namespace, Name: name}, lease); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("resourcelock: get lease %s: %w", name, err)
+	}
+	// Only the current holder may release — avoids deleting a lease that was
+	// re-acquired by another replica after our lock expired.
+	if lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity != lockerID {
+		return nil
+	}
+	if err := rl.client.Delete(ctx, lease); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("resourcelock: delete lease %s: %w", name, err)
+	}
+	return nil
+}

--- a/pkg/resourcelock/resourcelock_test.go
+++ b/pkg/resourcelock/resourcelock_test.go
@@ -1,0 +1,120 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcelock
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newFakeClient(t *testing.T) client.Client {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := coordinationv1.AddToScheme(s); err != nil {
+		t.Fatalf("add coordination scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(s).Build()
+}
+
+func TestAcquireAndRelease(t *testing.T) {
+	cl := newFakeClient(t)
+	rl := NewResourceLocker(cl, "default")
+	ctx := context.Background()
+
+	if err := rl.AcquireLock(ctx, "my-lock", "holder-1"); err != nil {
+		t.Fatalf("AcquireLock: %v", err)
+	}
+
+	lease := &coordinationv1.Lease{}
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: "default", Name: "my-lock"}, lease); err != nil {
+		t.Fatalf("get lease: %v", err)
+	}
+	if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != "holder-1" {
+		t.Fatalf("holder = %v, want holder-1", lease.Spec.HolderIdentity)
+	}
+
+	if err := rl.ReleaseLock(ctx, "my-lock", "holder-1"); err != nil {
+		t.Fatalf("ReleaseLock: %v", err)
+	}
+
+	err := cl.Get(ctx, client.ObjectKey{Namespace: "default", Name: "my-lock"}, lease)
+	if err == nil {
+		t.Fatal("expected lease to be deleted")
+	}
+}
+
+func TestAcquireAlreadyHeld(t *testing.T) {
+	cl := newFakeClient(t)
+	rl := NewResourceLocker(cl, "default",
+		WithRetryTimeout(100*time.Millisecond),
+		WithRetryInterval(20*time.Millisecond),
+	)
+	ctx := context.Background()
+
+	if err := rl.AcquireLock(ctx, "my-lock", "holder-1"); err != nil {
+		t.Fatalf("AcquireLock: %v", err)
+	}
+
+	err := rl.AcquireLock(ctx, "my-lock", "holder-2")
+	if !errors.Is(err, ErrLockHeld) {
+		t.Fatalf("got %v, want ErrLockHeld", err)
+	}
+}
+
+func TestReleaseNotOwner(t *testing.T) {
+	cl := newFakeClient(t)
+	rl := NewResourceLocker(cl, "default")
+	ctx := context.Background()
+
+	if err := rl.AcquireLock(ctx, "my-lock", "holder-1"); err != nil {
+		t.Fatalf("AcquireLock: %v", err)
+	}
+
+	if err := rl.ReleaseLock(ctx, "my-lock", "holder-2"); err != nil {
+		t.Fatalf("ReleaseLock: %v", err)
+	}
+
+	lease := &coordinationv1.Lease{}
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: "default", Name: "my-lock"}, lease); err != nil {
+		t.Fatal("expected lease to still exist after release by non-owner")
+	}
+}
+
+func TestReleaseNotFound(t *testing.T) {
+	cl := newFakeClient(t)
+	rl := NewResourceLocker(cl, "default")
+
+	if err := rl.ReleaseLock(context.Background(), "nonexistent", "holder-1"); err != nil {
+		t.Fatalf("ReleaseLock: %v", err)
+	}
+}
+
+func TestWithOptions(t *testing.T) {
+	cl := newFakeClient(t)
+	rl := NewResourceLocker(cl, "test-ns",
+		WithLeaseDuration(30*time.Second),
+		WithRetryInterval(100*time.Millisecond),
+		WithRetryTimeout(1*time.Second),
+	)
+
+	if rl.leaseDuration != 30 {
+		t.Errorf("leaseDuration = %d, want 30", rl.leaseDuration)
+	}
+	if rl.retryInterval != 100*time.Millisecond {
+		t.Errorf("retryInterval = %v, want 100ms", rl.retryInterval)
+	}
+	if rl.retryTimeout != 1*time.Second {
+		t.Errorf("retryTimeout = %v, want 1s", rl.retryTimeout)
+	}
+	if rl.namespace != "test-ns" {
+		t.Errorf("namespace = %q, want test-ns", rl.namespace)
+	}
+}


### PR DESCRIPTION
Feature-gated /traits endpoints that serve traits locally from Kubernetes
ConfigMaps instead of forwarding to upstream placement.

When conf.features.enableTraits is true, the shim reads from two ConfigMaps:
a static one managed by Helm (standard traits) and a dynamic one created
on-demand by the shim (CUSTOM_* traits). Writes to the dynamic ConfigMap are
serialized across replicas via a Lease-based distributed lock.

New pkg/resourcelock library: reusable Lease-backed AcquireLock/ReleaseLock
extracted from the traits code, designed for short-lived locks.

Helm: new configmap-traits.yaml template, Lease RBAC, configMapName and
static traits in values.