### PR TITLE
 feat: make RAM unit per flavor group operator-configurable

### DIFF
--- a/helm/bundles/cortex-nova/values.yaml
+++ b/helm/bundles/cortex-nova/values.yaml
@@ -197,6 +197,7 @@ cortex-scheduling-controllers:
             handlesCommitments: false
             hasCapacity: true
             hasQuota: false
+            ramUnitGiB: 1
           cores:
             handlesCommitments: false
             hasCapacity: true

--- a/internal/scheduling/reservations/commitments/api/change_commitments.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments.go
@@ -203,10 +203,9 @@ ProcessLoop:
 				break ProcessLoop
 			}
 
-			groupData := flavorGroups[flavorGroupName]
-			ramUnitMiB := groupData.RAMUnitMiB()
-
 			groupResourceConf := api.config.ResourceConfigForGroup(flavorGroupName)
+			ramUnitMiB := groupResourceConf.RAM.RAMUnitMiB()
+
 			var handlesCommitments bool
 			switch resourceType {
 			case v1alpha1.CommittedResourceTypeCores:

--- a/internal/scheduling/reservations/commitments/api/change_commitments_e2e_test.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_e2e_test.go
@@ -121,7 +121,7 @@ func newE2EEnv(t *testing.T, flavors []*TestFlavor, infoVersion int64, scheduler
 
 	// HTTPAPI wired directly to the real k8s client (no fakeControllerClient wrapper).
 	cfg := commitments.DefaultAPIConfig()
-	cfg.WatchTimeout = metav1.Duration{Duration: 5 * time.Second}
+	cfg.WatchTimeout = metav1.Duration{Duration: 20 * time.Second}
 	cfg.WatchPollInterval = metav1.Duration{Duration: 100 * time.Millisecond}
 	cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
 		"*": {RAM: commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasCapacity: true}},

--- a/internal/scheduling/reservations/commitments/api/change_commitments_e2e_test.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_e2e_test.go
@@ -124,7 +124,7 @@ func newE2EEnv(t *testing.T, flavors []*TestFlavor, infoVersion int64, scheduler
 	cfg.WatchTimeout = metav1.Duration{Duration: 5 * time.Second}
 	cfg.WatchPollInterval = metav1.Duration{Duration: 100 * time.Millisecond}
 	cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
-		"*": {RAM: commitments.ResourceTypeConfig{HandlesCommitments: true, HasCapacity: true}},
+		"*": {RAM: commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasCapacity: true}},
 	}
 	api := NewAPIWithConfig(k8sClient, cfg, nil)
 	mux := http.NewServeMux()

--- a/internal/scheduling/reservations/commitments/api/change_commitments_test.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_test.go
@@ -153,7 +153,7 @@ func TestHandleChangeCommitments(t *testing.T) {
 				cfg.WatchTimeout = metav1.Duration{}
 				cfg.WatchPollInterval = metav1.Duration{Duration: 100 * time.Millisecond}
 				cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
-					"*": {RAM: commitments.ResourceTypeConfig{HandlesCommitments: true, HasCapacity: true}},
+					"*": {RAM: commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasCapacity: true}},
 				}
 				return &cfg
 			}(),
@@ -750,7 +750,7 @@ func newCRTestEnv(t *testing.T, tc CommitmentChangeTestCase) *CRTestEnv {
 		cfg := commitments.DefaultAPIConfig()
 		cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
 			"*": {
-				RAM:       commitments.ResourceTypeConfig{HandlesCommitments: true, HasCapacity: true},
+				RAM:       commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasCapacity: true},
 				Cores:     commitments.ResourceTypeConfig{HasCapacity: true},
 				Instances: commitments.ResourceTypeConfig{HasCapacity: true},
 			},

--- a/internal/scheduling/reservations/commitments/api/handler.go
+++ b/internal/scheduling/reservations/commitments/api/handler.go
@@ -64,6 +64,7 @@ func (api *HTTPAPI) Init(mux *http.ServeMux, registry prometheus.Registerer, log
 		"changeCommitmentsEnabled", api.config.EnableChangeCommitments,
 		"reportUsageEnabled", api.config.EnableReportUsage,
 		"reportCapacityEnabled", api.config.EnableReportCapacity)
+	commitments.LogFlavorGroupResourceConfig(log, api.config.FlavorGroupResourceConfig)
 }
 
 // handleProjectEndpoint routes /commitments/v1/projects/:project_id/... requests to the appropriate handler.

