### PR TITLE
Bump core to 0.0.51 and bundles to 0.0.64 [skip ci]

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -907,11 +907,17 @@ func main() {
 		}
 	}
 
+	signalCtx := ctrl.SetupSignalHandler()
+
 	errchan := make(chan error)
 	go func() {
+		if !mgr.GetCache().WaitForCacheSync(signalCtx) {
+			setupLog.Error(nil, "cache sync failed, exiting before starting api server")
+			os.Exit(1)
+		}
 		errchan <- func() error {
 			setupLog.Info("starting api server", "address", ":8080")
-			return httpext.ListenAndServeContext(ctx, ":8080", mux)
+			return httpext.ListenAndServeContext(signalCtx, ":8080", mux)
 		}()
 	}()
 	go func() {
@@ -922,7 +928,7 @@ func main() {
 	}()
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(signalCtx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/helm/bundles/cortex-cinder/Chart.yaml
+++ b/helm/bundles/cortex-cinder/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cortex-cinder
 description: A Helm chart deploying Cortex for Cinder.
 type: application
-version: 0.0.63
+version: 0.0.64
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex-postgres
@@ -16,12 +16,12 @@ dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.50
+    version: 0.0.51
     alias: cortex-knowledge-controllers
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.50
+    version: 0.0.51
     alias: cortex-scheduling-controllers
 
   # Owner info adds a configmap to the kubernetes cluster with information on

--- a/helm/bundles/cortex-crds/Chart.yaml
+++ b/helm/bundles/cortex-crds/Chart.yaml
@@ -5,13 +5,13 @@ apiVersion: v2
 name: cortex-crds
 description: A Helm chart deploying Cortex CRDs.
 type: application
-version: 0.0.63
+version: 0.0.64
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.50
+    version: 0.0.51
 
   # Owner info adds a configmap to the kubernetes cluster with information on
   # the service owner. This makes it easier to find out who to contact in case

--- a/helm/bundles/cortex-ironcore/Chart.yaml
+++ b/helm/bundles/cortex-ironcore/Chart.yaml
@@ -5,13 +5,13 @@ apiVersion: v2
 name: cortex-ironcore
 description: A Helm chart deploying Cortex for IronCore.
 type: application
-version: 0.0.63
+version: 0.0.64
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.50
+    version: 0.0.51
 
   # Owner info adds a configmap to the kubernetes cluster with information on
   # the service owner. This makes it easier to find out who to contact in case

--- a/helm/bundles/cortex-manila/Chart.yaml
+++ b/helm/bundles/cortex-manila/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cortex-manila
 description: A Helm chart deploying Cortex for Manila.
 type: application
-version: 0.0.63
+version: 0.0.64
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex-postgres
@@ -16,12 +16,12 @@ dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.50
+    version: 0.0.51
     alias: cortex-knowledge-controllers
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.50
+    version: 0.0.51
     alias: cortex-scheduling-controllers
 
   # Owner info adds a configmap to the kubernetes cluster with information on

--- a/helm/bundles/cortex-nova/Chart.yaml
+++ b/helm/bundles/cortex-nova/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cortex-nova
 description: A Helm chart deploying Cortex for Nova.
 type: application
-version: 0.0.63
+version: 0.0.64
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex-postgres
@@ -16,12 +16,12 @@ dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.50
+    version: 0.0.51
     alias: cortex-knowledge-controllers
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.50
+    version: 0.0.51
     alias: cortex-scheduling-controllers
 
   # Owner info adds a configmap to the kubernetes cluster with information on

--- a/helm/bundles/cortex-nova/alerts/nova.alerts.yaml
+++ b/helm/bundles/cortex-nova/alerts/nova.alerts.yaml
@@ -432,3 +432,170 @@ groups:
         This may indicate issues with the webhook logic, connectivity problems, or
         external factors causing failures. Check the webhook server logs for error
         details and investigate the affected resources.
+
+  # Committed Resource Info API
+  - alert: CortexNovaCommittedResourceInfoUnavailable
+    expr: |
+      rate(cortex_committed_resource_info_api_requests_total{service="cortex-nova-metrics", status_code="503"}[5m]) > 0
+    for: 5m
+    labels:
+      context: committed-resource-api
+      dashboard: cortex-status-dashboard/cortex-status-dashboard
+      service: cortex
+      severity: warning
+      support_group: workload-management
+    annotations:
+      summary: "Committed Resource info API is unavailable"
+      description: >
+        The committed resource info API (Limes LIQUID integration) has been returning
+        503 Service Unavailable for more than 5 minutes. This typically means the
+        flavor group knowledge CRD is not ready or missing. Limes cannot discover
+        available committed resources until the issue is resolved.
+
+  # Committed Resource Change API
+  - alert: CortexNovaCommittedResourceChangeErrors
+    expr: |
+      rate(cortex_committed_resource_change_api_requests_total{service="cortex-nova-metrics", status_code=~"5.."}[5m]) > 0
+    for: 5m
+    labels:
+      context: committed-resource-api
+      dashboard: cortex-status-dashboard/cortex-status-dashboard
+      service: cortex
+      severity: warning
+      support_group: workload-management
+    annotations:
+      summary: "Committed Resource change API HTTP 5xx errors"
+      description: >
+        The committed resource change API (Limes LIQUID integration) is returning
+        HTTP 5xx errors. This is not expected and indicates an internal problem
+        processing commitment changes. Limes will retry, but new commitments may
+        not be fulfilled until the issue is resolved.
+
+  - alert: CortexNovaCommittedResourceRejectionRateTooHigh
+    expr: |
+      (
+        sum(rate(cortex_committed_resource_change_api_commitment_changes_total{service="cortex-nova-metrics", result="rejected"}[15m]))
+        / sum(rate(cortex_committed_resource_change_api_commitment_changes_total{service="cortex-nova-metrics"}[15m]))
+      ) > 0.3
+      and on() sum(rate(cortex_committed_resource_change_api_commitment_changes_total{service="cortex-nova-metrics"}[15m])) > 0
+    for: 15m
+    labels:
+      context: committed-resource-api
+      dashboard: cortex-status-dashboard/cortex-status-dashboard
+      service: cortex
+      severity: warning
+      support_group: workload-management
+    annotations:
+      summary: "Committed Resource rejection rate too high ({{ $value | humanizePercentage }})"
+      description: >
+        More than 30% of commitment changes have been rejected over the last 15 minutes.
+        This may indicate insufficient capacity to fulfill new commitments. Rejected
+        commitments are rolled back; Limes will see them as failed and may report
+        the failure to users.
+
+  - alert: CortexNovaCommittedResourceTimeoutsTooHigh
+    expr: increase(cortex_committed_resource_change_api_timeouts_total{service="cortex-nova-metrics"}[10m]) > 0
+    for: 1m
+    labels:
+      context: committed-resource-api
+      dashboard: cortex-status-dashboard/cortex-status-dashboard
+      service: cortex
+      severity: warning
+      support_group: workload-management
+    annotations:
+      summary: "Committed Resource change API timeout detected"
+      description: >
+        A commitment change request timed out after the 15-second deadline.
+        Timeouts indicate the scheduling pipeline could not place reservations in time.
+        Affected changes are rolled back. Investigate scheduler performance or reservation backlog.
+
+  - alert: CortexNovaCommittedResourceChangeLatencyTooHigh
+    expr: |
+      histogram_quantile(0.95, sum(rate(cortex_committed_resource_change_api_request_duration_seconds_bucket{service="cortex-nova-metrics"}[5m])) by (le)) >= 10
+      and on() sum(rate(cortex_committed_resource_change_api_requests_total{service="cortex-nova-metrics"}[5m])) > 0
+    for: 5m
+    labels:
+      context: committed-resource-api
+      dashboard: cortex-status-dashboard/cortex-status-dashboard
+      service: cortex
+      severity: warning
+      support_group: workload-management
+    annotations:
+      summary: "Committed Resource change API p95 latency >= 10s"
+      description: >
+        The committed resource change API p95 latency has reached or exceeded 10 seconds,
+        approaching the 15-second watch timeout. Requests close to the timeout are at risk
+        of being rolled back. Investigate scheduler performance or reservation backlog.
+
+  # Committed Resource Capacity API
+  - alert: CortexNovaCommittedResourceCapacityErrors
+    expr: |
+      rate(cortex_committed_resource_capacity_api_requests_total{service="cortex-nova-metrics", status_code=~"5.."}[5m]) > 0
+    for: 5m
+    labels:
+      context: committed-resource-api
+      dashboard: cortex-status-dashboard/cortex-status-dashboard
+      service: cortex
+      severity: warning
+      support_group: workload-management
+    annotations:
+      summary: "Committed Resource capacity API HTTP 5xx errors"
+      description: >
+        The committed resource capacity API (Limes LIQUID integration) is returning
+        HTTP 5xx errors. This indicates internal problems calculating cluster capacity.
+        Limes may receive stale or incomplete capacity data.
+
+  - alert: CortexNovaCommittedResourceCapacityDroppedToZero
+    expr: |
+      (cortex_committed_resource_reported_capacity_gib{service="cortex-nova-metrics"} == 0)
+      and on(resource, az) (cortex_committed_resource_reported_capacity_gib{service="cortex-nova-metrics"} offset 30m > 0)
+    for: 5m
+    labels:
+      context: committed-resource-api
+      dashboard: cortex-status-dashboard/cortex-status-dashboard
+      service: cortex
+      severity: warning
+      support_group: workload-management
+    annotations:
+      summary: "Committed Resource capacity for {{ $labels.resource }} in {{ $labels.az }} dropped to zero"
+      description: >
+        The reported capacity for committed resource {{ $labels.resource }} in
+        availability zone {{ $labels.az }} has dropped from a positive value to zero.
+        This may mean hypervisors in that AZ are fully utilized for the corresponding
+        flavor group and no further committed resources can be placed there.
+
+  # Committed Resource Usage API
+  - alert: CortexNovaCommittedResourceUsageErrors
+    expr: |
+      rate(cortex_committed_resource_usage_api_requests_total{service="cortex-nova-metrics", status_code=~"5.."}[5m]) > 0
+    for: 5m
+    labels:
+      context: committed-resource-api
+      dashboard: cortex-status-dashboard/cortex-status-dashboard
+      service: cortex
+      severity: warning
+      support_group: workload-management
+    annotations:
+      summary: "Committed Resource usage API HTTP 5xx errors"
+      description: >
+        The committed resource usage API (Limes LIQUID integration) is returning
+        HTTP 5xx errors. This indicates internal problems fetching reservation or
+        Nova server data. Limes may receive stale or incomplete usage data.
+
+  # Committed Resource Quota API
+  - alert: CortexNovaCommittedResourceQuotaErrors
+    expr: |
+      rate(cortex_committed_resource_quota_api_requests_total{service="cortex-nova-metrics", status_code=~"5.."}[5m]) > 0
+    for: 5m
+    labels:
+      context: committed-resource-api
+      dashboard: cortex-status-dashboard/cortex-status-dashboard
+      service: cortex
+      severity: warning
+      support_group: workload-management
+    annotations:
+      summary: "Committed Resource quota API HTTP 5xx errors"
+      description: >
+        The committed resource quota API (Limes LIQUID integration) is returning
+        HTTP 5xx errors. This indicates internal problems computing or applying
+        quota. Limes may not be able to enforce committed resource quotas.

--- a/helm/bundles/cortex-nova/values.yaml
+++ b/helm/bundles/cortex-nova/values.yaml
@@ -177,7 +177,7 @@ cortex-scheduling-controllers:
       maxRequeueInterval: "30m"
     committedResourceAPI:
       # Timeout for watching CommittedResource CRDs before rolling back
-      watchTimeout: "10s"
+      watchTimeout: "15s"
       # How often to poll CommittedResource CRD conditions during watch
       watchPollInterval: "500ms"
       # When false, the endpoint returns HTTP 503; the info endpoint remains available.

--- a/helm/bundles/cortex-pods/Chart.yaml
+++ b/helm/bundles/cortex-pods/Chart.yaml
@@ -5,13 +5,13 @@ apiVersion: v2
 name: cortex-pods
 description: A Helm chart deploying Cortex for Pods.
 type: application
-version: 0.0.63
+version: 0.0.64
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.50
+    version: 0.0.51
 
   # Owner info adds a configmap to the kubernetes cluster with information on
   # the service owner. This makes it easier to find out who to contact in case

--- a/helm/library/cortex-shim/Chart.yaml
+++ b/helm/library/cortex-shim/Chart.yaml
@@ -3,6 +3,6 @@ name: cortex-shim
 description: A Helm chart to distribute cortex shims.
 type: application
 version: 0.1.0
-appVersion: "sha-d8bb12ef"
+appVersion: "sha-8dd7100b"
 icon: "https://example.com/icon.png"
 dependencies: []

--- a/helm/library/cortex/Chart.yaml
+++ b/helm/library/cortex/Chart.yaml
@@ -3,6 +3,6 @@ name: cortex
 description: A Helm chart to distribute cortex.
 type: application
 version: 0.0.51
-appVersion: "sha-98597910"
+appVersion: "sha-8dd7100b"
 icon: "https://example.com/icon.png"
 dependencies: []

--- a/helm/library/cortex/Chart.yaml
+++ b/helm/library/cortex/Chart.yaml
@@ -3,6 +3,6 @@ name: cortex
 description: A Helm chart to distribute cortex.
 type: application
 version: 0.0.50
-appVersion: "sha-9d06fa65"
+appVersion: "sha-1a597c16"
 icon: "https://example.com/icon.png"
 dependencies: []

--- a/helm/library/cortex/Chart.yaml
+++ b/helm/library/cortex/Chart.yaml
@@ -3,6 +3,6 @@ name: cortex
 description: A Helm chart to distribute cortex.
 type: application
 version: 0.0.50
-appVersion: "sha-1a597c16"
+appVersion: "sha-7b05fb14"
 icon: "https://example.com/icon.png"
 dependencies: []

--- a/helm/library/cortex/Chart.yaml
+++ b/helm/library/cortex/Chart.yaml
@@ -3,6 +3,6 @@ name: cortex
 description: A Helm chart to distribute cortex.
 type: application
 version: 0.0.50
-appVersion: "sha-7b05fb14"
+appVersion: "sha-98597910"
 icon: "https://example.com/icon.png"
 dependencies: []

--- a/helm/library/cortex/Chart.yaml
+++ b/helm/library/cortex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cortex
 description: A Helm chart to distribute cortex.
 type: application
-version: 0.0.50
+version: 0.0.51
 appVersion: "sha-98597910"
 icon: "https://example.com/icon.png"
 dependencies: []

--- a/internal/scheduling/reservations/capacity/metrics.go
+++ b/internal/scheduling/reservations/capacity/metrics.go
@@ -20,53 +20,47 @@ var (
 // Monitor provides Prometheus metrics for FlavorGroupCapacity CRDs.
 // It implements prometheus.Collector and reads CRD status on each Collect call.
 type Monitor struct {
-	client               client.Client
-	totalCapacityVMSlots *prometheus.GaugeVec
-	placeableVMs         *prometheus.GaugeVec
-	totalCapacityHosts   *prometheus.GaugeVec
-	placeableHosts       *prometheus.GaugeVec
-	totalInstances       *prometheus.GaugeVec
-	committedCapacity    *prometheus.GaugeVec
+	client            client.Client
+	vmSlotsEmpty      *prometheus.GaugeVec
+	vmSlotsPlaceable  *prometheus.GaugeVec
+	hostsEmpty        *prometheus.GaugeVec
+	hostsPlaceable    *prometheus.GaugeVec
+	committedCapacity *prometheus.GaugeVec
 }
 
 // NewMonitor creates a new Monitor that reads FlavorGroupCapacity CRDs.
 func NewMonitor(c client.Client) Monitor {
 	return Monitor{
 		client: c,
-		totalCapacityVMSlots: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_committed_resource_capacity_total",
-			Help: "Total schedulable slots in an empty-datacenter scenario per flavor.",
+		vmSlotsEmpty: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_committed_resource_capacity_vm_slots_empty_datacenter",
+			Help: "Schedulable VM slots per flavor assuming an empty datacenter (no existing VMs).",
 		}, capacityFlavorLabels),
-		placeableVMs: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_committed_resource_capacity_placeable",
-			Help: "Schedulable slots remaining given current VM allocations per flavor.",
+		vmSlotsPlaceable: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_committed_resource_capacity_vm_slots_placeable",
+			Help: "Schedulable VM slots remaining per flavor given current VM allocations.",
 		}, capacityFlavorLabels),
-		totalCapacityHosts: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_committed_resource_capacity_hosts_total",
-			Help: "Number of hosts eligible for this flavor in the empty-state probe.",
+		hostsEmpty: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_committed_resource_capacity_hosts_empty_datacenter",
+			Help: "Number of hosts eligible for this flavor assuming an empty datacenter.",
 		}, capacityFlavorLabels),
