### PR TITLE
fix: bump artifact handles concurrent changes on main

### DIFF
--- a/.github/scripts/bump-chart.sh
+++ b/.github/scripts/bump-chart.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Bumps appVersion in a Helm Chart.yaml, skipping if a newer code commit already
+# covers this component.
+#
+# Usage: bump-chart.sh <chart-yaml> <short-sha> <trigger-sha> [path-filter ...]
+#
+# path-filter args scope the freshness check to specific paths (e.g. postgres/).
+# Omit them for an unconditional bump (the main cortex chart).
+set -euo pipefail
+
+CHART=$1; SHORT_SHA=$2; TRIGGER_SHA=$3; shift 3
+PATHS=("$@")
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git fetch origin main
+git reset --hard origin/main
+
+# Exclude bump commits ([skip ci]) so earlier steps in this same run don't
+# falsely count as "newer code". Only real code commits trigger a skip.
+if [ ${#PATHS[@]} -gt 0 ]; then
+    NEWER=$(git log --oneline --invert-grep --grep='\[skip ci\]' "$TRIGGER_SHA..HEAD" -- "${PATHS[@]}")
+else
+    NEWER=$(git log --oneline --invert-grep --grep='\[skip ci\]' "$TRIGGER_SHA..HEAD")
+fi
+
+if [ -n "$NEWER" ]; then
+    echo "Skipping $CHART: newer code commits exist on main for this component"
+    exit 0
+fi
+
+CHART_NAME=$(basename "$(dirname "$CHART")")
+sed -i 's/^\([ ]*appVersion:[ ]*\).*/\1"'"$SHORT_SHA"'"/' "$CHART"
+git add "$CHART"
+git diff --cached --quiet && { echo "No changes to commit for $CHART_NAME"; exit 0; }
+git commit -m "Bump $CHART_NAME chart appVersions to $SHORT_SHA [skip ci]"
+git push origin HEAD:main

--- a/.github/workflows/update-appversion.yml
+++ b/.github/workflows/update-appversion.yml
@@ -47,41 +47,11 @@ jobs:
 
       - name: Bump and push cortex-postgres appVersion
         if: steps.changed_postgres_files.outputs.all_changed_files != ''
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          SHA="${{ steps.vars.outputs.sha }}"
-          git fetch origin main
-          git reset --hard origin/main
-          sed -i 's/^\([ ]*appVersion:[ ]*\).*/\1"'"$SHA"'"/' helm/library/cortex-postgres/Chart.yaml
-          git add helm/library/cortex-postgres/Chart.yaml
-          git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
-          git commit -m "Bump cortex-postgres chart appVersions to $SHA [skip ci]"
-          git push origin HEAD:main
+        run: bash .github/scripts/bump-chart.sh helm/library/cortex-postgres/Chart.yaml "${{ steps.vars.outputs.sha }}" "${{ github.event.workflow_run.head_sha }}" postgres/
 
       - name: Bump and push cortex-shim appVersion
         if: steps.changed_shim_files.outputs.all_changed_files != ''
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          SHA="${{ steps.vars.outputs.sha }}"
-          git fetch origin main
-          git reset --hard origin/main
-          sed -i 's/^\([ ]*appVersion:[ ]*\).*/\1"'"$SHA"'"/' helm/library/cortex-shim/Chart.yaml
-          git add helm/library/cortex-shim/Chart.yaml
-          git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
-          git commit -m "Bump cortex-shim chart appVersions to $SHA [skip ci]"
-          git push origin HEAD:main
+        run: bash .github/scripts/bump-chart.sh helm/library/cortex-shim/Chart.yaml "${{ steps.vars.outputs.sha }}" "${{ github.event.workflow_run.head_sha }}" internal/shim/ cmd/shim/
 
       - name: Bump and push cortex appVersion
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          SHA="${{ steps.vars.outputs.sha }}"
-          git fetch origin main
-          git reset --hard origin/main
-          sed -i 's/^\([ ]*appVersion:[ ]*\).*/\1"'"$SHA"'"/' helm/library/cortex/Chart.yaml
-          git add helm/library/cortex/Chart.yaml
-          git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
-          git commit -m "Bump cortex chart appVersions to $SHA [skip ci]"
-          git push origin HEAD:main
+        run: bash .github/scripts/bump-chart.sh helm/library/cortex/Chart.yaml "${{ steps.vars.outputs.sha }}" "${{ github.event.workflow_run.head_sha }}"

--- a/.github/workflows/update-appversion.yml
+++ b/.github/workflows/update-appversion.yml
@@ -11,6 +11,13 @@ jobs:
     if: >-
       ${{ github.event.workflow_run.conclusion == 'success' && !contains(github.event.workflow_run.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
+    # Serialize runs so concurrent merges don't race on git push.
+    # Example: PR A changes shim, PR B changes cortex — both trigger this
+    # workflow. Without serialization, one push fails and that chart bump is
+    # lost permanently (no future run will retry it).
+    concurrency:
+      group: update-appversion
+      cancel-in-progress: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -30,21 +37,6 @@ jobs:
           files: |
             postgres/**
 
-      # Only bumped if there are changes in the postgres directory.
-      - name: Update appVersion in cortex-postgres Chart.yaml
-        if: steps.changed_postgres_files.outputs.all_changed_files != ''
-        run: |
-          sed -i 's/^\([ ]*appVersion:[ ]*\).*/\1"${{ steps.vars.outputs.sha }}"/' helm/library/cortex-postgres/Chart.yaml
-      - name: Commit and push changes for cortex-postgres
-        if: steps.changed_postgres_files.outputs.all_changed_files != ''
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add helm/library/cortex-postgres/Chart.yaml
-          git commit -m "Bump cortex-postgres chart appVersions to ${{ steps.vars.outputs.sha }} [skip ci]" || echo "No changes to commit"
-          git push origin HEAD:main
-
-      # Only bumped if there are changes in shim-related directories
       - name: Get all changed shim files
         id: changed_shim_files
         uses: tj-actions/changed-files@v47
@@ -52,26 +44,44 @@ jobs:
           files: |
             internal/shim/**
             cmd/shim/**
-      - name: Update appVersion in cortex-shim Chart.yaml
-        if: steps.changed_shim_files.outputs.all_changed_files != ''
-        run: |
-          sed -i 's/^\([ ]*appVersion:[ ]*\).*/\1"${{ steps.vars.outputs.sha }}"/' helm/library/cortex-shim/Chart.yaml
-      - name: Commit and push changes for cortex-shim
-        if: steps.changed_shim_files.outputs.all_changed_files != ''
+
+      - name: Bump and push cortex-postgres appVersion
+        if: steps.changed_postgres_files.outputs.all_changed_files != ''
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add helm/library/cortex-shim/Chart.yaml
-          git commit -m "Bump cortex-shim chart appVersions to ${{ steps.vars.outputs.sha }} [skip ci]" || echo "No changes to commit"
+          SHA="${{ steps.vars.outputs.sha }}"
+          git fetch origin main
+          git reset --hard origin/main
+          sed -i 's/^\([ ]*appVersion:[ ]*\).*/\1"'"$SHA"'"/' helm/library/cortex-postgres/Chart.yaml
+          git add helm/library/cortex-postgres/Chart.yaml
+          git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
+          git commit -m "Bump cortex-postgres chart appVersions to $SHA [skip ci]"
           git push origin HEAD:main
 
-      - name: Update appVersion in helm/library/cortex/Chart.yaml
-        run: |
-          sed -i 's/^\([ ]*appVersion:[ ]*\).*/\1"${{ steps.vars.outputs.sha }}"/' helm/library/cortex/Chart.yaml
-      - name: Commit and push changes for cortex
+      - name: Bump and push cortex-shim appVersion
+        if: steps.changed_shim_files.outputs.all_changed_files != ''
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          SHA="${{ steps.vars.outputs.sha }}"
+          git fetch origin main
+          git reset --hard origin/main
+          sed -i 's/^\([ ]*appVersion:[ ]*\).*/\1"'"$SHA"'"/' helm/library/cortex-shim/Chart.yaml
+          git add helm/library/cortex-shim/Chart.yaml
+          git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
+          git commit -m "Bump cortex-shim chart appVersions to $SHA [skip ci]"
+          git push origin HEAD:main
+
+      - name: Bump and push cortex appVersion
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          SHA="${{ steps.vars.outputs.sha }}"
+          git fetch origin main
+          git reset --hard origin/main
+          sed -i 's/^\([ ]*appVersion:[ ]*\).*/\1"'"$SHA"'"/' helm/library/cortex/Chart.yaml
           git add helm/library/cortex/Chart.yaml
-          git commit -m "Bump cortex chart appVersions to ${{ steps.vars.outputs.sha }} [skip ci]" || echo "No changes to commit"
+          git diff --cached --quiet && { echo "No changes to commit"; exit 0; }
+          git commit -m "Bump cortex chart appVersions to $SHA [skip ci]"
           git push origin HEAD:main


### PR DESCRIPTION
The workflow had two bugs when multiple PRs merged in quick succession:

Push races: separate sed and commit/push steps meant concurrent runs could push simultaneously and one would fail, losing that chart bump permanently with no retry.

Commit-age races: serializing pushes doesn't help if an older build finishes after a newer one — the stale run would overwrite the chart with an older SHA.

Fixed by adding a concurrency group to serialize runs, and a freshness check in each bump step that skips if a newer code commit already covers that component. The check uses git log scoped to the relevant paths for path-gated charts, and excludes [skip ci] bump commits so earlier steps in the same run don't cause a false skip.