### PR TITLE
Isolate AICORE secrets from Claude Code process environment

### DIFF
--- a/.github/actions/setup-claude-code-action/action.yml
+++ b/.github/actions/setup-claude-code-action/action.yml
@@ -37,3 +37,12 @@ runs:
       run: |
         curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.13"
         echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install LiteLLM dependencies
+      shell: bash
+      run: pip install litellm==1.83.10 fastapi==0.136.0 uvicorn==0.44.0 --quiet

--- a/.github/patches/claude-code-action/litellm-proxy.patch
+++ b/.github/patches/claude-code-action/litellm-proxy.patch
@@ -1,5 +1,5 @@
 diff --git a/action.yml b/action.yml
-index b6d0f05..e3e2145 100644
+index b6d0f05..054e0b8 100644
 --- a/action.yml
 +++ b/action.yml
 @@ -85,6 +85,14 @@ inputs:
@@ -33,66 +33,7 @@ index b6d0f05..e3e2145 100644
  
      - name: Setup Custom Bun Path
        if: inputs.path_to_bun_executable != ''
-@@ -237,6 +246,58 @@ runs:
-         echo "/usr/bin" >> "$GITHUB_PATH"
-         echo "/bin" >> "$GITHUB_PATH"
- 
-+    - name: Setup Python for LiteLLM
-+      if: inputs.use_litellm == 'true'
-+      uses: actions/setup-python@v5
-+      with:
-+        python-version: "3.12"
-+
-+    - name: Install LiteLLM dependencies
-+      if: inputs.use_litellm == 'true'
-+      shell: bash
-+      run: |
-+        pip install litellm==1.83.10 fastapi==0.136.0 uvicorn==0.44.0 --quiet
-+
-+    - name: Start LiteLLM Proxy
-+      if: inputs.use_litellm == 'true'
-+      id: litellm
-+      shell: bash
-+      env:
-+        LITELLM_MODEL: ${{ inputs.litellm_model }}
-+      run: |
-+        LITELLM_PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
-+        echo "Starting LiteLLM proxy on port ${LITELLM_PORT}..."
-+
-+        LITELLM_PROXY_PORT=${LITELLM_PORT} python3 "${GITHUB_ACTION_PATH}/scripts/litellm-proxy.py" &
-+        LITELLM_PID=$!
-+        echo "LITELLM_PID=${LITELLM_PID}" >> "$GITHUB_ENV"
-+        echo "LITELLM_PORT=${LITELLM_PORT}" >> "$GITHUB_ENV"
-+
-+        for i in $(seq 1 30); do
-+          if curl -sf --connect-timeout 2 --max-time 3 "http://localhost:${LITELLM_PORT}/health/readiness" > /dev/null 2>&1; then
-+            echo "LiteLLM proxy is ready on port ${LITELLM_PORT}"
-+            break
-+          fi
-+          if ! kill -0 $LITELLM_PID 2>/dev/null; then
-+            echo "ERROR: LiteLLM proxy process died"
-+            exit 1
-+          fi
-+          sleep 2
-+        done
-+
-+        if ! curl -sf --connect-timeout 2 --max-time 3 "http://localhost:${LITELLM_PORT}/health/readiness" > /dev/null 2>&1; then
-+          echo "ERROR: LiteLLM proxy failed to start after 60 seconds"
-+          exit 1
-+        fi
-+
-+        # Set env vars for Claude Code CLI to use the proxy
-+        echo "ANTHROPIC_BASE_URL=http://localhost:${LITELLM_PORT}" >> "$GITHUB_ENV"
-+        echo "ANTHROPIC_MODEL=${{ inputs.litellm_model }}" >> "$GITHUB_ENV"
-+
-+        # Set a dummy API key — the proxy handles auth via AICORE_SERVICE_KEY
-+        LITELLM_PROXY_API_KEY="litellm-proxy-key"
-+        echo "LITELLM_PROXY_API_KEY=${LITELLM_PROXY_API_KEY}" >> "$GITHUB_ENV"
-+
-     - name: Run Claude Code Action
-       id: run
-       shell: bash
-@@ -292,13 +353,14 @@ runs:
+@@ -292,13 +301,14 @@ runs:
          NODE_VERSION: ${{ env.NODE_VERSION }}
  
          # Provider configuration