-		placeableHosts: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		hostsPlaceable: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_committed_resource_capacity_hosts_placeable",
 			Help: "Number of hosts still able to accept a new VM of this flavor.",
 		}, capacityFlavorLabels),
-		totalInstances: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_committed_resource_capacity_instances",
-			Help: "Total VM instances running on hypervisors in this AZ (not filtered by flavor group).",
-		}, capacityLabels),
 		committedCapacity: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_committed_resource_capacity_committed",
-			Help: "Sum of AcceptedAmount across Ready CommittedResource CRDs for this flavor group and AZ.",
+			Name: "cortex_committed_resource_committed_gib",
+			Help: "Sum of AcceptedAmount in GiB across Ready CommittedResource CRDs for this flavor group and AZ.",
 		}, capacityLabels),
 	}
 }
 
 // Describe implements prometheus.Collector.
 func (m *Monitor) Describe(ch chan<- *prometheus.Desc) {
-	m.totalCapacityVMSlots.Describe(ch)
-	m.placeableVMs.Describe(ch)
-	m.totalCapacityHosts.Describe(ch)
-	m.placeableHosts.Describe(ch)
-	m.totalInstances.Describe(ch)
+	m.vmSlotsEmpty.Describe(ch)
+	m.vmSlotsPlaceable.Describe(ch)
+	m.hostsEmpty.Describe(ch)
+	m.hostsPlaceable.Describe(ch)
 	m.committedCapacity.Describe(ch)
 }
 
