### PR TITLE
feat: simply dry run logic for committed resources

### DIFF
--- a/helm/bundles/cortex-nova/values.yaml
+++ b/helm/bundles/cortex-nova/values.yaml
@@ -197,9 +197,11 @@ cortex-scheduling-controllers:
             handlesCommitments: false
             hasCapacity: true
             hasQuota: false
+            handlesDryRun: true
             ramUnitGiB: 1
           cores:
             handlesCommitments: false
+            handlesDryRun: true
             hasCapacity: true
             hasQuota: false
           instances:

--- a/internal/scheduling/reservations/commitments/api/change_commitments.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments.go
@@ -670,6 +670,7 @@ func (api *HTTPAPI) performDryRun(ctx context.Context, logger logr.Logger, req l
 		for i, e := range watchErrs {
 			msgs[i] = e.Error()
 		}
+		api.monitor.timeouts.Inc()
 		resp.RejectionReason = "dry run: timeout: " + strings.Join(msgs, "; ")
 	default:
 		logger.Info("dry run: capacity available", "probes", len(probeWatches))

--- a/internal/scheduling/reservations/commitments/api/change_commitments.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments.go
@@ -520,6 +520,18 @@ func (api *HTTPAPI) performDryRun(ctx context.Context, logger logr.Logger, req l
 		return
 	}
 
+	// Pass 1: aggregate raw unit deltas per resource name across all projects.
+	// A decrease in one project may cancel an increase in another, so we sum signed deltas.
+	netUnitDeltas := make(map[liquid.ResourceName]int64)
+	for _, projectChanges := range req.ByProject {
+		for resourceName, rc := range projectChanges.ByResource {
+			totalBefore := rc.TotalConfirmedBefore + rc.TotalGuaranteedBefore
+			totalAfter := rc.TotalConfirmedAfter + rc.TotalGuaranteedAfter
+			netUnitDeltas[resourceName] += int64(totalAfter) - int64(totalBefore) //nolint:gosec
+		}
+	}
+
+	// Pass 2: for each resource with a net increase, resolve config and convert to probe size.
 	// probeKey uniquely identifies a probe CR (one per resource with a net increase).
 	type probeKey struct {
 		flavorGroup  string
@@ -527,51 +539,44 @@ func (api *HTTPAPI) performDryRun(ctx context.Context, logger logr.Logger, req l
 	}
 	deltas := make(map[probeKey]int64) // bytes (memory) or core count (cores)
 
-	for _, projectID := range sortedKeys(req.ByProject) {
-		projectChanges := req.ByProject[projectID]
-		for _, resourceName := range sortedKeys(projectChanges.ByResource) {
-			rc := projectChanges.ByResource[resourceName]
-
-			totalBefore := rc.TotalConfirmedBefore + rc.TotalGuaranteedBefore
-			totalAfter := rc.TotalConfirmedAfter + rc.TotalGuaranteedAfter
-			if totalAfter <= totalBefore {
-				continue // no net increase for this resource
-			}
-			deltaUnits := totalAfter - totalBefore
-
-			flavorGroupName, resourceType, err := commitments.GetFlavorGroupAndTypeFromResource(string(resourceName))
-			if err != nil {
-				resp.RejectionReason = fmt.Sprintf("dry run: %v", err)
-				return
-			}
-			if _, ok := flavorGroups[flavorGroupName]; !ok {
-				resp.RejectionReason = "dry run: flavor group not found: " + flavorGroupName
-				return
-			}
-
-			groupResourceConf := api.config.ResourceConfigForGroup(flavorGroupName)
-			var handlesDryRun bool
-			switch resourceType {
-			case v1alpha1.CommittedResourceTypeCores:
-				handlesDryRun = groupResourceConf.Cores.HandlesCommitments && groupResourceConf.Cores.HandlesDryRun
-			default:
-				handlesDryRun = groupResourceConf.RAM.HandlesCommitments && groupResourceConf.RAM.HandlesDryRun
-			}
-			if !handlesDryRun {
-				continue
-			}
-
-			var deltaAmount int64
-			switch resourceType {
-			case v1alpha1.CommittedResourceTypeCores:
-				deltaAmount = int64(deltaUnits) //nolint:gosec
-			default:
-				deltaAmount = int64(deltaUnits) * int64(groupResourceConf.RAM.RAMUnitMiB()) * (1 << 20) //nolint:gosec
-			}
-
-			k := probeKey{flavorGroup: flavorGroupName, resourceType: resourceType}
-			deltas[k] += deltaAmount
+	for _, resourceName := range sortedKeys(netUnitDeltas) {
+		deltaUnits := netUnitDeltas[resourceName]
+		if deltaUnits <= 0 {
+			continue
 		}
+
+		flavorGroupName, resourceType, err := commitments.GetFlavorGroupAndTypeFromResource(string(resourceName))
+		if err != nil {
+			resp.RejectionReason = fmt.Sprintf("dry run: %v", err)
+			return
+		}
+		if _, ok := flavorGroups[flavorGroupName]; !ok {
+			resp.RejectionReason = "dry run: flavor group not found: " + flavorGroupName
+			return
+		}
+
+		groupResourceConf := api.config.ResourceConfigForGroup(flavorGroupName)
+		var handlesDryRun bool
+		switch resourceType {
+		case v1alpha1.CommittedResourceTypeCores:
+			handlesDryRun = groupResourceConf.Cores.HandlesCommitments && groupResourceConf.Cores.HandlesDryRun
+		default:
+			handlesDryRun = groupResourceConf.RAM.HandlesCommitments && groupResourceConf.RAM.HandlesDryRun
+		}
+		if !handlesDryRun {
+			continue
+		}
+
+		var deltaAmount int64
+		switch resourceType {
+		case v1alpha1.CommittedResourceTypeCores:
+			deltaAmount = deltaUnits
+		default:
+			deltaAmount = deltaUnits * int64(groupResourceConf.RAM.RAMUnitMiB()) * (1 << 20) //nolint:gosec
+		}
+
+		k := probeKey{flavorGroup: flavorGroupName, resourceType: resourceType}
+		deltas[k] += deltaAmount
 	}
 
 	if len(deltas) == 0 {

--- a/internal/scheduling/reservations/commitments/api/change_commitments.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments.go
@@ -106,10 +106,37 @@ func (api *HTTPAPI) HandleChangeCommitments(w http.ResponseWriter, r *http.Reque
 
 	logger.Info("received change commitments request", "affectedProjects", len(req.ByProject), "dryRun", req.DryRun, "availabilityZone", req.AZ)
 
-	if req.DryRun {
-		resp.RejectionReason = "Dry run not supported yet"
+	if req.AZ == "" {
+		statusCode = http.StatusBadRequest
+		http.Error(w, "availability zone is required", statusCode)
 		api.recordMetrics(req, resp, statusCode, startTime)
-		logger.Info("rejecting dry run request")
+		return
+	}
+
+	{
+		knowledge := &reservations.FlavorGroupKnowledgeClient{Client: api.client}
+		if knowledgeCRD, err := knowledge.Get(ctx); err == nil && knowledgeCRD != nil {
+			var currentVersion int64 = -1
+			if !knowledgeCRD.Status.LastContentChange.IsZero() {
+				currentVersion = knowledgeCRD.Status.LastContentChange.Unix()
+			}
+			if req.InfoVersion != currentVersion {
+				logger.Info("version mismatch in commitment change request",
+					"requestVersion", req.InfoVersion,
+					"currentVersion", currentVersion)
+				statusCode = http.StatusConflict
+				http.Error(w, fmt.Sprintf("Version mismatch: request version %d, current version %d. Please refresh and retry.",
+					req.InfoVersion, currentVersion), statusCode)
+				api.recordMetrics(req, resp, statusCode, startTime)
+				return
+			}
+		}
+	}
+
+	if req.DryRun {
+		api.performDryRun(ctx, logger, req, &resp)
+		api.recordMetrics(req, resp, statusCode, startTime)
+		logger.Info("dry run complete", "rejected", resp.RejectionReason != "")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
@@ -118,17 +145,8 @@ func (api *HTTPAPI) HandleChangeCommitments(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if req.AZ == "" {
-		statusCode = http.StatusBadRequest
-		http.Error(w, "availability zone is required", statusCode)
-		api.recordMetrics(req, resp, statusCode, startTime)
-		return
-	}
-
 	if err := api.processCommitmentChanges(ctx, w, logger, req, &resp); err != nil {
-		if strings.Contains(err.Error(), "version mismatch") {
-			statusCode = http.StatusConflict
-		} else if strings.Contains(err.Error(), "caches not ready") {
+		if strings.Contains(err.Error(), "caches not ready") {
 			statusCode = http.StatusServiceUnavailable
 		}
 		api.recordMetrics(req, resp, statusCode, startTime)
@@ -150,19 +168,6 @@ func (api *HTTPAPI) processCommitmentChanges(ctx context.Context, w http.Respons
 		logger.Info("failed to get flavor groups from knowledge extractor", "error", err)
 		http.Error(w, "caches not ready, please retry later", http.StatusServiceUnavailable)
 		return errors.New("caches not ready")
-	}
-
-	var currentVersion int64 = -1
-	if knowledgeCRD, err := knowledge.Get(ctx); err == nil && knowledgeCRD != nil && !knowledgeCRD.Status.LastContentChange.IsZero() {
-		currentVersion = knowledgeCRD.Status.LastContentChange.Unix()
-	}
-	if req.InfoVersion != currentVersion {
-		logger.Info("version mismatch in commitment change request",
-			"requestVersion", req.InfoVersion,
-			"currentVersion", currentVersion)
-		http.Error(w, fmt.Sprintf("Version mismatch: request version %d, current version %d. Please refresh and retry.",
-			req.InfoVersion, currentVersion), http.StatusConflict)
-		return errors.New("version mismatch")
 	}
 
 	// If Limes does not require confirmation for this batch (e.g. deletions, status-only transitions),
@@ -503,6 +508,209 @@ func rollbackCR(ctx context.Context, logger logr.Logger, k8sClient client.Client
 		return
 	}
 	logger.V(1).Info("restored CommittedResource CRD spec during rollback", "name", snap.crName)
+}
+
+// performDryRun checks whether the net capacity delta in req can be placed by running
+// temporary probe CommittedResource CRDs through the controller, then always cleaning them up.
+func (api *HTTPAPI) performDryRun(ctx context.Context, logger logr.Logger, req liquid.CommitmentChangeRequest, resp *liquid.CommitmentChangeResponse) {
+	knowledge := &reservations.FlavorGroupKnowledgeClient{Client: api.client}
+	flavorGroups, err := knowledge.GetAllFlavorGroups(ctx, nil)
+	if err != nil {
+		resp.RejectionReason = "dry run: caches not ready, please retry later"
+		return
+	}
+
+	// probeKey uniquely identifies a probe CR (one per resource with a net increase).
+	type probeKey struct {
+		flavorGroup  string
+		resourceType v1alpha1.CommittedResourceType
+	}
+	deltas := make(map[probeKey]int64) // bytes (memory) or core count (cores)
+
+	for _, projectID := range sortedKeys(req.ByProject) {
+		projectChanges := req.ByProject[projectID]
+		for _, resourceName := range sortedKeys(projectChanges.ByResource) {
+			rc := projectChanges.ByResource[resourceName]
+
+			totalBefore := rc.TotalConfirmedBefore + rc.TotalGuaranteedBefore
+			totalAfter := rc.TotalConfirmedAfter + rc.TotalGuaranteedAfter
+			if totalAfter <= totalBefore {
+				continue // no net increase for this resource
+			}
+			deltaUnits := totalAfter - totalBefore
+
+			flavorGroupName, resourceType, err := commitments.GetFlavorGroupAndTypeFromResource(string(resourceName))
+			if err != nil {
+				resp.RejectionReason = fmt.Sprintf("dry run: %v", err)
+				return
+			}
+			if _, ok := flavorGroups[flavorGroupName]; !ok {
+				resp.RejectionReason = "dry run: flavor group not found: " + flavorGroupName
+				return
+			}
+
+			groupResourceConf := api.config.ResourceConfigForGroup(flavorGroupName)
+			var handlesDryRun bool
+			switch resourceType {
+			case v1alpha1.CommittedResourceTypeCores:
+				handlesDryRun = groupResourceConf.Cores.HandlesCommitments && groupResourceConf.Cores.HandlesDryRun
+			default:
+				handlesDryRun = groupResourceConf.RAM.HandlesCommitments && groupResourceConf.RAM.HandlesDryRun
+			}
+			if !handlesDryRun {
+				continue
+			}
+
+			var deltaAmount int64
+			switch resourceType {
+			case v1alpha1.CommittedResourceTypeCores:
+				deltaAmount = int64(deltaUnits) //nolint:gosec
+			default:
+				deltaAmount = int64(deltaUnits) * int64(groupResourceConf.RAM.RAMUnitMiB()) * (1 << 20) //nolint:gosec
+			}
+
+			k := probeKey{flavorGroup: flavorGroupName, resourceType: resourceType}
+			deltas[k] += deltaAmount
+		}
+	}
+
+	if len(deltas) == 0 {
+		logger.Info("dry run: no net capacity increase, trivially accepted")
+		return
+	}
+
+	// Build a sorted list for deterministic probe naming.
+	type keyAmount struct {
+		key    probeKey
+		amount int64
+	}
+	probeList := make([]keyAmount, 0, len(deltas))
+	for k, v := range deltas {
+		probeList = append(probeList, keyAmount{key: k, amount: v})
+	}
+	sort.Slice(probeList, func(i, j int) bool {
+		if probeList[i].key.flavorGroup != probeList[j].key.flavorGroup {
+			return probeList[i].key.flavorGroup < probeList[j].key.flavorGroup
+		}
+		return string(probeList[i].key.resourceType) < string(probeList[j].key.resourceType)
+	})
+
+	// Use the first project's ID and domain so same-project reservation logic works correctly.
+	firstProjectID := string(sortedKeys(req.ByProject)[0])
+	firstProjectMeta := req.ByProject[liquid.ProjectUUID(firstProjectID)].ProjectMetadata.UnwrapOr(liquid.ProjectMetadata{})
+	probeDomainID := firstProjectMeta.Domain.UUID
+
+	// Probe ID is derived from the HTTP request ID for log traceability.
+	ctxRequestID := strings.TrimPrefix(reservations.GlobalRequestIDFromContext(ctx), "committed-resource-")
+	if len(ctxRequestID) > 8 {
+		ctxRequestID = ctxRequestID[:8]
+	}
+	probeBase := "dryrun-" + ctxRequestID
+	now := metav1.NewTime(time.Now())
+	endTime := metav1.NewTime(time.Now().Add(time.Minute))
+
+	var probeWatches []crWatch
+	defer func() { api.cleanupDryRunProbes(ctx, logger, probeWatches) }()
+
+	for i, entry := range probeList {
+		probeUUID := fmt.Sprintf("%s-%d", probeBase, i)
+		probeName := "commitment-" + probeUUID
+
+		var qty resource.Quantity
+		switch entry.key.resourceType {
+		case v1alpha1.CommittedResourceTypeCores:
+			qty = *resource.NewQuantity(entry.amount, resource.DecimalSI)
+		default:
+			qty = *resource.NewQuantity(entry.amount, resource.BinarySI)
+		}
+
+		probe := &v1alpha1.CommittedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: probeName,
+				Annotations: map[string]string{
+					v1alpha1.AnnotationCreatorRequestID: reservations.GlobalRequestIDFromContext(ctx),
+				},
+			},
+			Spec: v1alpha1.CommittedResourceSpec{
+				CommitmentUUID:   probeUUID,
+				SchedulingDomain: v1alpha1.SchedulingDomainNova,
+				FlavorGroupName:  entry.key.flavorGroup,
+				ResourceType:     entry.key.resourceType,
+				Amount:           qty,
+				AvailabilityZone: string(req.AZ),
+				ProjectID:        firstProjectID,
+				DomainID:         probeDomainID,
+				State:            v1alpha1.CommitmentStatusPending,
+				AllowRejection:   true,
+				StartTime:        &now,
+				EndTime:          &endTime,
+			},
+		}
+		if createErr := api.client.Create(ctx, probe); createErr != nil {
+			resp.RejectionReason = "dry run: failed to create probe: " + createErr.Error()
+			return
+		}
+		probeWatches = append(probeWatches, crWatch{name: probeName, generation: probe.Generation})
+	}
+
+	logger.Info("dry run: probes created, polling for controller outcome", "count", len(probeWatches))
+	rejected, watchErrs := watchCRsUntilReady(ctx, logger, api.client, probeWatches,
+		api.config.WatchTimeout.Duration, api.config.WatchPollInterval.Duration)
+
+	switch {
+	case len(rejected) > 0:
+		var b strings.Builder
+		fmt.Fprintf(&b, "dry run: %d probe(s) rejected:", len(rejected))
+		for _, w := range probeWatches {
+			if reason, ok := rejected[w.name]; ok {
+				fmt.Fprintf(&b, "\n- %s: %s", strings.TrimPrefix(w.name, "commitment-"), reason)
+			}
+		}
+		resp.RejectionReason = b.String()
+	case len(watchErrs) > 0:
+		msgs := make([]string, len(watchErrs))
+		for i, e := range watchErrs {
+			msgs[i] = e.Error()
+		}
+		resp.RejectionReason = "dry run: timeout: " + strings.Join(msgs, "; ")
+	default:
+		logger.Info("dry run: capacity available", "probes", len(probeWatches))
+	}
+}
+
+// cleanupDryRunProbes deletes probe CommittedResource CRDs and their child Reservation CRDs.
+// CR is deleted first so the controller cannot create new slots while we enumerate existing ones.
+// Reservations are listed by label (not field index) to avoid cache-lag false-negatives.
+func (api *HTTPAPI) cleanupDryRunProbes(ctx context.Context, logger logr.Logger, watches []crWatch) {
+	for _, w := range watches {
+		cr := &v1alpha1.CommittedResource{}
+		if err := api.client.Get(ctx, types.NamespacedName{Name: w.name}, cr); err != nil {
+			continue
+		}
+		commitmentUUID := cr.Spec.CommitmentUUID
+
+		if err := api.client.Delete(ctx, cr); client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "dry run: failed to delete probe", "probe", w.name)
+		}
+
+		var resList v1alpha1.ReservationList
+		if err := api.client.List(ctx, &resList, client.MatchingLabels{
+			v1alpha1.LabelReservationType: v1alpha1.ReservationTypeLabelCommittedResource,
+		}); err != nil {
+			logger.Error(err, "dry run: failed to list probe reservations", "probe", w.name)
+			continue
+		}
+		for i := range resList.Items {
+			res := &resList.Items[i]
+			if res.Spec.CommittedResourceReservation == nil ||
+				res.Spec.CommittedResourceReservation.CommitmentUUID != commitmentUUID {
+				continue
+			}
+			if err := api.client.Delete(ctx, res); client.IgnoreNotFound(err) != nil {
+				logger.Error(err, "dry run: failed to delete probe reservation", "reservation", res.Name)
+			}
+		}
+	}
 }
 
 // applyCRSpec writes CommitmentState fields into a CommittedResource CRD spec.

--- a/internal/scheduling/reservations/commitments/api/change_commitments.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments.go
@@ -522,14 +522,7 @@ func (api *HTTPAPI) performDryRun(ctx context.Context, logger logr.Logger, req l
 
 	// Pass 1: aggregate raw unit deltas per resource name across all projects.
 	// A decrease in one project may cancel an increase in another, so we sum signed deltas.
-	netUnitDeltas := make(map[liquid.ResourceName]int64)
-	for _, projectChanges := range req.ByProject {
-		for resourceName, rc := range projectChanges.ByResource {
-			totalBefore := rc.TotalConfirmedBefore + rc.TotalGuaranteedBefore
-			totalAfter := rc.TotalConfirmedAfter + rc.TotalGuaranteedAfter
-			netUnitDeltas[resourceName] += int64(totalAfter) - int64(totalBefore) //nolint:gosec
-		}
-	}
+	netUnitDeltas := computeNetUnitDeltas(req)
 
 	// Pass 2: for each resource with a net increase, resolve config and convert to probe size.
 	// probeKey uniquely identifies a probe CR (one per resource with a net increase).

--- a/internal/scheduling/reservations/commitments/api/change_commitments_e2e_test.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -289,9 +290,36 @@ func e2eRejectScheduler(t *testing.T) http.HandlerFunc {
 	}
 }
 
-// ============================================================================
-// E2E test cases
-// ============================================================================
+// assertNoDryRunProbes verifies that all probe CommittedResource CRDs and their child
+// Reservations have been cleaned up. It only checks objects associated with dry-run probes
+// (name prefix "commitment-dryrun-") rather than asserting zero total objects, so the
+// assertion stays valid when other CRs or Reservations exist in the same environment.
+func (e *e2eEnv) assertNoDryRunProbes(t *testing.T) {
+	t.Helper()
+
+	var crList v1alpha1.CommittedResourceList
+	if err := e.k8sClient.List(context.Background(), &crList); err != nil {
+		t.Fatalf("list CRs: %v", err)
+	}
+	for _, cr := range crList.Items {
+		if strings.HasPrefix(cr.Name, "commitment-dryrun-") {
+			t.Errorf("probe CommittedResource %q still exists after dry run cleanup", cr.Name)
+		}
+	}
+
+	var resList v1alpha1.ReservationList
+	if err := e.k8sClient.List(context.Background(), &resList, client.MatchingLabels{
+		v1alpha1.LabelReservationType: v1alpha1.ReservationTypeLabelCommittedResource,
+	}); err != nil {
+		t.Fatalf("list reservations: %v", err)
+	}
+	for _, res := range resList.Items {
+		if res.Spec.CommittedResourceReservation != nil &&
+			strings.HasPrefix(res.Spec.CommittedResourceReservation.CommitmentUUID, "dryrun-") {
+			t.Errorf("probe Reservation %q still exists after dry run cleanup", res.Name)
+		}
+	}
+}
 
 const e2eInfoVersion = int64(1234)
 
@@ -369,22 +397,7 @@ func TestE2EChangeCommitments(t *testing.T) {
 			WantResp: newAPIResponse(),
 			Verify: func(t *testing.T, env *e2eEnv) {
 				t.Helper()
-				var crList v1alpha1.CommittedResourceList
-				if err := env.k8sClient.List(context.Background(), &crList); err != nil {
-					t.Fatalf("list CRs: %v", err)
-				}
-				if len(crList.Items) != 0 {
-					t.Errorf("expected no CommittedResource CRDs after dry run, got %d", len(crList.Items))
-				}
-				var resList v1alpha1.ReservationList
-				if err := env.k8sClient.List(context.Background(), &resList, client.MatchingLabels{
-					v1alpha1.LabelReservationType: v1alpha1.ReservationTypeLabelCommittedResource,
-				}); err != nil {
-					t.Fatalf("list reservations: %v", err)
-				}
-				if len(resList.Items) != 0 {
-					t.Errorf("expected no Reservation CRDs after dry run cleanup, got %d", len(resList.Items))
-				}
+				env.assertNoDryRunProbes(t)
 			},
 		},
 		{
@@ -395,22 +408,7 @@ func TestE2EChangeCommitments(t *testing.T) {
 			WantResp: newAPIResponse("no hosts found"),
 			Verify: func(t *testing.T, env *e2eEnv) {
 				t.Helper()
-				var crList v1alpha1.CommittedResourceList
-				if err := env.k8sClient.List(context.Background(), &crList); err != nil {
-					t.Fatalf("list CRs: %v", err)
-				}
-				if len(crList.Items) != 0 {
-					t.Errorf("expected no CommittedResource CRDs after dry run, got %d", len(crList.Items))
-				}
-				var resList v1alpha1.ReservationList
-				if err := env.k8sClient.List(context.Background(), &resList, client.MatchingLabels{
-					v1alpha1.LabelReservationType: v1alpha1.ReservationTypeLabelCommittedResource,
-				}); err != nil {
-					t.Fatalf("list reservations: %v", err)
-				}
-				if len(resList.Items) != 0 {
-					t.Errorf("expected no Reservation CRDs after dry run cleanup, got %d", len(resList.Items))
-				}
+				env.assertNoDryRunProbes(t)
 			},
 		},
 		{

--- a/internal/scheduling/reservations/commitments/api/change_commitments_e2e_test.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_e2e_test.go
@@ -124,7 +124,7 @@ func newE2EEnv(t *testing.T, flavors []*TestFlavor, infoVersion int64, scheduler
 	cfg.WatchTimeout = metav1.Duration{Duration: 20 * time.Second}
 	cfg.WatchPollInterval = metav1.Duration{Duration: 100 * time.Millisecond}
 	cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
-		"*": {RAM: commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasCapacity: true}},
+		"*": {RAM: commitments.RAMResourceTypeConfig{HandlesCommitments: true, HandlesDryRun: true, HasCapacity: true}},
 	}
 	api := NewAPIWithConfig(k8sClient, cfg, nil)
 	mux := http.NewServeMux()
@@ -360,6 +360,58 @@ func TestE2EChangeCommitments(t *testing.T) {
 			)),
 			WantResp:   newAPIResponse("no hosts found"),
 			WantAbsent: []string{"commitment-uuid-e2e-batch-a", "commitment-uuid-e2e-batch-b"},
+		},
+		{
+			Name:      "dry run: scheduler accepts → API accepted, probe CR and Reservations cleaned up",
+			Scheduler: e2eAcceptScheduler,
+			ReqJSON: buildRequestJSON(newCommitmentRequest("az-a", true, e2eInfoVersion,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-e2e-dry-ok", "confirmed", 1))),
+			WantResp: newAPIResponse(),
+			Verify: func(t *testing.T, env *e2eEnv) {
+				t.Helper()
+				var crList v1alpha1.CommittedResourceList
+				if err := env.k8sClient.List(context.Background(), &crList); err != nil {
+					t.Fatalf("list CRs: %v", err)
+				}
+				if len(crList.Items) != 0 {
+					t.Errorf("expected no CommittedResource CRDs after dry run, got %d", len(crList.Items))
+				}
+				var resList v1alpha1.ReservationList
+				if err := env.k8sClient.List(context.Background(), &resList, client.MatchingLabels{
+					v1alpha1.LabelReservationType: v1alpha1.ReservationTypeLabelCommittedResource,
+				}); err != nil {
+					t.Fatalf("list reservations: %v", err)
+				}
+				if len(resList.Items) != 0 {
+					t.Errorf("expected no Reservation CRDs after dry run cleanup, got %d", len(resList.Items))
+				}
+			},
+		},
+		{
+			Name:      "dry run: scheduler rejects → API returns rejection, probe CR and Reservations cleaned up",
+			Scheduler: e2eRejectScheduler,
+			ReqJSON: buildRequestJSON(newCommitmentRequest("az-a", true, e2eInfoVersion,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-e2e-dry-rej", "confirmed", 1))),
+			WantResp: newAPIResponse("no hosts found"),
+			Verify: func(t *testing.T, env *e2eEnv) {
+				t.Helper()
+				var crList v1alpha1.CommittedResourceList
+				if err := env.k8sClient.List(context.Background(), &crList); err != nil {
+					t.Fatalf("list CRs: %v", err)
+				}
+				if len(crList.Items) != 0 {
+					t.Errorf("expected no CommittedResource CRDs after dry run, got %d", len(crList.Items))
+				}
+				var resList v1alpha1.ReservationList
+				if err := env.k8sClient.List(context.Background(), &resList, client.MatchingLabels{
+					v1alpha1.LabelReservationType: v1alpha1.ReservationTypeLabelCommittedResource,
+				}); err != nil {
+					t.Fatalf("list reservations: %v", err)
+				}
+				if len(resList.Items) != 0 {
+					t.Errorf("expected no Reservation CRDs after dry run cleanup, got %d", len(resList.Items))
+				}
+			},
 		},
 		{
 			Name:      "lifecycle: create then delete, CR and child Reservations cleaned up",

--- a/internal/scheduling/reservations/commitments/api/change_commitments_metrics.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_metrics.go
@@ -41,3 +41,17 @@ func countCommitments(req liquid.CommitmentChangeRequest) int {
 	}
 	return count
 }
+
+// computeNetUnitDeltas returns the signed net unit change per resource name summed across all projects.
+// A positive value means more capacity is requested; negative means capacity is being released.
+func computeNetUnitDeltas(req liquid.CommitmentChangeRequest) map[liquid.ResourceName]int64 {
+	deltas := make(map[liquid.ResourceName]int64)
+	for _, projectChanges := range req.ByProject {
+		for resourceName, rc := range projectChanges.ByResource {
+			totalBefore := rc.TotalConfirmedBefore + rc.TotalGuaranteedBefore
+			totalAfter := rc.TotalConfirmedAfter + rc.TotalGuaranteedAfter
+			deltas[resourceName] += int64(totalAfter) - int64(totalBefore) //nolint:gosec
+		}
+	}
+	return deltas
+}

--- a/internal/scheduling/reservations/commitments/api/change_commitments_metrics.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_metrics.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"net/http"
 	"strconv"
 	"time"
 
@@ -14,22 +15,20 @@ import (
 func (api *HTTPAPI) recordMetrics(req liquid.CommitmentChangeRequest, resp liquid.CommitmentChangeResponse, statusCode int, startTime time.Time) {
 	duration := time.Since(startTime).Seconds()
 	statusCodeStr := strconv.Itoa(statusCode)
+	dryRunStr := strconv.FormatBool(req.DryRun)
 
-	// Record request counter and duration
-	api.monitor.requestCounter.WithLabelValues(statusCodeStr).Inc()
-	api.monitor.requestDuration.WithLabelValues(statusCodeStr).Observe(duration)
-
-	// Count total commitment changes in the request
-	commitmentCount := countCommitments(req)
-
-	// Determine result based on response
 	result := "accepted"
-	if resp.RejectionReason != "" {
+	if statusCode != http.StatusOK {
+		result = "error"
+	} else if resp.RejectionReason != "" {
 		result = "rejected"
 	}
 
-	// Record commitment changes counter
-	api.monitor.commitmentChanges.WithLabelValues(result, string(req.AZ)).Add(float64(commitmentCount))
+	api.monitor.requestCounter.WithLabelValues(statusCodeStr, dryRunStr, result).Inc()
+	api.monitor.requestDuration.WithLabelValues(statusCodeStr, dryRunStr).Observe(duration)
+
+	commitmentCount := countCommitments(req)
+	api.monitor.commitmentChanges.WithLabelValues(result, string(req.AZ), dryRunStr).Add(float64(commitmentCount))
 }
 
 // countCommitments counts the total number of commitments in a request.

--- a/internal/scheduling/reservations/commitments/api/change_commitments_monitor.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_monitor.go
@@ -23,16 +23,16 @@ func NewChangeCommitmentsAPIMonitor() ChangeCommitmentsAPIMonitor {
 		requestCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_committed_resource_change_api_requests_total",
 			Help: "Total number of committed resource change API requests by HTTP status code",
-		}, []string{"status_code"}),
+		}, []string{"status_code", "dry_run", "result"}),
 		requestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "cortex_committed_resource_change_api_request_duration_seconds",
 			Help:    "Duration of committed resource change API requests in seconds by HTTP status code",
 			Buckets: []float64{0.5, 1, 2.5, 5, 7.5, 10, 12.5, 15, 20, 30},
-		}, []string{"status_code"}),
+		}, []string{"status_code", "dry_run"}),
 		commitmentChanges: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_committed_resource_change_api_commitment_changes_total",
 			Help: "Total number of commitment changes processed by result and availability zone",
-		}, []string{"result", "az"}),
+		}, []string{"result", "az", "dry_run"}),
 		timeouts: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "cortex_committed_resource_change_api_timeouts_total",
 			Help: "Total number of commitment change requests that timed out while waiting for reservations to become ready",