@@ -108,18 +49,10 @@ index b6d0f05..e3e2145 100644
  
          # AWS configuration
          AWS_REGION: ${{ env.AWS_REGION }}
-@@ -335,6 +397,18 @@ runs:
+@@ -335,6 +345,10 @@ runs:
          MCP_TOOL_TIMEOUT: ${{ env.MCP_TOOL_TIMEOUT }}
          MAX_MCP_OUTPUT_TOKENS: ${{ env.MAX_MCP_OUTPUT_TOKENS }}
  
-+        # SAP AI Core configuration (for LiteLLM)
-+        AICORE_SERVICE_KEY: ${{ env.AICORE_SERVICE_KEY }}
-+        AICORE_AUTH_URL: ${{ env.AICORE_AUTH_URL }}
-+        AICORE_CLIENT_ID: ${{ env.AICORE_CLIENT_ID }}
-+        AICORE_CLIENT_SECRET: ${{ env.AICORE_CLIENT_SECRET }}
-+        AICORE_BASE_URL: ${{ env.AICORE_BASE_URL }}
-+        AICORE_RESOURCE_GROUP: ${{ env.AICORE_RESOURCE_GROUP }}
-+
 +        # SAP compliance configuration
 +        DISABLE_TELEMETRY: "1"
 +        DISABLE_ERROR_REPORTING: "1"
@@ -127,30 +60,6 @@ index b6d0f05..e3e2145 100644
          # Telemetry configuration
          CLAUDE_CODE_ENABLE_TELEMETRY: ${{ env.CLAUDE_CODE_ENABLE_TELEMETRY }}
          OTEL_METRICS_EXPORTER: ${{ env.OTEL_METRICS_EXPORTER }}
-@@ -372,6 +446,23 @@ runs:
-           echo "DYLD_FRAMEWORK_PATH="
-         } >> "$GITHUB_ENV"
- 
-+    - name: Stop LiteLLM Proxy
-+      if: always() && inputs.use_litellm == 'true'
-+      shell: bash
-+      run: |
-+        if [ -n "${LITELLM_PID}" ] && kill -0 "${LITELLM_PID}" 2>/dev/null; then
-+          echo "Stopping LiteLLM proxy (PID: ${LITELLM_PID})..."
-+          kill "${LITELLM_PID}" 2>/dev/null || true
-+          for _ in $(seq 1 20); do
-+            kill -0 "${LITELLM_PID}" 2>/dev/null || break
-+            sleep 0.5
-+          done
-+          kill -9 "${LITELLM_PID}" 2>/dev/null || true
-+          echo "LiteLLM proxy stopped."
-+        else
-+          echo "LiteLLM proxy already stopped."
-+        fi
-+
-     - name: Cleanup SSH signing key
-       if: always() && inputs.ssh_signing_key != ''
-       shell: bash
 diff --git a/base-action/src/validate-env.ts b/base-action/src/validate-env.ts
 index 1f28da3..4eae3f2 100644
 --- a/base-action/src/validate-env.ts