@@ -81,11 +75,10 @@ func (m *Monitor) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	// Reset all gauges so deleted CRDs don't linger.
-	m.totalCapacityVMSlots.Reset()
-	m.placeableVMs.Reset()
-	m.totalCapacityHosts.Reset()
-	m.placeableHosts.Reset()
-	m.totalInstances.Reset()
+	m.vmSlotsEmpty.Reset()
+	m.vmSlotsPlaceable.Reset()
+	m.hostsEmpty.Reset()
+	m.hostsPlaceable.Reset()
 	m.committedCapacity.Reset()
 
 	for _, crd := range list.Items {
@@ -93,7 +86,6 @@ func (m *Monitor) Collect(ch chan<- prometheus.Metric) {
 			"flavor_group": crd.Spec.FlavorGroup,
 			"az":           crd.Spec.AvailabilityZone,
 		}
-		m.totalInstances.With(groupAZLabels).Set(float64(crd.Status.TotalInstances))
 		m.committedCapacity.With(groupAZLabels).Set(float64(crd.Status.CommittedCapacity))
 
 		for _, f := range crd.Status.Flavors {
@@ -102,17 +94,16 @@ func (m *Monitor) Collect(ch chan<- prometheus.Metric) {
 				"az":           crd.Spec.AvailabilityZone,
 				"flavor_name":  f.FlavorName,
 			}
-			m.totalCapacityVMSlots.With(flavorLabels).Set(float64(f.TotalCapacityVMSlots))
-			m.placeableVMs.With(flavorLabels).Set(float64(f.PlaceableVMs))
-			m.totalCapacityHosts.With(flavorLabels).Set(float64(f.TotalCapacityHosts))
-			m.placeableHosts.With(flavorLabels).Set(float64(f.PlaceableHosts))
+			m.vmSlotsEmpty.With(flavorLabels).Set(float64(f.TotalCapacityVMSlots))
+			m.vmSlotsPlaceable.With(flavorLabels).Set(float64(f.PlaceableVMs))
+			m.hostsEmpty.With(flavorLabels).Set(float64(f.TotalCapacityHosts))
+			m.hostsPlaceable.With(flavorLabels).Set(float64(f.PlaceableHosts))
 		}
 	}
 
