### PR TITLE
Bump core to 0.0.52 and bundles to 0.0.65 

### DIFF
--- a/.github/workflows/claude-assistant.yaml
+++ b/.github/workflows/claude-assistant.yaml
@@ -7,8 +7,6 @@ on:
     types: [opened, assigned]
   pull_request_review_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   check-allowlist:
@@ -31,6 +29,7 @@ jobs:
 
   claude:
     needs: check-allowlist
+    if: needs.check-allowlist.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,21 +12,7 @@ on:
       - '*'
 
 jobs:
-  test-without-docker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: 'go.mod'
-      - name: Test quickly without Docker
-        run: go test -v ./...
-
-  test-with-docker:
-    # We don't need to run this longer test if the previous one already failed.
-    needs: test-without-docker
+  test:
     runs-on: ubuntu-latest
     services:
       dind:
@@ -40,7 +26,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
-      - name: Run tests with Docker and calculate coverage
+      - name: Run tests and calculate coverage
         run: |
           export GITHUB_ACTIONS=1
           export POSTGRES_CONTAINER=1
@@ -48,7 +34,7 @@ jobs:
           echo "Running tests..."
           go test -v \
             -coverpkg=./internal/... \
-            -coverprofile=profile.cov ./internal/...
+            -coverprofile=profile.cov ./...
 
           # Exclude e2e files from the coverage profile so they don't
           # count against the coverage percentage.

--- a/helm/bundles/cortex-cinder/Chart.yaml
+++ b/helm/bundles/cortex-cinder/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cortex-cinder
 description: A Helm chart deploying Cortex for Cinder.
 type: application
-version: 0.0.64
+version: 0.0.65
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex-postgres
@@ -16,12 +16,12 @@ dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.51
+    version: 0.0.52
     alias: cortex-knowledge-controllers
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.51
+    version: 0.0.52
     alias: cortex-scheduling-controllers
 
   # Owner info adds a configmap to the kubernetes cluster with information on

--- a/helm/bundles/cortex-crds/Chart.yaml
+++ b/helm/bundles/cortex-crds/Chart.yaml
@@ -5,13 +5,13 @@ apiVersion: v2
 name: cortex-crds
 description: A Helm chart deploying Cortex CRDs.
 type: application
-version: 0.0.64
+version: 0.0.65
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.51
+    version: 0.0.52
 
   # Owner info adds a configmap to the kubernetes cluster with information on
   # the service owner. This makes it easier to find out who to contact in case

--- a/helm/bundles/cortex-ironcore/Chart.yaml
+++ b/helm/bundles/cortex-ironcore/Chart.yaml
@@ -5,13 +5,13 @@ apiVersion: v2
 name: cortex-ironcore
 description: A Helm chart deploying Cortex for IronCore.
 type: application
-version: 0.0.64
+version: 0.0.65
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.51
+    version: 0.0.52
 
   # Owner info adds a configmap to the kubernetes cluster with information on
   # the service owner. This makes it easier to find out who to contact in case

--- a/helm/bundles/cortex-manila/Chart.yaml
+++ b/helm/bundles/cortex-manila/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cortex-manila
 description: A Helm chart deploying Cortex for Manila.
 type: application
-version: 0.0.64
+version: 0.0.65
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex-postgres
@@ -16,12 +16,12 @@ dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.51
+    version: 0.0.52
     alias: cortex-knowledge-controllers
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.51
+    version: 0.0.52
     alias: cortex-scheduling-controllers
 
   # Owner info adds a configmap to the kubernetes cluster with information on

--- a/helm/bundles/cortex-nova/Chart.yaml
+++ b/helm/bundles/cortex-nova/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cortex-nova
 description: A Helm chart deploying Cortex for Nova.
 type: application
-version: 0.0.64
+version: 0.0.65
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex-postgres
@@ -16,12 +16,12 @@ dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.51
+    version: 0.0.52
     alias: cortex-knowledge-controllers
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.51
+    version: 0.0.52
     alias: cortex-scheduling-controllers
 
   # Owner info adds a configmap to the kubernetes cluster with information on

--- a/helm/bundles/cortex-pods/Chart.yaml
+++ b/helm/bundles/cortex-pods/Chart.yaml
@@ -5,13 +5,13 @@ apiVersion: v2
 name: cortex-pods
 description: A Helm chart deploying Cortex for Pods.
 type: application
-version: 0.0.64
+version: 0.0.65
 appVersion: 0.1.0
 dependencies:
   # from: file://../../library/cortex
   - name: cortex
     repository: oci://ghcr.io/cobaltcore-dev/cortex/charts
-    version: 0.0.51
+    version: 0.0.52
 
   # Owner info adds a configmap to the kubernetes cluster with information on
   # the service owner. This makes it easier to find out who to contact in case

--- a/helm/library/cortex/Chart.yaml
+++ b/helm/library/cortex/Chart.yaml
@@ -3,6 +3,6 @@ name: cortex
 description: A Helm chart to distribute cortex.
 type: application
 version: 0.0.52
-appVersion: "sha-8dd7100b"
+appVersion: "sha-295edcd8"
 icon: "https://example.com/icon.png"
 dependencies: []

--- a/helm/library/cortex/Chart.yaml
+++ b/helm/library/cortex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cortex
 description: A Helm chart to distribute cortex.
 type: application
-version: 0.0.51
+version: 0.0.52
 appVersion: "sha-8dd7100b"
 icon: "https://example.com/icon.png"
 dependencies: []


### PR DESCRIPTION
* fix: tolerate unreachable remote clusters during field index setup
* fix: CR api responses matching Limes validations
* fix: start API server only after cache sync to prevent startup race
* fix: Adds Prometheus metrics and alerting for the committed resource