@@ -207,163 +116,3 @@ index 1f28da3..4eae3f2 100644
    }
  
    if (errors.length > 0) {
-diff --git a/scripts/litellm-proxy.py b/scripts/litellm-proxy.py
-new file mode 100644
-index 0000000..79817a5
---- /dev/null
-+++ b/scripts/litellm-proxy.py
-@@ -0,0 +1,154 @@
-+"""
-+Minimal Anthropic Messages API proxy using LiteLLM SDK.
-+
-+Accepts Anthropic Messages API requests on /v1/messages and routes them
-+through LiteLLM to SAP AI Core (or any other LiteLLM-supported provider).
-+
-+Uses litellm.anthropic.messages.acreate() which handles Anthropic format
-+natively — no format translation, no Pydantic serialization bugs.
-+"""
-+
-+import json
-+import logging
-+import os
-+import sys
-+
-+from fastapi import FastAPI, Request
-+from fastapi.responses import JSONResponse, StreamingResponse
-+
-+import litellm
-+
-+# Drop unsupported params (e.g., 'thinking') instead of raising errors.
-+# Claude Code CLI sends params that not all providers support.
-+litellm.drop_params = True
-+
-+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
-+logger = logging.getLogger("litellm-proxy")
-+
-+app = FastAPI()
-+
-+# The LiteLLM model to route requests to (e.g., "sap/anthropic--claude-4.6-sonnet")
-+LITELLM_MODEL = os.environ.get("LITELLM_MODEL", "sap/anthropic--claude-4.6-sonnet")
-+
-+
-+@app.get("/health/readiness")
-+async def health_readiness():
-+    return {"status": "ok"}
-+
-+
-+@app.post("/v1/messages")
-+async def messages(request: Request):
-+    """
-+    Proxy Anthropic Messages API requests through LiteLLM SDK.
-+
-+    Claude Code CLI sends requests here (via ANTHROPIC_BASE_URL).
-+    We forward them to LiteLLM which routes to SAP AI Core.
-+    """
-+    try:
-+        body = await request.json()
-+    except Exception:
-+        return JSONResponse(
-+            status_code=400,
-+            content={
-+                "type": "error",
-+                "error": {
-+                    "type": "invalid_request_error",
-+                    "message": "Request body is not valid JSON.",
-+                },
-+            },
-+        )
-+
-+    original_model = body.get("model", "unknown")
-+    body["model"] = LITELLM_MODEL
-+
-+    logger.info(
-+        f"Proxying request: {original_model} -> {LITELLM_MODEL}, stream={body.get('stream', False)}"
-+    )
-+
-+    is_streaming = body.get("stream", False)
-+
-+    try:
-+        if is_streaming:
-+            return await _handle_streaming(body)
-+        else:
-+            return await _handle_non_streaming(body)
-+    except Exception as e:
-+        logger.exception(f"Error proxying request: {e}")
-+        return JSONResponse(
-+            status_code=500,
-+            content={
-+                "type": "error",
-+                "error": {
-+                    "type": "api_error",
-+                    "message": "An internal proxy error occurred. Check server logs for details.",
-+                },
-+            },
-+        )
-+
-+
-+async def _handle_non_streaming(body: dict) -> JSONResponse:
-+    """Handle non-streaming Anthropic Messages API request."""
-+    body.pop("stream", None)
-+
-+    response = await litellm.anthropic.messages.acreate(**body)
-+
-+    # litellm.anthropic.messages.acreate() returns Anthropic-format response
-+    if hasattr(response, "model_dump"):
-+        result = response.model_dump()
-+    elif isinstance(response, dict):
-+        result = response
-+    else:
-+        result = json.loads(str(response))
-+
-+    return JSONResponse(content=result)
-+
-+
-+async def _handle_streaming(body: dict) -> StreamingResponse:
-+    """Handle streaming Anthropic Messages API request."""
-+    body["stream"] = True
-+
-+    response = await litellm.anthropic.messages.acreate(**body)
-+
-+    async def event_generator():
-+        """Yield SSE events from LiteLLM streaming response."""
-+        try:
-+            async for chunk in response:
-+                # Each chunk from litellm.anthropic.messages.acreate(stream=True)
-+                # is already in Anthropic SSE format
-+                if hasattr(chunk, "model_dump"):
-+                    data = chunk.model_dump()
-+                elif isinstance(chunk, dict):
-+                    data = chunk
-+                else:
-+                    data = json.loads(str(chunk))
-+
-+                event_type = data.get("type")
-+                if not event_type:
-+                    logger.warning("Chunk missing 'type' field: %s", data)
-+                    continue
-+                yield f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
-+        except Exception as e:
-+            logger.exception(f"Streaming error: {e}")
-+            error_data = {
-+                "type": "error",
-+                "error": {"type": "api_error", "message": "An internal proxy error occurred. Check server logs for details."},
-+            }
-+            yield f"event: error\ndata: {json.dumps(error_data)}\n\n"
-+
-+    return StreamingResponse(
-+        event_generator(),
-+        media_type="text/event-stream",
-+        headers={
-+            "Cache-Control": "no-cache",
-+            "Connection": "keep-alive",
-+            "X-Accel-Buffering": "no",
-+        },
-+    )
-+
-+
-+if __name__ == "__main__":
-+    import uvicorn
-+
-+    port = int(os.environ.get("LITELLM_PROXY_PORT", "4000"))
-+    logger.info(f"Starting LiteLLM proxy on port {port}, model={LITELLM_MODEL}")
-+    uvicorn.run(app, host="127.0.0.1", port=port, log_level="info")

--- a/.github/scripts/litellm-proxy.py
+++ b/.github/scripts/litellm-proxy.py
@@ -1,0 +1,142 @@
+"""
+Minimal Anthropic Messages API proxy using LiteLLM SDK.
+
+Accepts Anthropic Messages API requests on /v1/messages and routes them
+through LiteLLM to SAP AI Core (or any other LiteLLM-supported provider).
+
+Uses litellm.anthropic.messages.acreate() which handles Anthropic format
+natively — no format translation, no Pydantic serialization bugs.
+"""
+
+import json
+import logging
+import os
+import sys
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+import litellm
+
+# Drop unsupported params (e.g., 'thinking') instead of raising errors.
+# Claude Code CLI sends params that not all providers support.
+litellm.drop_params = True
+
+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+logger = logging.getLogger("litellm-proxy")
+
+app = FastAPI()
+
+# The LiteLLM model to route requests to (e.g., "sap/anthropic--claude-4.6-sonnet")
+LITELLM_MODEL = os.environ.get("LITELLM_MODEL", "sap/anthropic--claude-4.6-sonnet")
+
+
+@app.get("/health/readiness")
+async def health_readiness():
+    return {"status": "ok"}
+
+
+@app.post("/v1/messages")
+async def messages(request: Request):
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "Request body is not valid JSON.",
+                },
+            },
+        )
+
+    original_model = body.get("model", "unknown")
+    body["model"] = LITELLM_MODEL
+
+    logger.info(
+        f"Proxying request: {original_model} -> {LITELLM_MODEL}, stream={body.get('stream', False)}"
+    )
+
+    is_streaming = body.get("stream", False)
+
+    try:
+        if is_streaming:
+            return await _handle_streaming(body)
+        else:
+            return await _handle_non_streaming(body)
+    except Exception as e:
+        logger.exception(f"Error proxying request: {e}")
+        return JSONResponse(
+            status_code=500,
+            content={
+                "type": "error",
+                "error": {
+                    "type": "api_error",
+                    "message": "An internal proxy error occurred. Check server logs for details.",
+                },
+            },
+        )
+
+
+async def _handle_non_streaming(body: dict) -> JSONResponse:
+    body.pop("stream", None)
+
+    response = await litellm.anthropic.messages.acreate(**body)
+
+    if hasattr(response, "model_dump"):
+        result = response.model_dump()
+    elif isinstance(response, dict):
+        result = response
+    else:
+        result = json.loads(str(response))
+
+    return JSONResponse(content=result)
+
+
+async def _handle_streaming(body: dict) -> StreamingResponse:
+    body["stream"] = True
+
+    response = await litellm.anthropic.messages.acreate(**body)
+
+    async def event_generator():
+        try:
+            async for chunk in response:
+                if hasattr(chunk, "model_dump"):
+                    data = chunk.model_dump()
+                elif isinstance(chunk, dict):
+                    data = chunk
+                else:
+                    data = json.loads(str(chunk))
+
+                event_type = data.get("type")
+                if not event_type:
+                    logger.warning("Chunk missing 'type' field: %s", data)
+                    continue
+                yield f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+        except Exception as e:
+            logger.exception(f"Streaming error: {e}")
+            error_data = {
+                "type": "error",
+                "error": {"type": "api_error", "message": "An internal proxy error occurred. Check server logs for details."},
+            }
+            yield f"event: error\ndata: {json.dumps(error_data)}\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ.get("LITELLM_PROXY_PORT", "4000"))
+    logger.info(f"Starting LiteLLM proxy on port {port}, model={LITELLM_MODEL}")
+    uvicorn.run(app, host="127.0.0.1", port=port, log_level="info")