-	m.totalCapacityVMSlots.Collect(ch)
-	m.placeableVMs.Collect(ch)
-	m.totalCapacityHosts.Collect(ch)
-	m.placeableHosts.Collect(ch)
-	m.totalInstances.Collect(ch)
+	m.vmSlotsEmpty.Collect(ch)
+	m.vmSlotsPlaceable.Collect(ch)
+	m.hostsEmpty.Collect(ch)
+	m.hostsPlaceable.Collect(ch)
 	m.committedCapacity.Collect(ch)
 }

--- a/internal/scheduling/reservations/commitments/api/change_commitments_metrics.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_metrics.go
@@ -29,7 +29,7 @@ func (api *HTTPAPI) recordMetrics(req liquid.CommitmentChangeRequest, resp liqui
 	}
 
 	// Record commitment changes counter
-	api.monitor.commitmentChanges.WithLabelValues(result).Add(float64(commitmentCount))
+	api.monitor.commitmentChanges.WithLabelValues(result, string(req.AZ)).Add(float64(commitmentCount))
 }
 
 // countCommitments counts the total number of commitments in a request.

--- a/internal/scheduling/reservations/commitments/api/change_commitments_monitor.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_monitor.go
@@ -25,30 +25,26 @@ func NewChangeCommitmentsAPIMonitor() ChangeCommitmentsAPIMonitor {
 			Help: "Total number of committed resource change API requests by HTTP status code",
 		}, []string{"status_code"}),
 		requestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: "cortex_committed_resource_change_api_request_duration_seconds",
-			Help: "Duration of committed resource change API requests in seconds by HTTP status code",
+			Name:    "cortex_committed_resource_change_api_request_duration_seconds",
+			Help:    "Duration of committed resource change API requests in seconds by HTTP status code",
+			Buckets: []float64{0.5, 1, 2.5, 5, 7.5, 10, 12.5, 15, 20, 30},
 		}, []string{"status_code"}),
 		commitmentChanges: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_committed_resource_change_api_commitment_changes_total",
-			Help: "Total number of commitment changes processed by result",
-		}, []string{"result"}),
+			Help: "Total number of commitment changes processed by result and availability zone",
+		}, []string{"result", "az"}),
 		timeouts: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "cortex_committed_resource_change_api_timeouts_total",
 			Help: "Total number of commitment change requests that timed out while waiting for reservations to become ready",
 		}),
 	}
 
-	// Pre-initialize metrics with zero values for common HTTP status codes.
+	// Pre-initialize request metrics with zero values for common HTTP status codes.
 	// This ensures metrics exist in Prometheus before the first request,
 	// preventing "metric missing" warnings in alerting rules.
 	for _, statusCode := range []string{"200", "400", "409", "500", "503"} {
 		m.requestCounter.WithLabelValues(statusCode)
 		m.requestDuration.WithLabelValues(statusCode)
-	}
-
-	// Pre-initialize commitment change result labels
-	for _, result := range []string{"accepted", "rejected"} {
-		m.commitmentChanges.WithLabelValues(result)
 	}
 
 	return m