@@ -42,9 +42,13 @@ func NewChangeCommitmentsAPIMonitor() ChangeCommitmentsAPIMonitor {
 	// Pre-initialize request metrics with zero values for common HTTP status codes.
 	// This ensures metrics exist in Prometheus before the first request,
 	// preventing "metric missing" warnings in alerting rules.
-	for _, statusCode := range []string{"200", "400", "409", "500", "503"} {
-		m.requestCounter.WithLabelValues(statusCode)
-		m.requestDuration.WithLabelValues(statusCode)
+	for _, dryRun := range []string{"true", "false"} {
+		for _, statusCode := range []string{"200", "400", "409", "500", "503"} {
+			for _, result := range []string{"accepted", "rejected", "error"} {
+				m.requestCounter.WithLabelValues(statusCode, dryRun, result)
+			}
+			m.requestDuration.WithLabelValues(statusCode, dryRun)
+		}
 	}
 
 	return m

--- a/internal/scheduling/reservations/commitments/api/change_commitments_monitor_test.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_monitor_test.go
@@ -177,6 +177,95 @@ func TestChangeCommitmentsAPIMonitor_MetricLabels(t *testing.T) {
 	}
 }
 
+func TestComputeNetUnitDeltas(t *testing.T) {
+	testCases := []struct {
+		name     string
+		request  CommitmentChangeRequest
+		expected map[string]int64 // resourceName → expected net delta
+	}{
+		{
+			name: "single project increase",
+			request: newCommitmentRequest("az-a", true, 1234,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-1", "confirmed", 5)),
+			expected: map[string]int64{"hw_version_hana_1_ram": 5},
+		},
+		{
+			name: "single project decrease",
+			request: newCommitmentRequest("az-a", true, 1234,
+				deleteCommitment("hw_version_hana_1_ram", "project-A", "uuid-1", "confirmed", 5)),
+			expected: map[string]int64{"hw_version_hana_1_ram": -5},
+		},
+		{
+			name: "two projects same resource: +5 and -5 cancel to zero",
+			request: newCommitmentRequest("az-a", true, 1234,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-a", "confirmed", 5),
+				deleteCommitment("hw_version_hana_1_ram", "project-B", "uuid-b", "confirmed", 5)),
+			expected: map[string]int64{"hw_version_hana_1_ram": 0},
+		},
+		{
+			name: "two projects same resource: +5 and -3 leaves net +2",
+			request: newCommitmentRequest("az-a", true, 1234,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-a", "confirmed", 5),
+				deleteCommitment("hw_version_hana_1_ram", "project-B", "uuid-b", "confirmed", 3)),
+			expected: map[string]int64{"hw_version_hana_1_ram": 2},
+		},
+		{
+			name: "two projects same resource: +3 and -5 leaves net -2",
+			request: newCommitmentRequest("az-a", true, 1234,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-a", "confirmed", 3),
+				deleteCommitment("hw_version_hana_1_ram", "project-B", "uuid-b", "confirmed", 5)),
+			expected: map[string]int64{"hw_version_hana_1_ram": -2},
+		},
+		{
+			name: "two resources tracked independently",
+			request: newCommitmentRequest("az-a", true, 1234,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-1", "confirmed", 4),
+				createCommitment("hw_version_hana_2_ram", "project-A", "uuid-2", "confirmed", 2)),
+			expected: map[string]int64{
+				"hw_version_hana_1_ram": 4,
+				"hw_version_hana_2_ram": 2,
+			},
+		},
+		{
+			name: "two resources: one net positive, one net zero",
+			request: newCommitmentRequest("az-a", true, 1234,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-a1", "confirmed", 5),
+				deleteCommitment("hw_version_hana_1_ram", "project-B", "uuid-b1", "confirmed", 5),
+				createCommitment("hw_version_hana_2_ram", "project-A", "uuid-a2", "confirmed", 3)),
+			expected: map[string]int64{
+				"hw_version_hana_1_ram": 0,
+				"hw_version_hana_2_ram": 3,
+			},
+		},
+		{
+			name:     "empty request",
+			request:  newCommitmentRequest("az-a", true, 1234),
+			expected: map[string]int64{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqJSON := buildRequestJSON(tc.request)
+			var req liquid.CommitmentChangeRequest
+			if err := json.Unmarshal([]byte(reqJSON), &req); err != nil {
+				t.Fatalf("parse request: %v", err)
+			}
+
+			got := computeNetUnitDeltas(req)
+
+			if len(got) != len(tc.expected) {
+				t.Fatalf("expected %d resource entries, got %d: %v", len(tc.expected), len(got), got)
+			}
+			for name, want := range tc.expected {
+				if got[liquid.ResourceName(name)] != want {
+					t.Errorf("resource %q: want delta %d, got %d", name, want, got[liquid.ResourceName(name)])
+				}
+			}
+		})
+	}
+}
+
 func TestCountCommitments(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/internal/scheduling/reservations/commitments/api/change_commitments_monitor_test.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_monitor_test.go
@@ -21,9 +21,9 @@ func TestChangeCommitmentsAPIMonitor_MetricsRegistration(t *testing.T) {
 	}
 
 	// Observe metrics before gathering (Prometheus metrics with labels only appear after being used)
-	monitor.requestCounter.WithLabelValues("200").Inc()
-	monitor.requestDuration.WithLabelValues("200").Observe(0.1)
-	monitor.commitmentChanges.WithLabelValues("success", "az-1").Inc()
+	monitor.requestCounter.WithLabelValues("200", "false", "accepted").Inc()
+	monitor.requestDuration.WithLabelValues("200", "false").Observe(0.1)
+	monitor.commitmentChanges.WithLabelValues("accepted", "az-1", "false").Inc()
 	monitor.timeouts.Inc()
 
 	// Verify metrics can be gathered
@@ -86,12 +86,12 @@ func TestChangeCommitmentsAPIMonitor_MetricLabels(t *testing.T) {
 	}
 
 	// Record some test metrics
-	monitor.requestCounter.WithLabelValues("200").Inc()
-	monitor.requestCounter.WithLabelValues("409").Inc()
-	monitor.requestCounter.WithLabelValues("503").Inc()
-	monitor.requestDuration.WithLabelValues("200").Observe(1.5)
-	monitor.commitmentChanges.WithLabelValues("success", "az-1").Add(5)
-	monitor.commitmentChanges.WithLabelValues("rejected", "az-1").Add(2)
+	monitor.requestCounter.WithLabelValues("200", "false", "accepted").Inc()
+	monitor.requestCounter.WithLabelValues("409", "false", "error").Inc()
+	monitor.requestCounter.WithLabelValues("503", "false", "error").Inc()
+	monitor.requestDuration.WithLabelValues("200", "false").Observe(1.5)
+	monitor.commitmentChanges.WithLabelValues("accepted", "az-1", "false").Add(5)
+	monitor.commitmentChanges.WithLabelValues("rejected", "az-1", "false").Add(2)
 
 	// Gather metrics
 	families, err := registry.Gather()
@@ -108,7 +108,7 @@ func TestChangeCommitmentsAPIMonitor_MetricLabels(t *testing.T) {
 				t.Errorf("Expected at least 3 request counter metrics, got %d", len(family.Metric))
 			}
 
-			// Check all metrics have the status_code label
+			// Check all metrics have the status_code, dry_run, and result labels
 			for _, metric := range family.Metric {
 				labelNames := make(map[string]bool)
 				for _, label := range metric.Label {
@@ -117,6 +117,12 @@ func TestChangeCommitmentsAPIMonitor_MetricLabels(t *testing.T) {
 
 				if !labelNames["status_code"] {
 					t.Error("Missing 'status_code' label in request counter")
+				}
+				if !labelNames["dry_run"] {
+					t.Error("Missing 'dry_run' label in request counter")
+				}
+				if !labelNames["result"] {
+					t.Error("Missing 'result' label in request counter")
 				}
 			}
 		}
@@ -128,7 +134,7 @@ func TestChangeCommitmentsAPIMonitor_MetricLabels(t *testing.T) {
 				t.Errorf("Expected at least 1 histogram metric, got %d", len(family.Metric))
 			}
 
-			// Check all metrics have the status_code label
+			// Check all metrics have the status_code and dry_run labels
 			for _, metric := range family.Metric {
 				labelNames := make(map[string]bool)
 				for _, label := range metric.Label {
@@ -138,16 +144,19 @@ func TestChangeCommitmentsAPIMonitor_MetricLabels(t *testing.T) {
 				if !labelNames["status_code"] {
 					t.Error("Missing 'status_code' label in histogram")
 				}
+				if !labelNames["dry_run"] {
+					t.Error("Missing 'dry_run' label in histogram")
+				}
 			}
 		}
 
 		if *family.Name == "cortex_committed_resource_change_api_commitment_changes_total" {
-			// 2 label combinations: (success,az-1) and (rejected,az-1)
+			// 2 label combinations: (accepted,az-1,false) and (rejected,az-1,false)
 			if len(family.Metric) < 2 {
 				t.Errorf("Expected at least 2 commitment changes metrics, got %d", len(family.Metric))
 			}
 
-			// Check all metrics have both result and az labels
+			// Check all metrics have result, az, and dry_run labels
 			for _, metric := range family.Metric {
 				labelNames := make(map[string]bool)
 				for _, label := range metric.Label {
@@ -159,6 +168,9 @@ func TestChangeCommitmentsAPIMonitor_MetricLabels(t *testing.T) {
 				}
 				if !labelNames["az"] {
 					t.Error("Missing 'az' label in commitment changes counter")
+				}
+				if !labelNames["dry_run"] {
+					t.Error("Missing 'dry_run' label in commitment changes counter")
 				}
 			}
 		}

--- a/internal/scheduling/reservations/commitments/api/change_commitments_test.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_test.go
@@ -206,11 +206,40 @@ func TestHandleChangeCommitments(t *testing.T) {
 			ExpectedAPIResponse: APIResponseExpectation{StatusCode: 503},
 		},
 		{
-			Name:    "Dry run: not supported yet",
+			Name:    "Dry run: controller accepts probe → API returns accepted",
 			Flavors: []*TestFlavor{m1Small},
 			CommitmentRequest: newCommitmentRequest("az-a", true, 1234,
 				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-dry", "confirmed", 2)),
-			ExpectedAPIResponse: newAPIResponse("Dry run not supported"),
+			ExpectedAPIResponse: newAPIResponse(), // no rejection reason = success
+		},
+		{
+			Name:    "Dry run: version mismatch → 409 Conflict",
+			Flavors: []*TestFlavor{m1Small},
+			CommitmentRequest: newCommitmentRequest("az-a", true, 9999,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-dry-vm", "confirmed", 2)),
+			EnvInfoVersion:      1234, // env is at 1234, request claims 9999 → mismatch
+			ExpectedAPIResponse: APIResponseExpectation{StatusCode: 409},
+		},
+		{
+			Name:    "Dry run: HandlesDryRun=false → resource skipped, trivially accepted",
+			Flavors: []*TestFlavor{m1Small},
+			CommitmentRequest: newCommitmentRequest("az-a", true, 1234,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-dry-dis", "confirmed", 2)),
+			CustomConfig: func() *commitments.APIConfig {
+				cfg := commitments.DefaultAPIConfig()
+				cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
+					"*": {RAM: commitments.RAMResourceTypeConfig{HandlesCommitments: true, HandlesDryRun: false}},
+				}
+				return &cfg
+			}(),
+			ExpectedAPIResponse: newAPIResponse(),
+		},
+		{
+			Name:    "Dry run: no net capacity increase (deletion only) → trivially accepted",
+			Flavors: []*TestFlavor{m1Small},
+			CommitmentRequest: newCommitmentRequest("az-a", true, 1234,
+				deleteCommitment("hw_version_hana_1_ram", "project-A", "uuid-dry-del", "confirmed", 2)),
+			ExpectedAPIResponse: newAPIResponse(),
 		},
 		{
 			Name:                "Empty request: no CRDs created",
@@ -750,7 +779,7 @@ func newCRTestEnv(t *testing.T, tc CommitmentChangeTestCase) *CRTestEnv {
 		cfg := commitments.DefaultAPIConfig()
 		cfg.FlavorGroupResourceConfig = map[string]commitments.FlavorGroupResourcesConfig{
 			"*": {
-				RAM:       commitments.RAMResourceTypeConfig{HandlesCommitments: true, HasCapacity: true},
+				RAM:       commitments.RAMResourceTypeConfig{HandlesCommitments: true, HandlesDryRun: true, HasCapacity: true},
 				Cores:     commitments.ResourceTypeConfig{HasCapacity: true},
 				Instances: commitments.ResourceTypeConfig{HasCapacity: true},
 			},

--- a/internal/scheduling/reservations/commitments/api/change_commitments_test.go
+++ b/internal/scheduling/reservations/commitments/api/change_commitments_test.go
@@ -242,6 +242,15 @@ func TestHandleChangeCommitments(t *testing.T) {
 			ExpectedAPIResponse: newAPIResponse(),
 		},
 		{
+			Name:    "Dry run: increase in one project cancelled by decrease in another → net zero, trivially accepted",
+			Flavors: []*TestFlavor{m1Small},
+			CommitmentRequest: newCommitmentRequest("az-a", true, 1234,
+				createCommitment("hw_version_hana_1_ram", "project-A", "uuid-dry-net-a", "confirmed", 2),
+				deleteCommitment("hw_version_hana_1_ram", "project-B", "uuid-dry-net-b", "confirmed", 2)),
+			// Net delta = 0 → no probe CRDs, trivially accepted even with a rejecting scheduler.
+			ExpectedAPIResponse: newAPIResponse(),
+		},
+		{
 			Name:                "Empty request: no CRDs created",
 			Flavors:             []*TestFlavor{m1Small},
 			CommitmentRequest:   newCommitmentRequest("az-a", false, 1234),

--- a/internal/scheduling/reservations/commitments/config.go
+++ b/internal/scheduling/reservations/commitments/config.go
@@ -102,6 +102,7 @@ func (c *CommittedResourceControllerConfig) ApplyDefaults() {
 // ResourceTypeConfig holds per-resource flags for a single resource type within a flavor group.
 type ResourceTypeConfig struct {
 	HandlesCommitments bool `json:"handlesCommitments"`
+	HandlesDryRun      bool `json:"handlesDryRun"`
 	HasCapacity        bool `json:"hasCapacity"`
 	HasQuota           bool `json:"hasQuota"`
 }
@@ -109,6 +110,7 @@ type ResourceTypeConfig struct {
 // RAMResourceTypeConfig extends ResourceTypeConfig with RAM-specific unit configuration.
 type RAMResourceTypeConfig struct {
 	HandlesCommitments bool `json:"handlesCommitments"`
+	HandlesDryRun      bool `json:"handlesDryRun"`
 	HasCapacity        bool `json:"hasCapacity"`
 	HasQuota           bool `json:"hasQuota"`
 	// RAMUnitGiB is the size of one declared LIQUID RAM unit in GiB.

--- a/internal/scheduling/reservations/commitments/e2e_checks.go
+++ b/internal/scheduling/reservations/commitments/e2e_checks.go
@@ -463,7 +463,84 @@ func e2eBatchFlavorGroupResource(
 	}
 }
 
-// e2eFetchUsageReport calls POST /commitments/v1/projects/:id/report-usage, decodes the response,
+// CheckCommitmentsDryRun verifies that the dry-run path of change-commitments works end-to-end
+// for each (AZ, HandlesCommitments resource) pair. A dry-run request is sent with amount=2;
+// both accepted and capacity-rejected responses are valid outcomes. No cleanup is needed
+// because dry-run does not persist any state.
+func CheckCommitmentsDryRun(ctx context.Context, config E2EChecksConfig) {
+	baseURL := e2eBaseURL(config)
+	projectID := e2eProjectID(config)
+	azs := e2eAZs(config)
+
+	serviceInfo := e2eFetchServiceInfo(ctx, baseURL)
+
+	checked := 0
+	for _, az := range azs {
+		for resourceName, resInfo := range serviceInfo.Resources {
+			if !resInfo.HandlesCommitments {
+				continue
+			}
+			e2eDryRunResource(ctx, baseURL, serviceInfo.Version, az, projectID, resourceName, config.e2eRequestTimeout())
+			checked++
+		}
+	}
+
+	if checked == 0 {
+		slog.Warn("dry-run check: no HandlesCommitments resources found in /info — nothing checked")
+	}
+}
+
+// e2eDryRunResource sends a single dry-run change-commitments request for one (AZ, resource) pair.
+func e2eDryRunResource(
+	ctx context.Context,
+	baseURL string,
+	infoVersion int64,
+	az liquid.AvailabilityZone,
+	projectID liquid.ProjectUUID,
+	resourceName liquid.ResourceName,
+	requestTimeout time.Duration,
+) {
+
+	testUUID := liquid.CommitmentUUID(fmt.Sprintf("e2e-dry-%d", time.Now().UnixMilli()))
+	expiresAt := time.Now().Add(5 * time.Minute)
+	const amount = uint64(2)
+
+	req := liquid.CommitmentChangeRequest{
+		InfoVersion: infoVersion,
+		AZ:          az,
+		DryRun:      true,
+		ByProject: map[liquid.ProjectUUID]liquid.ProjectCommitmentChangeset{
+			projectID: {
+				ByResource: map[liquid.ResourceName]liquid.ResourceCommitmentChangeset{
+					resourceName: {
+						TotalConfirmedAfter: amount,
+						Commitments: []liquid.Commitment{{
+							UUID:      testUUID,
+							Amount:    amount,
+							NewStatus: Some(liquid.CommitmentStatusConfirmed),
+							ExpiresAt: expiresAt,
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	slog.Info("dry-run check: sending dry-run request",
+		"resource", resourceName, "uuid", testUUID, "project", projectID, "az", az)
+
+	rejectionReason := e2eSendChangeCommitments(ctx, baseURL, req, requestTimeout)
+	switch {
+	case rejectionReason == "":
+		slog.Info("dry-run check: accepted", "resource", resourceName, "az", az)
+	case strings.Contains(rejectionReason, "no hosts found") || strings.Contains(rejectionReason, "insufficient CPU cores"):
+		slog.Info("dry-run check: capacity rejection (expected in constrained clusters)",
+			"resource", resourceName, "az", az, "reason", rejectionReason)
+	default:
+		panic(fmt.Sprintf("dry-run check: unexpected rejection for resource %s in %s: %s", resourceName, az, rejectionReason))
+	}
+}
+
 // and returns it. Panics on HTTP errors or decode failures.
 func e2eFetchUsageReport(ctx context.Context, baseURL string, az liquid.AvailabilityZone, projectID liquid.ProjectUUID) liquid.ServiceUsageReport {
 	usageReq := liquid.ServiceUsageRequest{AllAZs: []liquid.AvailabilityZone{az}}
@@ -578,6 +655,7 @@ func e2eBaseURL(config E2EChecksConfig) string {
 func RunCommitmentsE2EChecks(ctx context.Context, config E2EChecksConfig) {
 	slog.Info("running commitments e2e checks")
 	CheckCommitmentsInfoEndpoint(ctx, config)
+	CheckCommitmentsDryRun(ctx, config)
 	CheckCommitmentsRoundTrip(ctx, config)
 	CheckCommitmentsMultiFlavorGroupBatch(ctx, config)
 	slog.Info("all commitments e2e checks passed")


### PR DESCRIPTION
Adds basic dry-run support to the POST /v1/commitment/change-commitments endpoint