### PR TITLE
Rename hypervisor ClusterRoleBindings to avoid roleRef conflict

### DIFF
--- a/helm/bundles/cortex-nova/templates/rbac.yaml
+++ b/helm/bundles/cortex-nova/templates/rbac.yaml
@@ -49,7 +49,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ (index .Values "cortex-scheduling-controllers").namePrefix }}-manager-rolebinding-hypervisor
+  name: cortex-nova-manager-rolebinding-hypervisor-scheduling
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -62,7 +62,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ (index .Values "cortex-knowledge-controllers").namePrefix }}-manager-rolebinding-hypervisor
+  name: cortex-nova-manager-rolebinding-hypervisor-knowledge
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
After PR #797 moved hypervisor RBAC from the per-subchart library into the cortex-nova bundle chart, deploying fails because the existing ClusterRoleBindings in the cluster still reference the old per-subchart ClusterRoles (e.g. cortex-nova-scheduling-manager-role-hypervisor). Kubernetes does not allow changing roleRef on an existing ClusterRoleBinding, so the deployment errors out. This renames both ClusterRoleBindings to new unique names so Helm creates them fresh, pointing to the shared cortex-nova-manager-role-hypervisor ClusterRole.

Assisted-by: Claude Code:claude-opus-4-20250514 [Bash] [Read]