--- a/internal/scheduling/reservations/commitments/api/change_commitments_monitor_test.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_monitor_test.go
@@ -23,7 +23,7 @@ func TestChangeCommitmentsAPIMonitor_MetricsRegistration(t *testing.T) {
 	// Observe metrics before gathering (Prometheus metrics with labels only appear after being used)
 	monitor.requestCounter.WithLabelValues("200").Inc()
 	monitor.requestDuration.WithLabelValues("200").Observe(0.1)
-	monitor.commitmentChanges.WithLabelValues("success").Inc()
+	monitor.commitmentChanges.WithLabelValues("success", "az-1").Inc()
 	monitor.timeouts.Inc()
 
 	// Verify metrics can be gathered
@@ -90,8 +90,8 @@ func TestChangeCommitmentsAPIMonitor_MetricLabels(t *testing.T) {
 	monitor.requestCounter.WithLabelValues("409").Inc()
 	monitor.requestCounter.WithLabelValues("503").Inc()
 	monitor.requestDuration.WithLabelValues("200").Observe(1.5)
-	monitor.commitmentChanges.WithLabelValues("success").Add(5)
-	monitor.commitmentChanges.WithLabelValues("rejected").Add(2)
+	monitor.commitmentChanges.WithLabelValues("success", "az-1").Add(5)
+	monitor.commitmentChanges.WithLabelValues("rejected", "az-1").Add(2)
 
 	// Gather metrics
 	families, err := registry.Gather()
@@ -142,13 +142,12 @@ func TestChangeCommitmentsAPIMonitor_MetricLabels(t *testing.T) {
 		}
 
 		if *family.Name == "cortex_committed_resource_change_api_commitment_changes_total" {
-			// At minimum we expect the 2 labels we added (success, rejected)
-			// Plus pre-initialized labels (accepted) - so >= 2 total
+			// 2 label combinations: (success,az-1) and (rejected,az-1)
 			if len(family.Metric) < 2 {
 				t.Errorf("Expected at least 2 commitment changes metrics, got %d", len(family.Metric))
 			}
 
-			// Check all metrics have the result label
+			// Check all metrics have both result and az labels
 			for _, metric := range family.Metric {
 				labelNames := make(map[string]bool)
 				for _, label := range metric.Label {
@@ -157,6 +156,9 @@ func TestChangeCommitmentsAPIMonitor_MetricLabels(t *testing.T) {
 
 				if !labelNames["result"] {
 					t.Error("Missing 'result' label in commitment changes counter")
+				}
+				if !labelNames["az"] {
+					t.Error("Missing 'az' label in commitment changes counter")
 				}
 			}
 		}

--- a/internal/scheduling/reservations/commitments/api/info.go
+++ b/internal/scheduling/reservations/commitments/api/info.go
@@ -76,7 +76,7 @@ func (api *HTTPAPI) recordInfoMetrics(statusCode int, startTime time.Time) {
 }
 
 // resourceAttributes holds the custom attributes for a resource in the info API response.
-// Ratio values are in GiB per vCPU, matching the RAM resource unit (UnitGibibytes).
+// Ratio values are in GiB per vCPU.
 type resourceAttributes struct {
 	RamCoreRatio    *uint64 `json:"ramCoreRatio,omitempty"`
 	RamCoreRatioMin *uint64 `json:"ramCoreRatioMin,omitempty"`
@@ -137,26 +137,22 @@ func (api *HTTPAPI) buildServiceInfo(ctx context.Context, logger logr.Logger) (l
 
 		// === 1. RAM Resource ===
 		ramResourceName := liquid.ResourceName(commitments.ResourceNameRAM(groupName))
-		// Determine topology: AZSeparatedTopology only for groups that accept commitments
-		// (AZSeparatedTopology means quota is also AZ-aware, required when HasQuota=true)
-		ramTopology := liquid.AZAwareTopology
-		if resCfg.RAM.HandlesCommitments {
-			ramTopology = liquid.AZSeparatedTopology
+		// Fixed-ratio groups: unit = smallest flavor's RAM in MiB (e.g. "480 GiB" for hana);
+		// variable-ratio groups: unit = 1 GiB.  RAMUnitMiB() encodes both cases.
+		ramUnit, err := liquid.UnitMebibytes.MultiplyBy(groupData.RAMUnitMiB())
+		if err != nil {
+			return liquid.ServiceInfo{}, fmt.Errorf("failed to create RAM unit for flavor group %q: %w", groupName, err)
 		}
-		// Fixed-ratio groups: unit is 1 slot (= 1 smallest-flavor instance); variable-ratio: GiB.
-		var ramUnit liquid.Unit
 		var ramDisplayName string
-		if groupData.HasFixedRamCoreRatio() {
-			ramUnit = liquid.UnitNone
+		if groupData.HasFixedRamCoreRatio() && groupData.SmallestFlavor.MemoryMB > 0 {
 			ramDisplayName = fmt.Sprintf("multiples of %d MiB (usable by: %s)", groupData.SmallestFlavor.MemoryMB, flavorListStr)
 		} else {
-			ramUnit = liquid.UnitGibibytes
 			ramDisplayName = fmt.Sprintf("GiB of RAM (usable by: %s)", flavorListStr)
 		}
 		resources[ramResourceName] = liquid.ResourceInfo{
 			DisplayName:         ramDisplayName,
 			Unit:                ramUnit,
-			Topology:            ramTopology,
+			Topology:            liquid.AZSeparatedTopology,
 			NeedsResourceDemand: false,
 			HasCapacity:         resCfg.RAM.HasCapacity,
 			HasQuota:            resCfg.RAM.HasQuota,
@@ -166,17 +162,13 @@ func (api *HTTPAPI) buildServiceInfo(ctx context.Context, logger logr.Logger) (l
 
 		// === 2. Cores Resource ===
 		coresResourceName := liquid.ResourceName(commitments.ResourceNameCores(groupName))
-		coresTopology := liquid.AZAwareTopology
-		if resCfg.Cores.HandlesCommitments {
-			coresTopology = liquid.AZSeparatedTopology
-		}
 		resources[coresResourceName] = liquid.ResourceInfo{
 			DisplayName: fmt.Sprintf(
 				"CPU cores (usable by: %s)",
 				flavorListStr,
 			),
 			Unit:                liquid.UnitNone,
-			Topology:            coresTopology,
+			Topology:            liquid.AZSeparatedTopology,
 			NeedsResourceDemand: false,
 			HasCapacity:         resCfg.Cores.HasCapacity,
 			HasQuota:            resCfg.Cores.HasQuota,
@@ -186,17 +178,13 @@ func (api *HTTPAPI) buildServiceInfo(ctx context.Context, logger logr.Logger) (l
 
 		// === 3. Instances Resource ===
 		instancesResourceName := liquid.ResourceName(commitments.ResourceNameInstances(groupName))
-		instancesTopology := liquid.AZAwareTopology
-		if resCfg.Instances.HandlesCommitments {
-			instancesTopology = liquid.AZSeparatedTopology
-		}
 		resources[instancesResourceName] = liquid.ResourceInfo{
 			DisplayName: fmt.Sprintf(
 				"instances (usable by: %s)",
 				flavorListStr,
 			),
 			Unit:                liquid.UnitNone,
-			Topology:            instancesTopology,
+			Topology:            liquid.AZSeparatedTopology,
 			NeedsResourceDemand: false,
 			HasCapacity:         resCfg.Instances.HasCapacity,
 			HasQuota:            resCfg.Instances.HasQuota,

--- a/internal/scheduling/reservations/commitments/api/info_test.go
+++ b/internal/scheduling/reservations/commitments/api/info_test.go
@@ -247,7 +247,7 @@ func TestHandleInfo_ResourceFlagsFromConfig(t *testing.T) {
 		t.Error("hw_version_hana_fixed_ram: expected HasQuota=true (fixed ratio groups accept quotas)")
 	}
 
-	// Test Cores resource: hw_version_hana_fixed_cores (HandlesCommitments=false → AZAwareTopology)
+	// Test Cores resource: hw_version_hana_fixed_cores
 	coresResource, ok := serviceInfo.Resources["hw_version_hana_fixed_cores"]
 	if !ok {
 		t.Fatal("expected hw_version_hana_fixed_cores resource to exist")
@@ -258,14 +258,14 @@ func TestHandleInfo_ResourceFlagsFromConfig(t *testing.T) {
 	if coresResource.HandlesCommitments {
 		t.Error("hw_version_hana_fixed_cores: expected HandlesCommitments=false")
 	}
-	if coresResource.Topology != liquid.AZAwareTopology {
-		t.Errorf("hw_version_hana_fixed_cores: expected Topology=%q, got %q", liquid.AZAwareTopology, coresResource.Topology)
+	if coresResource.Topology != liquid.AZSeparatedTopology {
+		t.Errorf("hw_version_hana_fixed_cores: expected Topology=%q, got %q", liquid.AZSeparatedTopology, coresResource.Topology)
 	}
 	if coresResource.HasQuota {
 		t.Error("hw_version_hana_fixed_cores: expected HasQuota=false")
 	}
 
-	// Test Instances resource: hw_version_hana_fixed_instances (HandlesCommitments=false → AZAwareTopology)
+	// Test Instances resource: hw_version_hana_fixed_instances
 	instancesResource, ok := serviceInfo.Resources["hw_version_hana_fixed_instances"]
 	if !ok {
 		t.Fatal("expected hw_version_hana_fixed_instances resource to exist")
@@ -276,8 +276,8 @@ func TestHandleInfo_ResourceFlagsFromConfig(t *testing.T) {
 	if instancesResource.HandlesCommitments {
 		t.Error("hw_version_hana_fixed_instances: expected HandlesCommitments=false")
 	}
-	if instancesResource.Topology != liquid.AZAwareTopology {
-		t.Errorf("hw_version_hana_fixed_instances: expected Topology=%q, got %q", liquid.AZAwareTopology, instancesResource.Topology)
+	if instancesResource.Topology != liquid.AZSeparatedTopology {
+		t.Errorf("hw_version_hana_fixed_instances: expected Topology=%q, got %q", liquid.AZSeparatedTopology, instancesResource.Topology)
 	}
 	if instancesResource.HasQuota {
 		t.Error("hw_version_hana_fixed_instances: expected HasQuota=false")
@@ -294,8 +294,8 @@ func TestHandleInfo_ResourceFlagsFromConfig(t *testing.T) {
 	if v2RamResource.HandlesCommitments {
 		t.Error("hw_version_v2_variable_ram: expected HandlesCommitments=false (not in config)")
 	}
-	if v2RamResource.Topology != liquid.AZAwareTopology {
-		t.Errorf("hw_version_v2_variable_ram: expected Topology=%q, got %q", liquid.AZAwareTopology, v2RamResource.Topology)
+	if v2RamResource.Topology != liquid.AZSeparatedTopology {
+		t.Errorf("hw_version_v2_variable_ram: expected Topology=%q, got %q", liquid.AZSeparatedTopology, v2RamResource.Topology)
 	}
 	if v2RamResource.HasQuota {
 		t.Error("hw_version_v2_variable_ram: expected HasQuota=false (variable ratio)")
@@ -311,8 +311,8 @@ func TestHandleInfo_ResourceFlagsFromConfig(t *testing.T) {
 	if v2CoresResource.HandlesCommitments {
 		t.Error("hw_version_v2_variable_cores: expected HandlesCommitments=false")
 	}
-	if v2CoresResource.Topology != liquid.AZAwareTopology {
-		t.Errorf("hw_version_v2_variable_cores: expected Topology=%q, got %q", liquid.AZAwareTopology, v2CoresResource.Topology)
+	if v2CoresResource.Topology != liquid.AZSeparatedTopology {
+		t.Errorf("hw_version_v2_variable_cores: expected Topology=%q, got %q", liquid.AZSeparatedTopology, v2CoresResource.Topology)
 	}
 	if v2CoresResource.HasQuota {
 		t.Error("hw_version_v2_variable_cores: expected HasQuota=false")
@@ -328,8 +328,8 @@ func TestHandleInfo_ResourceFlagsFromConfig(t *testing.T) {
 	if v2InstancesResource.HandlesCommitments {
 		t.Error("hw_version_v2_variable_instances: expected HandlesCommitments=false")
 	}
-	if v2InstancesResource.Topology != liquid.AZAwareTopology {
-		t.Errorf("hw_version_v2_variable_instances: expected Topology=%q, got %q", liquid.AZAwareTopology, v2InstancesResource.Topology)
+	if v2InstancesResource.Topology != liquid.AZSeparatedTopology {
+		t.Errorf("hw_version_v2_variable_instances: expected Topology=%q, got %q", liquid.AZSeparatedTopology, v2InstancesResource.Topology)
 	}
 	if v2InstancesResource.HasQuota {
 		t.Error("hw_version_v2_variable_instances: expected HasQuota=false")
@@ -341,17 +341,22 @@ func TestHandleInfo_ResourceFlagsFromConfig(t *testing.T) {
 	// v2_variable has ramCoreRatioMin=2048 MiB/vCPU, ramCoreRatioMax=16384 MiB/vCPU → expect 2, 16 GiB/vCPU.
 	checkAttrsRatio(t, "hw_version_v2_variable_ram", v2RamResource.Attributes, 0, ptr(uint64(2)), ptr(uint64(16)))
 
-	// Verify RAM units: fixed-ratio groups use UnitNone (slot-based), variable-ratio use UnitGibibytes.
-	if ramResource.Unit != liquid.UnitNone {
-		t.Errorf("hw_version_hana_fixed_ram: expected Unit=%q (slot-based), got %q", liquid.UnitNone, ramResource.Unit)
+	// Verify RAM units: fixed-ratio groups use smallest-flavor-based unit (e.g. "16 GiB"),
+	// variable-ratio groups use UnitGibibytes ("GiB").
+	expectedFixedUnit, err := liquid.UnitMebibytes.MultiplyBy(16384) // hana_fixed smallest flavor: 16384 MiB = 16 GiB
+	if err != nil {
+		t.Fatalf("failed to create expected fixed unit: %v", err)
+	}
+	if ramResource.Unit != expectedFixedUnit {
+		t.Errorf("hw_version_hana_fixed_ram: expected Unit=%q (slot-based), got %q", expectedFixedUnit, ramResource.Unit)
 	}
 	if v2RamResource.Unit != liquid.UnitGibibytes {
 		t.Errorf("hw_version_v2_variable_ram: expected Unit=%q, got %q", liquid.UnitGibibytes, v2RamResource.Unit)
 	}
 }
 
-func TestHandleInfo_TopologyFollowsHandlesCommitments(t *testing.T) {
-	// Verifies that any resource with HandlesCommitments=true gets AZSeparatedTopology,
+func TestHandleInfo_AllResourcesAZSeparated(t *testing.T) {
+	// Verifies that all resources always get AZSeparatedTopology.
 	// regardless of whether it's RAM, Cores, or Instances.
 	scheme := runtime.NewScheme()
 	if err := v1alpha1.AddToScheme(scheme); err != nil {

--- a/internal/scheduling/reservations/commitments/api/report_capacity.go
+++ b/internal/scheduling/reservations/commitments/api/report_capacity.go
@@ -71,6 +71,13 @@ func (api *HTTPAPI) HandleReportCapacity(w http.ResponseWriter, r *http.Request)
 
 	logger.Info("calculated capacity report", "resourceCount", len(report.Resources))
 
+	// Update capacity gauge for each resource/AZ combination.
+	for resName, resReport := range report.Resources {
+		for az, azReport := range resReport.PerAZ {
+			api.capacityMonitor.reportedCapacity.WithLabelValues(string(resName), string(az)).Set(float64(azReport.Capacity))
+		}
+	}
+
 	// Return response
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)

--- a/internal/scheduling/reservations/commitments/api/report_capacity_monitor.go
+++ b/internal/scheduling/reservations/commitments/api/report_capacity_monitor.go
@@ -9,8 +9,9 @@ import (
 
 // ReportCapacityAPIMonitor provides metrics for the CR report-capacity API.
 type ReportCapacityAPIMonitor struct {
-	requestCounter  *prometheus.CounterVec
-	requestDuration *prometheus.HistogramVec
+	requestCounter   *prometheus.CounterVec
+	requestDuration  *prometheus.HistogramVec
+	reportedCapacity *prometheus.GaugeVec
 }
 
 // NewReportCapacityAPIMonitor creates a new monitor with Prometheus metrics.
@@ -27,6 +28,10 @@ func NewReportCapacityAPIMonitor() ReportCapacityAPIMonitor {
 			Help:    "Duration of committed resource capacity API requests in seconds by HTTP status code",
 			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		}, []string{"status_code"}),
+		reportedCapacity: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_committed_resource_reported_capacity_gib",
+			Help: "Last reported capacity in GiB per resource and availability zone as returned by the capacity API",
+		}, []string{"resource", "az"}),
 	}
 
 	// Pre-initialize metrics with zero values for common HTTP status codes.
@@ -44,10 +49,12 @@ func NewReportCapacityAPIMonitor() ReportCapacityAPIMonitor {
 func (m *ReportCapacityAPIMonitor) Describe(ch chan<- *prometheus.Desc) {
 	m.requestCounter.Describe(ch)
 	m.requestDuration.Describe(ch)
+	m.reportedCapacity.Describe(ch)
 }
 
 // Collect implements prometheus.Collector.
 func (m *ReportCapacityAPIMonitor) Collect(ch chan<- prometheus.Metric) {
 	m.requestCounter.Collect(ch)
 	m.requestDuration.Collect(ch)
+	m.reportedCapacity.Collect(ch)
 }

--- a/internal/scheduling/reservations/commitments/usage.go
+++ b/internal/scheduling/reservations/commitments/usage.go
@@ -509,29 +509,34 @@ func (c *UsageCalculator) buildUsageResponse(
 	// Build ResourceUsageReport for all flavor groups (not just those with fixed ratio)
 	for flavorGroupName := range flavorGroups {
 		// All flavor groups are included in usage reporting.
+		resCfg := config.ResourceConfigForGroup(flavorGroupName)
+
+		// helper: look up stored quota for a resource in a given AZ (stored in GiB).
+		// Returns -1 (infinite) if not found. Unit conversion is done by the caller.
+		lookupQuotaGiB := func(resourceName string, az liquid.AvailabilityZone) int64 {
+			if quotaByResourceAZ == nil {
+				return -1
+			}
+			if azMap, ok := quotaByResourceAZ[resourceName]; ok {
+				if q, ok := azMap[string(az)]; ok {
+					return q
+				}
+			}
+			return -1
+		}
 
 		// === 1. RAM Resource ===
 		ramResourceName := liquid.ResourceName(ResourceNameRAM(flavorGroupName))
 		ramPerAZ := make(map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport)
-		// Include per-AZ quota for AZSeparatedTopology resources — same condition as info.go.
-		ramHasAZQuota := config.ResourceConfigForGroup(flavorGroupName).RAM.HandlesCommitments
 		for _, az := range allAZs {
 			report := &liquid.AZResourceUsageReport{
 				Usage:        0,
 				Subresources: []liquid.Subresource{},
 			}
-			if ramHasAZQuota {
-				quota := int64(-1) // default: infinite
-				if quotaByResourceAZ != nil {
-					if azMap, ok := quotaByResourceAZ[string(ramResourceName)]; ok {
-						if q, ok := azMap[string(az)]; ok {
-							// CRD stores quota in GiB; convert to declared unit for Limes.
-							fg := flavorGroups[flavorGroupName]
-							quota = fg.GiBToDeclaredUnits(q)
-						}
-					}
-				}
-				report.Quota = Some(quota)
+			if resCfg.RAM.HasQuota {
+				// CRD stores quota in GiB; convert to declared unit for Limes.
+				fg := flavorGroups[flavorGroupName]
+				report.Quota = Some(fg.GiBToDeclaredUnits(lookupQuotaGiB(string(ramResourceName), az)))
 			}
 			ramPerAZ[az] = report
 		}
@@ -541,7 +546,6 @@ func (c *UsageCalculator) buildUsageResponse(
 					continue // skip VMs in AZs not in allAZs
 				}
 				ramPerAZ[az].Usage = data.ramUsage
-				// Subresources are only on instances resource
 			}
 		}
 		resources[ramResourceName] = &liquid.ResourceUsageReport{
@@ -552,10 +556,14 @@ func (c *UsageCalculator) buildUsageResponse(
 		coresResourceName := liquid.ResourceName(ResourceNameCores(flavorGroupName))
 		coresPerAZ := make(map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport)
 		for _, az := range allAZs {
-			coresPerAZ[az] = &liquid.AZResourceUsageReport{
+			report := &liquid.AZResourceUsageReport{
 				Usage:        0,
 				Subresources: []liquid.Subresource{},
 			}
+			if resCfg.Cores.HasQuota {
+				report.Quota = Some(lookupQuotaGiB(string(coresResourceName), az))
+			}
+			coresPerAZ[az] = report
 		}
 		if azData, exists := usageByFlavorGroupAZ[flavorGroupName]; exists {
 			for az, data := range azData {
@@ -563,7 +571,6 @@ func (c *UsageCalculator) buildUsageResponse(
 					continue // skip VMs in AZs not in allAZs
 				}
 				coresPerAZ[az].Usage = data.coresUsage
-				// Subresources are only on instances resource
 			}
 		}
 		resources[coresResourceName] = &liquid.ResourceUsageReport{
@@ -574,10 +581,14 @@ func (c *UsageCalculator) buildUsageResponse(
 		instancesResourceName := liquid.ResourceName(ResourceNameInstances(flavorGroupName))
 		instancesPerAZ := make(map[liquid.AvailabilityZone]*liquid.AZResourceUsageReport)
 		for _, az := range allAZs {
-			instancesPerAZ[az] = &liquid.AZResourceUsageReport{
+			report := &liquid.AZResourceUsageReport{
 				Usage:        0,
 				Subresources: []liquid.Subresource{},
 			}
+			if resCfg.Instances.HasQuota {
+				report.Quota = Some(lookupQuotaGiB(string(instancesResourceName), az))
+			}
+			instancesPerAZ[az] = report
 		}
 		if azData, exists := usageByFlavorGroupAZ[flavorGroupName]; exists {
 			for az, data := range azData {

--- a/internal/scheduling/reservations/monitor.go
+++ b/internal/scheduling/reservations/monitor.go
@@ -33,12 +33,12 @@ func NewMonitor(k8sClient client.Client) Monitor {
 	return Monitor{
 		Client: k8sClient,
 		numberOfReservations: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_reservations_number",
-			Help: "Number of reservations.",
+			Name: "cortex_reservations",
+			Help: "Number of reservations by readiness and error status.",
 		}, []string{"status_ready", "status_error"}),
 		reservedResources: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_reservations_resources",
-			Help: "Resources reserved by reservations.",
+			Name: "cortex_reservations_allocated_resources",
+			Help: "Resource units allocated across active reservations, by host and resource type.",
 		}, []string{"status_ready", "status_error", "host", "resource"}),
 	}
 }

--- a/internal/shim/placement/field_index_test.go
+++ b/internal/shim/placement/field_index_test.go
@@ -133,17 +133,15 @@ func TestIndexFields_RegistersAllIndexes(t *testing.T) {
 	}
 }
 
-func TestIndexFields_PropagatesError(t *testing.T) {
-	wantErr := errors.New("cache failure")
-	cc := &captureCache{err: wantErr}
+func TestIndexFields_ToleratesClusterError(t *testing.T) {
+	// A failing cluster cache should not prevent index setup for other clusters.
+	// The multicluster IndexField logs per-cluster errors and continues, so
+	// IndexFields must return nil even when every cache call fails.
+	cc := &captureCache{err: errors.New("cache failure")}
 	mcl := buildClient(t, cc)
 
-	err := IndexFields(context.Background(), mcl)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, wantErr) {
-		t.Errorf("got %v, want %v", err, wantErr)
+	if err := IndexFields(context.Background(), mcl); err != nil {
+		t.Fatalf("expected nil, got %v", err)
 	}
 }
 

--- a/pkg/multicluster/client.go
+++ b/pkg/multicluster/client.go
@@ -641,7 +641,13 @@ func (c *subResourceClient) Apply(ctx context.Context, obj runtime.ApplyConfigur
 // Index a field for a resource in all matching cluster caches.
 // Usually, you want to index the same field in both the object and list type,
 // as both would be mapped to individual clients based on their GVK.
+//
+// Per-cluster errors are logged and skipped — a temporarily-unreachable cluster
+// does not prevent index setup for the other clusters. This mirrors the List
+// error-handling pattern: the affected cluster's objects will be silently absent
+// from MatchingFields queries until the index is established (e.g. after restart).
 func (c *Client) IndexField(ctx context.Context, obj client.Object, list client.ObjectList, field string, extractValue client.IndexerFunc) error {
+	log := ctrl.LoggerFrom(ctx)
 	gvk, err := c.GVKFromHomeScheme(obj)
 	if err != nil {
 		return err
@@ -663,7 +669,8 @@ func (c *Client) IndexField(ctx context.Context, obj client.Object, list client.
 		}
 		indexed[ch] = true
 		if err := ch.IndexField(ctx, obj, field, extractValue); err != nil {
-			return err
+			log.Error(err, "failed to register field index for cluster — objects from this cluster will be absent from index queries; restart required to recover", "field", field)
+			continue
 		}
 	}
 	clustersList, err := c.ClustersForGVK(gvkList)
@@ -677,7 +684,8 @@ func (c *Client) IndexField(ctx context.Context, obj client.Object, list client.
 		}
 		indexed[ch] = true
 		if err := ch.IndexField(ctx, obj, field, extractValue); err != nil {
-			return err
+			log.Error(err, "failed to register field index for cluster — objects from this cluster will be absent from index queries; restart required to recover", "field", field)
+			continue
 		}
 	}
 	return nil


### PR DESCRIPTION
* fix: CR api responses matching Limes validations
* fix: start API server only after cache sync to prevent startup race
* fix: Adds Prometheus metrics and alerting for the committed resource