--- a/internal/scheduling/reservations/commitments/api/info.go
+++ b/internal/scheduling/reservations/commitments/api/info.go
@@ -137,15 +137,13 @@ func (api *HTTPAPI) buildServiceInfo(ctx context.Context, logger logr.Logger) (l
 
 		// === 1. RAM Resource ===
 		ramResourceName := liquid.ResourceName(commitments.ResourceNameRAM(groupName))
-		// Fixed-ratio groups: unit = smallest flavor's RAM in MiB (e.g. "480 GiB" for hana);
-		// variable-ratio groups: unit = 1 GiB.  RAMUnitMiB() encodes both cases.
-		ramUnit, err := liquid.UnitMebibytes.MultiplyBy(groupData.RAMUnitMiB())
+		ramUnit, err := liquid.UnitMebibytes.MultiplyBy(resCfg.RAM.RAMUnitMiB())
 		if err != nil {
 			return liquid.ServiceInfo{}, fmt.Errorf("failed to create RAM unit for flavor group %q: %w", groupName, err)
 		}
 		var ramDisplayName string
-		if groupData.HasFixedRamCoreRatio() && groupData.SmallestFlavor.MemoryMB > 0 {
-			ramDisplayName = fmt.Sprintf("multiples of %d MiB (usable by: %s)", groupData.SmallestFlavor.MemoryMB, flavorListStr)
+		if resCfg.RAM.RAMUnitGiB > 1 {
+			ramDisplayName = fmt.Sprintf("multiples of %d GiB (usable by: %s)", resCfg.RAM.RAMUnitGiB, flavorListStr)
 		} else {
 			ramDisplayName = fmt.Sprintf("GiB of RAM (usable by: %s)", flavorListStr)
 		}

--- a/internal/scheduling/reservations/commitments/api/info_test.go
+++ b/internal/scheduling/reservations/commitments/api/info_test.go
@@ -197,7 +197,7 @@ func TestHandleInfo_ResourceFlagsFromConfig(t *testing.T) {
 	cfg := commitments.DefaultAPIConfig()
 	cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
 		"hana_fixed": {
-			RAM:       commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasCapacity: true, HasQuota: true},
+			RAM:       commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasCapacity: true, HasQuota: true, RAMUnitGiB: 16},
 			Cores:     commitments.ResourceTypeConfig{HasCapacity: true},
 			Instances: commitments.ResourceTypeConfig{HasCapacity: true},
 		},

--- a/internal/scheduling/reservations/commitments/api/info_test.go
+++ b/internal/scheduling/reservations/commitments/api/info_test.go
@@ -197,12 +197,12 @@ func TestHandleInfo_ResourceFlagsFromConfig(t *testing.T) {
 	cfg := commitments.DefaultAPIConfig()
 	cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
 		"hana_fixed": {
-			RAM:       commitments.ResourceTypeConfig{HandlesCommitments: true, HasCapacity: true, HasQuota: true},
+			RAM:       commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasCapacity: true, HasQuota: true},
 			Cores:     commitments.ResourceTypeConfig{HasCapacity: true},
 			Instances: commitments.ResourceTypeConfig{HasCapacity: true},
 		},
 		"*": {
-			RAM:       commitments.ResourceTypeConfig{HasCapacity: true},
+			RAM:       commitments.RAMResourceTypeConfig{HasCapacity: true},
 			Cores:     commitments.ResourceTypeConfig{HasCapacity: true},
 			Instances: commitments.ResourceTypeConfig{HasCapacity: true},
 		},
@@ -393,7 +393,7 @@ func TestHandleInfo_AllResourcesAZSeparated(t *testing.T) {
 	cfg := commitments.DefaultAPIConfig()
 	cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
 		"fg": {
-			RAM:       commitments.ResourceTypeConfig{HandlesCommitments: true, HasCapacity: true, HasQuota: true},
+			RAM:       commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasCapacity: true, HasQuota: true},
 			Cores:     commitments.ResourceTypeConfig{HandlesCommitments: true, HasCapacity: true, HasQuota: true},
 			Instances: commitments.ResourceTypeConfig{HandlesCommitments: true, HasCapacity: true, HasQuota: true},
 		},

--- a/internal/scheduling/reservations/commitments/api/quota.go
+++ b/internal/scheduling/reservations/commitments/api/quota.go
@@ -122,8 +122,7 @@ func (api *HTTPAPI) HandleQuota(w http.ResponseWriter, r *http.Request) {
 			}
 			quotaValue := int64(azQuota.Quota)
 			if groupName, ok := ramResourceToGroup[string(resourceName)]; ok {
-				fg := flavorGroups[groupName]
-				quotaValue = fg.DeclaredUnitsToGiB(quotaValue)
+				quotaValue = api.config.ResourceConfigForGroup(groupName).RAM.DeclaredUnitsToGiB(quotaValue)
 			}
 			azStr := string(az)
 			if quotaByAZ[azStr] == nil {

--- a/internal/scheduling/reservations/commitments/api/quota_test.go
+++ b/internal/scheduling/reservations/commitments/api/quota_test.go
@@ -593,7 +593,11 @@ func TestHandleQuota_UnitConversion(t *testing.T) {
 		[]*TestFlavor{{Name: "hana_c4_m2", Group: "hana_1", MemoryMB: 2048, VCPUs: 4}}, 1,
 	))
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(knowledge).Build()
-	httpAPI := NewAPI(k8sClient)
+	cfg := commitments.DefaultAPIConfig()
+	cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
+		"hana_1": {RAM: commitments.RAMResourceTypeConfig{RAMUnitGiB: 2}},
+	}
+	httpAPI := NewAPIWithConfig(k8sClient, cfg, nil)
 
 	quotaReq := liquid.ServiceQuotaRequest{
 		Resources: map[liquid.ResourceName]liquid.ResourceQuotaRequest{

--- a/internal/scheduling/reservations/commitments/api/report_capacity_test.go
+++ b/internal/scheduling/reservations/commitments/api/report_capacity_test.go
@@ -34,7 +34,7 @@ func TestHandleReportCapacity(t *testing.T) {
 		EnableReportCapacity: true,
 		FlavorGroupResourceConfig: map[string]commitments.FlavorGroupResourcesConfig{
 			"*": {
-				RAM:       commitments.ResourceTypeConfig{HasCapacity: true},
+				RAM:       commitments.RAMResourceTypeConfig{HasCapacity: true},
 				Cores:     commitments.ResourceTypeConfig{HasCapacity: true},
 				Instances: commitments.ResourceTypeConfig{HasCapacity: true},
 			},
@@ -146,7 +146,7 @@ func TestCapacityCalculator(t *testing.T) {
 	testCapacityConfig := commitments.APIConfig{
 		FlavorGroupResourceConfig: map[string]commitments.FlavorGroupResourcesConfig{
 			"*": {
-				RAM:       commitments.ResourceTypeConfig{HasCapacity: true},
+				RAM:       commitments.RAMResourceTypeConfig{HasCapacity: true},
 				Cores:     commitments.ResourceTypeConfig{HasCapacity: true},
 				Instances: commitments.ResourceTypeConfig{HasCapacity: true},
 			},
@@ -396,7 +396,7 @@ func TestCapacityCalculator(t *testing.T) {
 		cfgNoInstances := commitments.APIConfig{
 			FlavorGroupResourceConfig: map[string]commitments.FlavorGroupResourcesConfig{
 				"*": {
-					RAM:       commitments.ResourceTypeConfig{HasCapacity: true},
+					RAM:       commitments.RAMResourceTypeConfig{HasCapacity: true},
 					Cores:     commitments.ResourceTypeConfig{HasCapacity: true},
 					Instances: commitments.ResourceTypeConfig{HasCapacity: false},
 				},

--- a/internal/scheduling/reservations/commitments/api/report_usage_test.go
+++ b/internal/scheduling/reservations/commitments/api/report_usage_test.go
@@ -391,7 +391,7 @@ func TestReportUsageIntegration(t *testing.T) {
 			Flavors:   []*TestFlavor{m1Small, m1Large},
 			Config: &commitments.APIConfig{
 				FlavorGroupResourceConfig: map[string]commitments.FlavorGroupResourcesConfig{
-					"hana_1": {RAM: commitments.ResourceTypeConfig{HandlesCommitments: true, HasQuota: true}},
+					"hana_1": {RAM: commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasQuota: true}},
 				},
 			},
 			VMs: []*TestVMUsage{
@@ -433,7 +433,7 @@ func TestReportUsageIntegration(t *testing.T) {
 			Flavors:   []*TestFlavor{m1Small, m1Large},
 			Config: &commitments.APIConfig{
 				FlavorGroupResourceConfig: map[string]commitments.FlavorGroupResourcesConfig{
-					"hana_1": {RAM: commitments.ResourceTypeConfig{HandlesCommitments: true, HasQuota: true}},
+					"hana_1": {RAM: commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasQuota: true}},
 				},
 			},
 			VMs: []*TestVMUsage{

--- a/internal/scheduling/reservations/commitments/api/usage_test.go
+++ b/internal/scheduling/reservations/commitments/api/usage_test.go
@@ -36,7 +36,7 @@ import (
 var testUsageConfig = commitments.APIConfig{
 	FlavorGroupResourceConfig: map[string]commitments.FlavorGroupResourcesConfig{
 		"*": {
-			RAM: commitments.ResourceTypeConfig{HandlesCommitments: true, HasQuota: true},
+			RAM: commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasQuota: true},
 		},
 	},
 }

--- a/internal/scheduling/reservations/commitments/config.go
+++ b/internal/scheduling/reservations/commitments/config.go
@@ -4,8 +4,10 @@
 package commitments
 
 import (
+	"sort"
 	"time"
 
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -139,6 +141,30 @@ type FlavorGroupResourcesConfig struct {
 	RAM       RAMResourceTypeConfig `json:"ram"`
 	Cores     ResourceTypeConfig    `json:"cores"`
 	Instances ResourceTypeConfig    `json:"instances"`
+}
+
+// LogFlavorGroupResourceConfig logs the effective RAM unit for each configured flavor group.
+// It warns when RAMUnitGiB is 0, which silently defaults to 1 GiB.
+func LogFlavorGroupResourceConfig(log logr.Logger, cfg map[string]FlavorGroupResourcesConfig) {
+	if len(cfg) == 0 {
+		log.Info("WARNING: no flavorGroupResourceConfig set; all flavor groups will use default RAM unit of 1 GiB")
+		return
+	}
+	groups := make([]string, 0, len(cfg))
+	for g := range cfg {
+		groups = append(groups, g)
+	}
+	sort.Strings(groups)
+	for _, groupName := range groups {
+		resCfg := cfg[groupName]
+		if resCfg.RAM.RAMUnitGiB == 0 {
+			log.Info("WARNING: ramUnitGiB not configured for flavor group, defaulting to 1 GiB",
+				"flavorGroup", groupName)
+		} else {
+			log.Info("flavor group RAM unit",
+				"flavorGroup", groupName, "ramUnitGiB", resCfg.RAM.RAMUnitGiB)
+		}
+	}
 }
 
 // ResourceConfigForGroup returns the resource config for the given flavor group name,

--- a/internal/scheduling/reservations/commitments/config.go
+++ b/internal/scheduling/reservations/commitments/config.go
@@ -104,11 +104,55 @@ type ResourceTypeConfig struct {
 	HasQuota           bool `json:"hasQuota"`
 }
 
+// RAMResourceTypeConfig extends ResourceTypeConfig with RAM-specific unit configuration.
+type RAMResourceTypeConfig struct {
+	HandlesCommitments bool `json:"handlesCommitments"`
+	HasCapacity        bool `json:"hasCapacity"`
+	HasQuota           bool `json:"hasQuota"`
+	// RAMUnitGiB is the size of one declared LIQUID RAM unit in GiB.
+	// Fixed-ratio groups set this to the smallest flavor's RAM (e.g. 480 for a 480 GiB HANA slot).
+	// Variable-ratio groups set this to 1 (1 unit = 1 GiB).
+	// Defaults to 1 if unset.
+	RAMUnitGiB uint64 `json:"ramUnitGiB,omitempty"`
+}
+
+// RAMUnitMiB returns the RAM unit in MiB (RAMUnitGiB × 1024), defaulting to 1024 if unset.
+func (c RAMResourceTypeConfig) RAMUnitMiB() uint64 {
+	if c.RAMUnitGiB > 0 {
+		return c.RAMUnitGiB * 1024
+	}
+	return 1024
+}
+
+// DeclaredUnitsToGiB converts a value in declared LIQUID units to GiB.
+func (c RAMResourceTypeConfig) DeclaredUnitsToGiB(units int64) int64 {
+	return units * int64(c.RAMUnitMiB()) / 1024 //nolint:gosec
+}
+
+// GiBToDeclaredUnits converts a GiB value to declared LIQUID units.
+func (c RAMResourceTypeConfig) GiBToDeclaredUnits(gib int64) int64 {
+	return gib * 1024 / int64(c.RAMUnitMiB()) //nolint:gosec
+}
+
 // FlavorGroupResourcesConfig groups resource type configs for the three resources of a flavor group.
 type FlavorGroupResourcesConfig struct {
-	RAM       ResourceTypeConfig `json:"ram"`
-	Cores     ResourceTypeConfig `json:"cores"`
-	Instances ResourceTypeConfig `json:"instances"`
+	RAM       RAMResourceTypeConfig `json:"ram"`
+	Cores     ResourceTypeConfig    `json:"cores"`
+	Instances ResourceTypeConfig    `json:"instances"`
+}
+
+// ResourceConfigForGroup returns the resource config for the given flavor group name,
+// falling back to the "*" catch-all if no exact match exists.
+func ResourceConfigForGroup(cfg map[string]FlavorGroupResourcesConfig, groupName string) FlavorGroupResourcesConfig {
+	if cfg != nil {
+		if c, ok := cfg[groupName]; ok {
+			return c
+		}
+		if c, ok := cfg["*"]; ok {
+			return c
+		}
+	}
+	return FlavorGroupResourcesConfig{}
 }
 
 // APIConfig holds configuration for the LIQUID commitment HTTP endpoints.
@@ -137,18 +181,10 @@ type APIConfig struct {
 	QuotaServedAvailabilityZones []string `json:"quotaServedAvailabilityZones,omitempty"`
 }
 
-// ResourceConfigForGroup returns the resource config for the given flavor group ID,
+// ResourceConfigForGroup returns the resource config for the given flavor group name,
 // falling back to the "*" catch-all if no exact match exists.
-func (c APIConfig) ResourceConfigForGroup(groupID string) FlavorGroupResourcesConfig {
-	if c.FlavorGroupResourceConfig != nil {
-		if cfg, ok := c.FlavorGroupResourceConfig[groupID]; ok {
-			return cfg
-		}
-		if cfg, ok := c.FlavorGroupResourceConfig["*"]; ok {
-			return cfg
-		}
-	}
-	return FlavorGroupResourcesConfig{}
+func (c APIConfig) ResourceConfigForGroup(groupName string) FlavorGroupResourcesConfig {
+	return ResourceConfigForGroup(c.FlavorGroupResourceConfig, groupName)
 }
 
 func DefaultAPIConfig() APIConfig {

--- a/internal/scheduling/reservations/commitments/e2e_checks.go
+++ b/internal/scheduling/reservations/commitments/e2e_checks.go
@@ -17,6 +17,7 @@ import (
 	liquid "github.com/sapcc/go-api-declarations/liquid"
 	"github.com/sapcc/go-bits/must"
 	. "go.xyrillian.de/gg/option"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -40,11 +41,21 @@ type E2EChecksConfig struct {
 	// If empty, falls back to RoundTripCheck.TestProjectID, then defaultE2EProjectUUID.
 	ProjectID string `json:"projectID,omitempty"`
 	// AZs is the list of availability zones to test. If empty, falls back to
-	// RoundTripCheck.AZ, then uses "" (any AZ).
+	// RoundTripCheck.AZ, then uses "qa-de-1b".
 	AZs []string `json:"azs,omitempty"`
+	// RequestTimeout is the per-request HTTP timeout for change-commitments calls.
+	// Defaults to 30s if unset.
+	RequestTimeout metav1.Duration `json:"requestTimeout,omitempty"`
 	// RoundTripCheck holds optional overrides for backward compatibility.
 	// Prefer the top-level ProjectID and AZs fields for new configurations.
 	RoundTripCheck *E2ERoundTripConfig `json:"roundTripCheck,omitempty"`
+}
+
+func (c E2EChecksConfig) e2eRequestTimeout() time.Duration {
+	if c.RequestTimeout.Duration > 0 {
+		return c.RequestTimeout.Duration
+	}
+	return 30 * time.Second
 }
 
 // E2ERoundTripConfig holds optional overrides for the create→delete round-trip e2e check.
@@ -70,7 +81,7 @@ func e2eProjectID(config E2EChecksConfig) liquid.ProjectUUID {
 }
 
 // e2eAZs returns the effective AZ list for e2e tests.
-// Falls back to RoundTripCheck.AZ (single AZ), then to [""] (any AZ).
+// Falls back to RoundTripCheck.AZ (single AZ), then to ["qa-de-1b"].
 func e2eAZs(config E2EChecksConfig) []liquid.AvailabilityZone {
 	if len(config.AZs) > 0 {
 		azs := make([]liquid.AvailabilityZone, len(config.AZs))
@@ -82,7 +93,7 @@ func e2eAZs(config E2EChecksConfig) []liquid.AvailabilityZone {
 	if rt := config.RoundTripCheck; rt != nil && rt.AZ != "" {
 		return []liquid.AvailabilityZone{liquid.AvailabilityZone(rt.AZ)}
 	}
-	return []liquid.AvailabilityZone{""}
+	return []liquid.AvailabilityZone{"qa-de-1b"}
 }
 
 // CheckCommitmentsInfoEndpoint verifies that GET /commitments/v1/info returns 200 with a valid ServiceInfo.
@@ -136,7 +147,7 @@ func CheckCommitmentsRoundTrip(ctx context.Context, config E2EChecksConfig) {
 			if !resInfo.HandlesCommitments {
 				continue
 			}
-			e2eRoundTripResource(ctx, baseURL, serviceInfo.Version, az, projectID, resourceName, config.NoCleanup)
+			e2eRoundTripResource(ctx, baseURL, serviceInfo.Version, az, projectID, resourceName, config.NoCleanup, config.e2eRequestTimeout())
 			checked++
 		}
 	}
@@ -155,6 +166,7 @@ func e2eRoundTripResource(
 	projectID liquid.ProjectUUID,
 	resourceName liquid.ResourceName,
 	noCleanup bool,
+	requestTimeout time.Duration,
 ) {
 
 	testUUID := liquid.CommitmentUUID(fmt.Sprintf("e2e-%d", time.Now().UnixMilli()))
@@ -184,7 +196,7 @@ func e2eRoundTripResource(
 	slog.Info("round-trip check: creating test commitment",
 		"resource", resourceName, "uuid", testUUID, "project", projectID, "az", az)
 
-	rejectionReason := e2eSendChangeCommitments(ctx, baseURL, createReq)
+	rejectionReason := e2eSendChangeCommitments(ctx, baseURL, createReq, requestTimeout)
 	if rejectionReason != "" {
 		// Only capacity rejections (no hosts available) are expected in production clusters.
 		// Any other reason (flavor group ineligible, config error, timeout) indicates a
@@ -226,7 +238,7 @@ func e2eRoundTripResource(
 			},
 		}
 		slog.Info("round-trip check: deleting test commitment", "resource", resourceName, "uuid", testUUID)
-		if reason := e2eSendChangeCommitments(ctx, baseURL, deleteReq); reason != "" {
+		if reason := e2eSendChangeCommitments(ctx, baseURL, deleteReq, requestTimeout); reason != "" {
 			panic(fmt.Sprintf("round-trip check: delete of test commitment %s was rejected: %s", testUUID, reason))
 		}
 		slog.Info("round-trip check: commitment deleted", "resource", resourceName, "uuid", testUUID)
@@ -258,7 +270,7 @@ func CheckCommitmentsMultiFlavorGroupBatch(ctx context.Context, config E2EChecks
 			if !resInfo.HandlesCommitments {
 				continue
 			}
-			e2eBatchFlavorGroupResource(ctx, baseURL, serviceInfo.Version, az, projectID, resourceName, config.NoCleanup)
+			e2eBatchFlavorGroupResource(ctx, baseURL, serviceInfo.Version, az, projectID, resourceName, config.NoCleanup, config.e2eRequestTimeout())
 			checked++
 		}
 	}
@@ -277,6 +289,7 @@ func e2eBatchFlavorGroupResource(
 	projectID liquid.ProjectUUID,
 	resourceName liquid.ResourceName,
 	noCleanup bool,
+	requestTimeout time.Duration,
 ) {
 
 	now := time.Now()
@@ -313,7 +326,7 @@ func e2eBatchFlavorGroupResource(
 
 	slog.Info("batch check: creating pending commitment",
 		"resource", resourceName, "uuid", uuidA, "project", projectID, "az", az)
-	if reason := e2eSendChangeCommitments(ctx, baseURL, req1); reason != "" {
+	if reason := e2eSendChangeCommitments(ctx, baseURL, req1, requestTimeout); reason != "" {
 		panic(fmt.Sprintf("batch check: unexpected rejection for pending creation of %s: %s", resourceName, reason))
 	}
 	slog.Info("batch check: pending commitment accepted", "resource", resourceName, "uuid", uuidA)
@@ -346,7 +359,7 @@ func e2eBatchFlavorGroupResource(
 			},
 		}
 		slog.Info("batch check: deleting pending commitment", "resource", resourceName, "uuid", uuidA)
-		if reason := e2eSendChangeCommitments(ctx, baseURL, req); reason != "" {
+		if reason := e2eSendChangeCommitments(ctx, baseURL, req, requestTimeout); reason != "" {
 			panic(fmt.Sprintf("batch check: delete of pending commitment %s rejected: %s", uuidA, reason))
 		}
 		slog.Info("batch check: pending commitment deleted", "resource", resourceName, "uuid", uuidA)
@@ -390,7 +403,7 @@ func e2eBatchFlavorGroupResource(
 		"totalConfirmed", confirmedAmountA+confirmedAmountB,
 		"project", projectID, "az", az)
 
-	if reason := e2eSendChangeCommitments(ctx, baseURL, req2); reason != "" {
+	if reason := e2eSendChangeCommitments(ctx, baseURL, req2, requestTimeout); reason != "" {
 		if !strings.Contains(reason, "no hosts found") && !strings.Contains(reason, "insufficient CPU cores") {
 			panic(fmt.Sprintf("batch check: unexpected rejection for batch of %s: %s", resourceName, reason))
 		}
@@ -443,7 +456,7 @@ func e2eBatchFlavorGroupResource(
 			},
 		}
 		slog.Info("batch check: deleting confirmed commitments", "resource", resourceName, "uuidA", uuidA, "uuidB", uuidB)
-		if reason := e2eSendChangeCommitments(ctx, baseURL, req); reason != "" {
+		if reason := e2eSendChangeCommitments(ctx, baseURL, req, requestTimeout); reason != "" {
 			panic(fmt.Sprintf("batch check: cleanup of confirmed commitments %s/%s rejected: %s", uuidA, uuidB, reason))
 		}
 		slog.Info("batch check: confirmed commitments deleted", "resource", resourceName, "uuidA", uuidA, "uuidB", uuidB)
@@ -512,7 +525,9 @@ func e2eLogUsageReport(report liquid.ServiceUsageReport, az liquid.AvailabilityZ
 // Panics on HTTP non-200 (infrastructure error).
 // Returns the rejection reason on 200+rejection (expected for capacity-constrained clusters).
 // Returns "" on success.
-func e2eSendChangeCommitments(ctx context.Context, baseURL string, req liquid.CommitmentChangeRequest) string {
+func e2eSendChangeCommitments(ctx context.Context, baseURL string, req liquid.CommitmentChangeRequest, requestTimeout time.Duration) string {
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
 	body := must.Return(json.Marshal(req))
 	httpReq := must.Return(http.NewRequestWithContext(ctx, http.MethodPost,
 		baseURL+"/commitments/v1/change-commitments", bytes.NewReader(body)))

--- a/internal/scheduling/reservations/commitments/state.go
+++ b/internal/scheduling/reservations/commitments/state.go
@@ -136,7 +136,7 @@ type CommitmentState struct {
 }
 
 // FromCommitment converts Limes commitment to CommitmentState.
-// ramUnitMiB is the size of one external RAM unit in MiB, as returned by FlavorGroupFeature.RAMUnitMiB():
+// ramUnitMiB is the size of one external RAM unit in MiB, as returned by RAMResourceTypeConfig.RAMUnitMiB():
 //   - fixed-ratio flavor groups: SmallestFlavor.MemoryMB (1 unit = 1 smallest-flavor slot)
 //   - variable-ratio flavor groups: 1024 (1 unit = 1 GiB)
 func FromCommitment(

--- a/internal/scheduling/reservations/commitments/state.go
+++ b/internal/scheduling/reservations/commitments/state.go
@@ -136,8 +136,12 @@ type CommitmentState struct {
 }
 
 // FromCommitment converts Limes commitment to CommitmentState.
+// ramUnitMiB is the size of one external RAM unit in MiB, as returned by FlavorGroupFeature.RAMUnitMiB():
+//   - fixed-ratio flavor groups: SmallestFlavor.MemoryMB (1 unit = 1 smallest-flavor slot)
+//   - variable-ratio flavor groups: 1024 (1 unit = 1 GiB)
 func FromCommitment(
 	commitment Commitment,
+	ramUnitMiB uint64,
 ) (*CommitmentState, error) {
 	// Validate commitment UUID format
 	if !commitmentUUIDPattern.MatchString(commitment.UUID) {
@@ -149,9 +153,8 @@ func FromCommitment(
 		return nil, err
 	}
 
-	// Calculate total memory from commitment amount (1 GiB per unit)
-	const gibInBytes = int64(1) << 30
-	totalMemoryBytes := int64(commitment.Amount) * gibInBytes //nolint:gosec // commitment amount from Limes API, bounded by quota limits
+	// Convert external unit to bytes: 1 unit = ramUnitMiB MiB (mirrors FromChangeCommitmentTargetState).
+	totalMemoryBytes := int64(commitment.Amount) * int64(ramUnitMiB) * (1 << 20) //nolint:gosec // bounded by quota limits
 
 	// Set start time: use ConfirmedAt if available, otherwise CreatedAt
 	var startTime *time.Time

--- a/internal/scheduling/reservations/commitments/state_test.go
+++ b/internal/scheduling/reservations/commitments/state_test.go
@@ -36,10 +36,11 @@ func TestFromCommitment_CalculatesMemoryCorrectly(t *testing.T) {
 		UUID:         "test-uuid",
 		ProjectID:    "project-1",
 		ResourceName: "hw_version_test-group_ram",
-		Amount:       5, // 5 multiples of smallest flavor
+		Amount:       5,
 	}
 
-	state, err := FromCommitment(commitment)
+	// Variable-ratio group: RAMUnitMiB = 1024 (1 GiB per unit)
+	state, err := FromCommitment(commitment, 1024)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,10 +56,21 @@ func TestFromCommitment_CalculatesMemoryCorrectly(t *testing.T) {
 		t.Errorf("expected FlavorGroupName test-group, got %s", state.FlavorGroupName)
 	}
 
-	// Verify memory calculation: 5 GiB = 5 * 1<<30 bytes
+	// 5 units × 1024 MiB = 5 GiB
 	expectedMemory := int64(5) * (1 << 30)
 	if state.TotalMemoryBytes != expectedMemory {
 		t.Errorf("expected memory %d, got %d", expectedMemory, state.TotalMemoryBytes)
+	}
+
+	// Fixed-ratio group: RAMUnitMiB = 8192 (8 GiB per unit, e.g. SmallestFlavor.MemoryMB = 8192)
+	stateFixed, err := FromCommitment(commitment, 8192)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 5 units × 8192 MiB = 40 GiB
+	expectedFixed := int64(5) * 8192 * (1 << 20)
+	if stateFixed.TotalMemoryBytes != expectedFixed {
+		t.Errorf("fixed-ratio: expected memory %d, got %d", expectedFixed, stateFixed.TotalMemoryBytes)
 	}
 }
 
@@ -70,7 +82,7 @@ func TestFromCommitment_InvalidResourceName(t *testing.T) {
 		Amount:       1,
 	}
 
-	_, err := FromCommitment(commitment)
+	_, err := FromCommitment(commitment, 1024)
 	if err == nil {
 		t.Fatal("expected error for invalid resource name, got nil")
 	}

--- a/internal/scheduling/reservations/commitments/syncer.go
+++ b/internal/scheduling/reservations/commitments/syncer.go
@@ -70,6 +70,7 @@ func NewSyncer(k8sClient client.Client, monitor *SyncerMonitor) *Syncer {
 func (s *Syncer) Init(ctx context.Context, config SyncerConfig) error {
 	s.syncInterval = config.SyncInterval.Duration
 	s.resourceConfig = config
+	LogFlavorGroupResourceConfig(baseLog, config.FlavorGroupResourceConfig)
 	if err := s.CommitmentsClient.Init(ctx, s.Client, config); err != nil {
 		return err
 	}

--- a/internal/scheduling/reservations/commitments/syncer.go
+++ b/internal/scheduling/reservations/commitments/syncer.go
@@ -37,6 +37,13 @@ type SyncerConfig struct {
 	SSOSecretRef *corev1.SecretReference `json:"ssoSecretRef"`
 	// SyncInterval defines how often the syncer reconciles Limes commitments to Reservation CRDs.
 	SyncInterval metav1.Duration `json:"committedResourceSyncInterval"`
+	// FlavorGroupResourceConfig maps flavor group names to resource configs; "*" acts as catch-all.
+	FlavorGroupResourceConfig map[string]FlavorGroupResourcesConfig `json:"flavorGroupResourceConfig,omitempty"`
+}
+
+// ResourceConfigForGroup returns the resource config for the given flavor group name.
+func (c SyncerConfig) ResourceConfigForGroup(groupName string) FlavorGroupResourcesConfig {
+	return ResourceConfigForGroup(c.FlavorGroupResourceConfig, groupName)
 }
 
 type Syncer struct {
@@ -48,6 +55,8 @@ type Syncer struct {
 	monitor *SyncerMonitor
 	// SyncInterval is stored for logging purposes (actual interval managed by task.Runner)
 	syncInterval time.Duration
+	// resourceConfig is the flavor group resource config used for unit conversion.
+	resourceConfig SyncerConfig
 }
 
 func NewSyncer(k8sClient client.Client, monitor *SyncerMonitor) *Syncer {
@@ -60,6 +69,7 @@ func NewSyncer(k8sClient client.Client, monitor *SyncerMonitor) *Syncer {
 
 func (s *Syncer) Init(ctx context.Context, config SyncerConfig) error {
 	s.syncInterval = config.SyncInterval.Duration
+	s.resourceConfig = config
 	if err := s.CommitmentsClient.Init(ctx, s.Client, config); err != nil {
 		return err
 	}
@@ -130,7 +140,7 @@ func (s *Syncer) getCommitmentStates(ctx context.Context, log logr.Logger, flavo
 		}
 
 		// Validate flavor group exists in Knowledge
-		flavorGroup, exists := flavorGroups[flavorGroupName]
+		_, exists := flavorGroups[flavorGroupName]
 		if !exists {
 			log.Info("skipping commitment with unknown flavor group",
 				"id", id,
@@ -143,7 +153,7 @@ func (s *Syncer) getCommitmentStates(ctx context.Context, log logr.Logger, flavo
 
 		// Validate unit matches the unit declared in the LIQUID ServiceInfo for this flavor group.
 		// Variable-ratio groups declare "GiB"; fixed-ratio groups declare "N GiB" (SmallestFlavor.MemoryMB MiB).
-		ramUnitMiB := flavorGroup.RAMUnitMiB()
+		ramUnitMiB := s.resourceConfig.ResourceConfigForGroup(flavorGroupName).RAM.RAMUnitMiB()
 		expectedLiquidUnit, err := liquid.UnitMebibytes.MultiplyBy(ramUnitMiB)
 		if err != nil {
 			log.Error(err, "failed to compute expected RAM unit for flavor group",

--- a/internal/scheduling/reservations/commitments/syncer.go
+++ b/internal/scheduling/reservations/commitments/syncer.go
@@ -141,18 +141,23 @@ func (s *Syncer) getCommitmentStates(ctx context.Context, log logr.Logger, flavo
 			continue
 		}
 
-		// Validate unit matches between Limes commitment and Cortex (1 GiB per unit)
-		expectedUnit := liquid.UnitGibibytes.String() // "GiB"
+		// Validate unit matches the unit declared in the LIQUID ServiceInfo for this flavor group.
+		// Variable-ratio groups declare "GiB"; fixed-ratio groups declare "N GiB" (SmallestFlavor.MemoryMB MiB).
+		ramUnitMiB := flavorGroup.RAMUnitMiB()
+		expectedLiquidUnit, err := liquid.UnitMebibytes.MultiplyBy(ramUnitMiB)
+		if err != nil {
+			log.Error(err, "failed to compute expected RAM unit for flavor group",
+				"flavorGroup", flavorGroupName,
+				"ramUnitMiB", ramUnitMiB)
+			continue
+		}
+		expectedUnit := expectedLiquidUnit.String()
 		if commitment.Unit != "" && commitment.Unit != expectedUnit {
-			// Unit mismatch: Limes has not yet updated this commitment to the new unit.
-			// Skip this commitment - trust what Cortex already has stored in CRDs.
-			// On the next sync cycle after Limes updates, this will be processed.
-			log.V(0).Info("WARNING: skipping commitment due to unit mismatch - Limes unit differs from Cortex flavor group, waiting for Limes to update",
+			log.V(0).Info("WARNING: skipping commitment with unexpected unit",
 				"commitmentUUID", commitment.UUID,
 				"flavorGroup", flavorGroupName,
 				"limesUnit", commitment.Unit,
-				"expectedUnit", expectedUnit,
-				"smallestFlavorMemoryMB", flavorGroup.SmallestFlavor.MemoryMB)
+				"expectedUnit", expectedUnit)
 			if s.monitor != nil {
 				s.monitor.RecordCommitmentSkipped(SkipReasonUnitMismatch)
 			}
@@ -174,7 +179,7 @@ func (s *Syncer) getCommitmentStates(ctx context.Context, log logr.Logger, flavo
 		}
 
 		// Convert commitment to state using FromCommitment
-		state, err := FromCommitment(commitment)
+		state, err := FromCommitment(commitment, ramUnitMiB)
 		if err != nil {
 			log.Error(err, "failed to convert commitment to state",
 				"id", id,

--- a/internal/scheduling/reservations/commitments/usage.go
+++ b/internal/scheduling/reservations/commitments/usage.go
@@ -535,8 +535,7 @@ func (c *UsageCalculator) buildUsageResponse(
 			}
 			if resCfg.RAM.HasQuota {
 				// CRD stores quota in GiB; convert to declared unit for Limes.
-				fg := flavorGroups[flavorGroupName]
-				report.Quota = Some(fg.GiBToDeclaredUnits(lookupQuotaGiB(string(ramResourceName), az)))
+				report.Quota = Some(resCfg.RAM.GiBToDeclaredUnits(lookupQuotaGiB(string(ramResourceName), az)))
 			}
 			ramPerAZ[az] = report
 		}

--- a/internal/scheduling/reservations/quota/config.go
+++ b/internal/scheduling/reservations/quota/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cobaltcore-dev/cortex/api/v1alpha1"
+	commitments "github.com/cobaltcore-dev/cortex/internal/scheduling/reservations/commitments"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -24,6 +25,10 @@ type QuotaControllerConfig struct {
 	// When false, only periodic full reconciles update TotalUsage (safer but slower convergence).
 	// Default: true.
 	EnableHVDiff *bool `json:"enableHVDiff,omitempty"`
+
+	// FlavorGroupResourceConfig maps flavor group names to resource configs; "*" acts as catch-all.
+	// Used for unit conversion when building Limes-unit summaries.
+	FlavorGroupResourceConfig map[string]commitments.FlavorGroupResourcesConfig `json:"flavorGroupResourceConfig,omitempty"`
 }
 
 // ApplyDefaults fills in any unset values with defaults.

--- a/internal/scheduling/reservations/quota/controller.go
+++ b/internal/scheduling/reservations/quota/controller.go
@@ -130,7 +130,7 @@ func (c *QuotaController) ReconcilePeriodic(ctx context.Context) error {
 		paygUsage := derivePaygUsage(projectTotalUsage, crUsage)
 
 		// Write status with conflict retry (full reconcile sets LastFullReconcileAt)
-		if err := c.updateProjectQuotaStatusWithRetry(ctx, pq.Name, projectTotalUsage, paygUsage, true, flavorGroups); err != nil {
+		if err := c.updateProjectQuotaStatusWithRetry(ctx, pq.Name, projectTotalUsage, paygUsage, true); err != nil {
 			logger.Error(err, "failed to update ProjectQuota status", "project", projectID)
 			skipped++
 			continue
@@ -237,7 +237,7 @@ func (c *QuotaController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	paygUsage := derivePaygUsage(totalUsage, crUsage)
 
 	// Write updated status with conflict retry
-	if err := c.updateProjectQuotaStatusWithRetry(ctx, pq.Name, totalUsage, paygUsage, specChanged, flavorGroups); err != nil {
+	if err := c.updateProjectQuotaStatusWithRetry(ctx, pq.Name, totalUsage, paygUsage, specChanged); err != nil {
 		logger.Error(err, "failed to update ProjectQuota status")
 		return ctrl.Result{}, err
 	}
@@ -619,8 +619,8 @@ func (c *QuotaController) applyDeltaAndUpdateStatus(
 			// Update human-readable summaries for wide kubectl output
 			pq.Status.TotalUsageSummary = buildUsageSummary(pq.Status.TotalUsage)
 			pq.Status.PaygUsageSummary = buildUsageSummary(pq.Status.PaygUsage)
-			pq.Status.LimesUsageSummary = buildLimesSummary(pq.Status.TotalUsage, flavorGroups)
-			pq.Status.LimesQuotaSummary = buildLimesSummary(pq.Spec.Quota, flavorGroups)
+			pq.Status.LimesUsageSummary = buildLimesSummary(pq.Status.TotalUsage, c.Config.FlavorGroupResourceConfig)
+			pq.Status.LimesQuotaSummary = buildLimesSummary(pq.Spec.Quota, c.Config.FlavorGroupResourceConfig)
 
 			now := metav1.Now()
 			pq.Status.LastReconcileAt = &now
@@ -931,7 +931,6 @@ func (c *QuotaController) updateProjectQuotaStatusWithRetry(
 	totalUsage map[string]map[string]int64,
 	paygUsage map[string]map[string]int64,
 	fullReconcile bool,
-	flavorGroups map[string]compute.FlavorGroupFeature,
 ) error {
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -948,8 +947,8 @@ func (c *QuotaController) updateProjectQuotaStatusWithRetry(
 		pq.Status.TotalUsageSummary = buildUsageSummary(pq.Status.TotalUsage)
 		pq.Status.PaygUsageSummary = buildUsageSummary(pq.Status.PaygUsage)
 		// Limes unit summaries for debugging (converted from internal GiB to declared units)
-		pq.Status.LimesUsageSummary = buildLimesSummary(pq.Status.TotalUsage, flavorGroups)
-		pq.Status.LimesQuotaSummary = buildLimesSummary(pq.Spec.Quota, flavorGroups)
+		pq.Status.LimesUsageSummary = buildLimesSummary(pq.Status.TotalUsage, c.Config.FlavorGroupResourceConfig)
+		pq.Status.LimesQuotaSummary = buildLimesSummary(pq.Spec.Quota, c.Config.FlavorGroupResourceConfig)
 		pq.Status.ObservedGeneration = pq.Generation
 		now := metav1.Now()
 		pq.Status.LastReconcileAt = &now
@@ -1047,7 +1046,7 @@ func buildUsageSummary(usage map[string]int64) string {
 // For RAM resources in fixed-ratio groups: value * 1024 / SmallestFlavor.MemoryMB (GiB→slots).
 // For RAM resources in variable-ratio groups: value is already in GiB = declared units (1:1).
 // For cores and instances: value is 1:1 (no conversion).
-func buildLimesSummary(values map[string]int64, flavorGroups map[string]compute.FlavorGroupFeature) string {
+func buildLimesSummary(values map[string]int64, cfg map[string]commitments.FlavorGroupResourcesConfig) string {
 	if len(values) == 0 {
 		return ""
 	}
@@ -1055,14 +1054,9 @@ func buildLimesSummary(values map[string]int64, flavorGroups map[string]compute.
 	converted := make(map[string]int64, len(values))
 	for key, val := range values {
 		if strings.HasPrefix(key, "hw_version_") && strings.HasSuffix(key, "_ram") {
-			// Extract group name: "hw_version_<group>_ram" → "<group>"
 			name := strings.TrimPrefix(key, "hw_version_")
 			groupName := strings.TrimSuffix(name, "_ram")
-			if fg, ok := flavorGroups[groupName]; ok {
-				converted[key] = (&fg).GiBToDeclaredUnits(val)
-			} else {
-				converted[key] = val
-			}
+			converted[key] = commitments.ResourceConfigForGroup(cfg, groupName).RAM.GiBToDeclaredUnits(val)
 		} else {
 			converted[key] = val
 		}


### PR DESCRIPTION
Make the RAM unit per flavor group operator-configurable via ramUnitGiB in flavorGroupResourceConfig, replacing runtime inference from flavor data; fixed-ratio groups set this to their slot size (e.g. 480), variable-ratio groups set 1