### PR TITLE
refactor: rename metrics for unused VMware commitments

### DIFF
--- a/internal/knowledge/kpis/plugins/infrastructure/vmware_project_commitments.go
+++ b/internal/knowledge/kpis/plugins/infrastructure/vmware_project_commitments.go
@@ -43,12 +43,12 @@ func (k *VMwareProjectCommitmentsKPI) Init(dbConn *db.DB, c client.Client, opts 
 	}
 
 	k.unusedGeneralPurposeCommitmentsPerProject = prometheus.NewDesc(
-		"cortex_vmware_commitments_general_purpose",
+		"cortex_vmware_unused_commitments_general_purpose",
 		"Committed general purpose resources that are currently unused. CPU (resource=cpu) in vCPUs, memory (resource=ram) in bytes.",
 		[]string{"availability_zone", "resource", "project_id", "project_name", "domain_id", "domain_name"}, nil,
 	)
 	k.unusedHanaCommittedResourcesPerProject = prometheus.NewDesc(
-		"cortex_vmware_commitments_hana_resources",
+		"cortex_vmware_unused_commitments_hana_resources",
 		"Total committed HANA instances capacity that is currently unused, translated to resources. CPU in vCPUs, memory and disk in bytes.",
 		[]string{"availability_zone", "cpu_architecture", "resource", "project_id", "project_name", "domain_id", "domain_name"}, nil,
 	)

--- a/internal/knowledge/kpis/plugins/infrastructure/vmware_project_commitments_test.go
+++ b/internal/knowledge/kpis/plugins/infrastructure/vmware_project_commitments_test.go
@@ -65,12 +65,12 @@ func collectProjectCommitmentsMetrics(t *testing.T, testDB *db.DB) map[string]fl
 // gpKey builds the expected map key for a general-purpose metric.
 // cpu_architecture is always empty because the GP metric descriptor omits that label.
 func gpKey(az, resource string, p projectWithDomain) string {
-	return "cortex_vmware_commitments_general_purpose|" + az + "||" + resource + "|" + p.ProjectID + "|" + p.ProjectName + "|" + p.DomainID + "|" + p.DomainName
+	return "cortex_vmware_unused_commitments_general_purpose|" + az + "||" + resource + "|" + p.ProjectID + "|" + p.ProjectName + "|" + p.DomainID + "|" + p.DomainName
 }
 
 // hKey builds the expected map key for a HANA metric.
 func hKey(az, cpuArch, resource string, p projectWithDomain) string {
-	return "cortex_vmware_commitments_hana_resources|" + az + "|" + cpuArch + "|" + resource + "|" + p.ProjectID + "|" + p.ProjectName + "|" + p.DomainID + "|" + p.DomainName
+	return "cortex_vmware_unused_commitments_hana_resources|" + az + "|" + cpuArch + "|" + resource + "|" + p.ProjectID + "|" + p.ProjectName + "|" + p.DomainID + "|" + p.DomainName
 }
 
 func TestVMwareProjectCommitmentsKPI_Init(t *testing.T) {


### PR DESCRIPTION
The old name implied its the total commitments by a project and not just the unused portion