--- a/.github/workflows/claude-on-issues-and-prs.yaml
+++ b/.github/workflows/claude-on-issues-and-prs.yaml
@@ -26,6 +26,46 @@ jobs:
 
       - uses: ./.github/actions/setup-claude-code-action
 
+      - name: Start LiteLLM Proxy
+        shell: bash
+        env:
+          AICORE_RESOURCE_GROUP: ${{ secrets.AICORE_RESOURCE_GROUP }}
+          AICORE_BASE_URL: ${{ secrets.AICORE_BASE_URL }}
+          AICORE_AUTH_URL: ${{ secrets.AICORE_AUTH_URL }}
+          AICORE_CLIENT_ID: ${{ secrets.AICORE_CLIENT_ID }}
+          AICORE_CLIENT_SECRET: ${{ secrets.AICORE_CLIENT_SECRET }}
+          LITELLM_MODEL: "sap/anthropic--claude-4.6-sonnet"
+        run: |
+          LITELLM_PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
+          echo "Starting LiteLLM proxy on port ${LITELLM_PORT}..."
+
+          LITELLM_PROXY_PORT=${LITELLM_PORT} python3 "${{ github.workspace }}/.github/scripts/litellm-proxy.py" &
+          LITELLM_PID=$!
+          echo "LITELLM_PID=${LITELLM_PID}" >> "$GITHUB_ENV"
+          echo "LITELLM_PORT=${LITELLM_PORT}" >> "$GITHUB_ENV"
+
+          for i in $(seq 1 30); do
+            if curl -sf --connect-timeout 2 --max-time 3 "http://localhost:${LITELLM_PORT}/health/readiness" > /dev/null 2>&1; then
+              echo "LiteLLM proxy is ready on port ${LITELLM_PORT}"
+              break
+            fi
+            if ! kill -0 $LITELLM_PID 2>/dev/null; then
+              echo "ERROR: LiteLLM proxy process died"
+              exit 1
+            fi
+            sleep 2
+          done
+
+          if ! curl -sf --connect-timeout 2 --max-time 3 "http://localhost:${LITELLM_PORT}/health/readiness" > /dev/null 2>&1; then
+            echo "ERROR: LiteLLM proxy failed to start after 60 seconds"
+            exit 1
+          fi
+
+          echo "ANTHROPIC_BASE_URL=http://localhost:${LITELLM_PORT}" >> "$GITHUB_ENV"
+          echo "ANTHROPIC_MODEL=sap/anthropic--claude-4.6-sonnet" >> "$GITHUB_ENV"
+          LITELLM_PROXY_API_KEY="litellm-proxy-key"
+          echo "LITELLM_PROXY_API_KEY=${LITELLM_PROXY_API_KEY}" >> "$GITHUB_ENV"
+
       - uses: ./.claude-code-action
         with:
           trigger_phrase: "@claude"
