### PR TITLE
fix(scheduling): skip weigher validation when no hosts to weigh

### DIFF
--- a/internal/scheduling/lib/weigher_validation.go
+++ b/internal/scheduling/lib/weigher_validation.go
@@ -36,10 +36,6 @@ func validateWeigher[RequestType FilterWeigherPipelineRequest](weigher Weigher[R
 
 // Run the weigher and validate what happens.
 func (s *WeigherValidator[RequestType]) Run(traceLog *slog.Logger, request RequestType) (*FilterWeigherPipelineStepResult, error) {
-	result, err := s.Weigher.Run(traceLog, request)
-	if err != nil {
-		return nil, err
-	}
 	// Note that for some schedulers the same host (e.g. compute host) may
 	// appear multiple times if there is a substruct (e.g. hypervisor hostname).
 	// Since cortex will only schedule on the host level and not below,
@@ -48,11 +44,24 @@ func (s *WeigherValidator[RequestType]) Run(traceLog *slog.Logger, request Reque
 	for _, host := range request.GetHosts() {
 		deduplicated[host] = struct{}{}
 	}
+	// Skip the weigher entirely if there are no hosts to weigh. There is
+	// nothing meaningful for the weigher to do, and running it would only
+	// produce a misleading "no hosts remain" safety error below.
+	if len(deduplicated) == 0 {
+		traceLog.Info("scheduler: skipping weigher, no hosts to weigh")
+		return nil, ErrStepSkipped
+	}
+	result, err := s.Weigher.Run(traceLog, request)
+	if err != nil {
+		return nil, err
+	}
 	if len(result.Activations) != len(deduplicated) {
 		return nil, errors.New("safety: number of (deduplicated) hosts changed during step execution")
 	}
-	// Validate that some hosts remain.
-	if len(result.Activations) == 0 {
+	// Defensive guard: with the skip above this should be unreachable, but we
+	// keep the safety net in case the skip is ever removed or the deduplicated
+	// set is non-empty while activations come back empty.
+	if len(deduplicated) > 0 && len(result.Activations) == 0 {
 		return nil, errors.New("safety: no hosts remain after step execution")
 	}
 	return result, nil

--- a/internal/scheduling/lib/weigher_validation_test.go
+++ b/internal/scheduling/lib/weigher_validation_test.go
@@ -144,3 +144,28 @@ func TestWeigherValidator_Run_HostNumberMismatch(t *testing.T) {
 		t.Errorf("Run() error = %v, want %v", err.Error(), expectedError)
 	}
 }
+
+func TestWeigherValidator_Run_NoHosts_Skips(t *testing.T) {
+	called := false
+	mockStep := &mockWeigher[mockFilterWeigherPipelineRequest]{
+		RunFunc: func(traceLog *slog.Logger, request mockFilterWeigherPipelineRequest) (*FilterWeigherPipelineStepResult, error) {
+			called = true
+			return &FilterWeigherPipelineStepResult{Activations: map[string]float64{}}, nil
+		},
+	}
+
+	request := mockFilterWeigherPipelineRequest{Hosts: []string{}}
+
+	validator := WeigherValidator[mockFilterWeigherPipelineRequest]{Weigher: mockStep}
+
+	result, err := validator.Run(slog.Default(), request)
+	if !errors.Is(err, ErrStepSkipped) {
+		t.Errorf("Run() error = %v, want ErrStepSkipped", err)
+	}
+	if result != nil {
+		t.Errorf("Run() result = %v, want nil", result)
+	}
+	if called {
+		t.Error("expected wrapped weigher not to be called when there are no hosts")
+	}
+}


### PR DESCRIPTION
When the request has 0 hosts (e.g. all hosts were filtered out earlier), the WeigherValidator now returns ErrStepSkipped instead of running the wrapped weigher. This avoids a misleading 'safety: no hosts remain after step execution' error that fired even though the weigher never had any hosts to begin with.

The existing 'no hosts remain' check is also guarded with len(deduplicated) > 0 as a defensive net.