### PR TITLE
Fix claude workflow: enforce allowlist and remove review trigger

### DIFF
--- a/.github/workflows/claude-assistant.yaml
+++ b/.github/workflows/claude-assistant.yaml
@@ -7,8 +7,6 @@ on:
     types: [opened, assigned]
   pull_request_review_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   check-allowlist:
@@ -31,6 +29,7 @@ jobs:
 
   claude:
     needs: check-allowlist
+    if: needs.check-allowlist.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
- Add missing 'if' condition on claude job to actually gate on the allowlist check output. Previously the check ran but was never used.
- Remove pull_request_review trigger to avoid firing on approvals/ request_changes. Inline review comments and issue comments still work.