@@ -33,9 +73,20 @@ jobs:
           litellm_model: "sap/anthropic--claude-4.6-sonnet"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: "true"
-        env:
-          AICORE_RESOURCE_GROUP: ${{ secrets.AICORE_RESOURCE_GROUP }}
-          AICORE_BASE_URL: ${{ secrets.AICORE_BASE_URL }}
-          AICORE_AUTH_URL: ${{ secrets.AICORE_AUTH_URL }}
-          AICORE_CLIENT_ID: ${{ secrets.AICORE_CLIENT_ID }}
-          AICORE_CLIENT_SECRET: ${{ secrets.AICORE_CLIENT_SECRET }}
+
+      - name: Stop LiteLLM Proxy
+        if: always()
+        shell: bash
+        run: |
+          if [ -n "${LITELLM_PID}" ] && kill -0 "${LITELLM_PID}" 2>/dev/null; then
+            echo "Stopping LiteLLM proxy (PID: ${LITELLM_PID})..."
+            kill "${LITELLM_PID}" 2>/dev/null || true
+            for _ in $(seq 1 20); do
+              kill -0 "${LITELLM_PID}" 2>/dev/null || break
+              sleep 0.5
+            done
+            kill -9 "${LITELLM_PID}" 2>/dev/null || true
+            echo "LiteLLM proxy stopped."
+          else
+            echo "LiteLLM proxy already stopped."
+          fi


### PR DESCRIPTION
Move LiteLLM proxy lifecycle (start/stop) out of the upstream action patch and into the workflow as separate shell steps. AICORE_* secrets are now scoped only to the proxy start step, so Claude Code never has real credentials in its process environment. The proxy script is moved from the patch into the repo at .github/scripts/litellm-proxy.py. The upstream patch is simplified to only contain input definitions, conditional env logic, SAP compliance flags, and validate-env.ts changes. Python 3.12 and LiteLLM dependency installation are added to the setup composite action.