### PR TITLE
postgres: bump to 18.4 and apply base image security upgrades

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -9,6 +9,12 @@ RUN set -eux; \
 # see https://github.com/docker-library/postgres/issues/274
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
+# upgrade pre-installed packages from the base image to pick up security fixes
+RUN set -ex; \
+	apt-get update; \
+	apt-get upgrade -y; \
+	rm -rf /var/lib/apt/lists/*
+
 RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -67,7 +73,7 @@ RUN set -ex; \
 ENV PG_MAJOR 18
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 
-ENV PG_VERSION 18.3-1.pgdg13+1
+ENV PG_VERSION 18.4-1.pgdg13+1
 
 RUN set -ex; \
 	\

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -4,4 +4,4 @@ https://github.com/docker-library/postgres with the most recent stable version o
 
 Also contains some minor changes, such as that `gosu` is directly installed over apt.
 
-Current postgres version: `v17.9`
+Current postgres version: `v18.4`


### PR DESCRIPTION
- bump PG_VERSION to 18.4-1.pgdg13+1 (18.3 no longer in pgdg apt repo, broke build)

- add 'apt-get upgrade' on the debian:trixie-slim base to pick up debian security updates (clears libcap2 CVE-2026-4878 and systemd CVE-2026-29111)

- update README to reflect new postgres version

Trivy scan of resulting image: 0 fixable vulnerabilities.