### PR TITLE
Downgrade Python to 3.13 for claude-code-action setup

### DIFF
--- a/.github/actions/setup-claude-code-action/action.yml
+++ b/.github/actions/setup-claude-code-action/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.14"
+        python-version: "3.13"
 
     - name: Install LiteLLM dependencies
       shell: bash

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,8 @@
   ],
   "commitMessageAction": "Renovate: Update",
   "constraints": {
-    "go": "1.26"
+    "go": "1.26",
+    "python": "3.13"
   },
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
The setup-claude-code-action was failing with "ERROR: No matching distribution found for litellm==1.83.10" because litellm 1.83.10 declares requires_python >=3.10,<3.14, but the action was using Python 3.14. This downgrades to Python 3.13 and adds a python constraint to the renovate config so it does not get bumped back up.

Assisted-by: Claude Code:claude-opus-4-20250514 [Bash] [Read]