### PR TITLE
fix: Remove ignoreAllocations from kvm-report-capacity pipeline

### DIFF
--- a/helm/bundles/cortex-nova/templates/pipelines_kvm.yaml
+++ b/helm/bundles/cortex-nova/templates/pipelines_kvm.yaml
@@ -584,7 +584,6 @@ spec:
         VM allocations and all reservation types are ignored to represent an
         empty datacenter scenario.
       params:
-        - {key: ignoreAllocations, boolValue: true}
         - {key: ignoredReservationTypes, stringListValue: ["CommittedResourceReservation", "FailoverReservation"]}
     - name: filter_has_requested_traits
       description: |


### PR DESCRIPTION
The admission webhook in staging runs the old code and rejects the field with "json: unknown field ignoreAllocations". Removing it here unblocks pipeline deployment. A follow-up PR will re-add it once the new webhook has rolled through all regions.