### PR TITLE
fix: tolerate unreachable remote clusters during field index setup

### DIFF
--- a/internal/shim/placement/field_index_test.go
+++ b/internal/shim/placement/field_index_test.go
@@ -133,17 +133,15 @@ func TestIndexFields_RegistersAllIndexes(t *testing.T) {
 	}
 }
 
-func TestIndexFields_PropagatesError(t *testing.T) {
-	wantErr := errors.New("cache failure")
-	cc := &captureCache{err: wantErr}
+func TestIndexFields_ToleratesClusterError(t *testing.T) {
+	// A failing cluster cache should not prevent index setup for other clusters.
+	// The multicluster IndexField logs per-cluster errors and continues, so
+	// IndexFields must return nil even when every cache call fails.
+	cc := &captureCache{err: errors.New("cache failure")}
 	mcl := buildClient(t, cc)
 
-	err := IndexFields(context.Background(), mcl)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, wantErr) {
-		t.Errorf("got %v, want %v", err, wantErr)
+	if err := IndexFields(context.Background(), mcl); err != nil {
+		t.Fatalf("expected nil, got %v", err)
 	}
 }
 

--- a/pkg/multicluster/client.go
+++ b/pkg/multicluster/client.go
@@ -641,7 +641,13 @@ func (c *subResourceClient) Apply(ctx context.Context, obj runtime.ApplyConfigur
 // Index a field for a resource in all matching cluster caches.
 // Usually, you want to index the same field in both the object and list type,
 // as both would be mapped to individual clients based on their GVK.
+//
+// Per-cluster errors are logged and skipped — a temporarily-unreachable cluster
+// does not prevent index setup for the other clusters. This mirrors the List
+// error-handling pattern: the affected cluster's objects will be silently absent
+// from MatchingFields queries until the index is established (e.g. after restart).
 func (c *Client) IndexField(ctx context.Context, obj client.Object, list client.ObjectList, field string, extractValue client.IndexerFunc) error {
+	log := ctrl.LoggerFrom(ctx)
 	gvk, err := c.GVKFromHomeScheme(obj)
 	if err != nil {
 		return err
@@ -663,7 +669,8 @@ func (c *Client) IndexField(ctx context.Context, obj client.Object, list client.
 		}
 		indexed[ch] = true
 		if err := ch.IndexField(ctx, obj, field, extractValue); err != nil {
-			return err
+			log.Error(err, "failed to register field index for cluster — objects from this cluster will be absent from index queries; restart required to recover", "field", field)
+			continue
 		}
 	}
 	clustersList, err := c.ClustersForGVK(gvkList)
@@ -677,7 +684,8 @@ func (c *Client) IndexField(ctx context.Context, obj client.Object, list client.
 		}
 		indexed[ch] = true
 		if err := ch.IndexField(ctx, obj, field, extractValue); err != nil {
-			return err
+			log.Error(err, "failed to register field index for cluster — objects from this cluster will be absent from index queries; restart required to recover", "field", field)
+			continue
 		}
 	}
 	return nil


### PR DESCRIPTION
When a compute cluster is temporarily down at startup, IndexField fails
for that cluster — propagating the error through SetupWithManager and
crashing the controller via os.Exit. This takes down all AZs for a
failure in one.

Apply the same log-and-continue pattern already used by the multicluster
List implementation: per-cluster errors are logged and skipped so the
remaining clusters can be indexed and the controller can operate normally.

Caveat: objects from the unreachable cluster will be absent from
MatchingFields index queries until Cortex is restarted after the cluster
recovers. This is the same degraded-but-running trade-off accepted by
List.