### PR TITLE
feat: enrich CommittedResource kubectl wide view with status summary

### DIFF
--- a/api/v1alpha1/committed_resource_summary.go
+++ b/api/v1alpha1/committed_resource_summary.go
@@ -1,0 +1,99 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+// ComputeStatusSummary produces a compact human-readable summary of the committed resource's
+// current state for the kubectl wide view.
+//
+// Format: {reason}[( diff)] [· {N} VM[s]] [· exp in {duration}|no expiry]
+func ComputeStatusSummary(spec CommittedResourceSpec, status CommittedResourceStatus, now time.Time) string {
+	cond := meta.FindStatusCondition(status.Conditions, CommittedResourceConditionReady)
+	if cond == nil {
+		return ""
+	}
+	reason := cond.Reason
+
+	var parts []string
+
+	// Reason with optional spec-vs-acceptedSpec diff.
+	if diff := buildSpecDiff(spec, status.AcceptedSpec); diff != "" {
+		parts = append(parts, fmt.Sprintf("%s (%s)", reason, diff))
+	} else {
+		parts = append(parts, reason)
+	}
+
+	// VM count — only meaningful once placement is accepted.
+	if reason == CommittedResourceReasonAccepted {
+		n := len(status.AssignedInstances)
+		if n == 1 {
+			parts = append(parts, "1 VM")
+		} else {
+			parts = append(parts, fmt.Sprintf("%d VMs", n))
+		}
+	}
+
+	// Expiry — omit for Rejected (CR is terminal, expiry irrelevant).
+	if reason != CommittedResourceReasonRejected {
+		if spec.EndTime == nil {
+			parts = append(parts, "no expiry")
+		} else if remaining := spec.EndTime.Sub(now); remaining <= 0 {
+			parts = append(parts, "expired")
+		} else {
+			parts = append(parts, "exp in "+formatRemaining(remaining))
+		}
+	}
+
+	return strings.Join(parts, " · ")
+}
+
+// buildSpecDiff returns a semicolon-separated list of placement-relevant field changes
+// between spec and the last accepted spec.
+func buildSpecDiff(spec CommittedResourceSpec, accepted *CommittedResourceSpec) string {
+	if accepted == nil {
+		return ""
+	}
+	var diffs []string
+	if spec.Amount.Cmp(accepted.Amount) != 0 {
+		diffs = append(diffs, fmt.Sprintf("amount %s→%s", accepted.Amount.String(), spec.Amount.String()))
+	}
+	if spec.FlavorGroupName != accepted.FlavorGroupName {
+		diffs = append(diffs, fmt.Sprintf("fg %s→%s", accepted.FlavorGroupName, spec.FlavorGroupName))
+	}
+	if spec.AvailabilityZone != accepted.AvailabilityZone {
+		diffs = append(diffs, fmt.Sprintf("az %s→%s", accepted.AvailabilityZone, spec.AvailabilityZone))
+	}
+	if spec.ResourceType != accepted.ResourceType {
+		diffs = append(diffs, fmt.Sprintf("type %s→%s", accepted.ResourceType, spec.ResourceType))
+	}
+	return strings.Join(diffs, "; ")
+}
+
+// formatRemaining formats a positive duration as a compact two-unit string,
+// scaling from days down to seconds based on magnitude.
+func formatRemaining(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		m := int(d.Minutes())
+		s := int(d.Seconds()) - m*60
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	if d < 24*time.Hour {
+		h := int(d.Hours())
+		m := int(d.Minutes()) - h*60
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+	days := int(d.Hours()) / 24
+	h := int(d.Hours()) - days*24
+	return fmt.Sprintf("%dd %dh", days, h)
+}

--- a/api/v1alpha1/committed_resource_summary_test.go
+++ b/api/v1alpha1/committed_resource_summary_test.go
@@ -1,0 +1,189 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func makeSpec(amount, fg, az string, endTime *time.Time) CommittedResourceSpec {
+	s := CommittedResourceSpec{
+		Amount:           resource.MustParse(amount),
+		FlavorGroupName:  fg,
+		AvailabilityZone: az,
+		ResourceType:     CommittedResourceTypeMemory,
+		ProjectID:        "proj-1",
+		DomainID:         "dom-1",
+		CommitmentUUID:   "uuid-1",
+		State:            CommitmentStatusConfirmed,
+	}
+	if endTime != nil {
+		s.EndTime = &metav1.Time{Time: *endTime}
+	}
+	return s
+}
+
+func makeStatus(reason string, accepted *CommittedResourceSpec, instances []string) CommittedResourceStatus {
+	status := CommittedResourceStatus{
+		AssignedInstances: instances,
+	}
+	if accepted != nil {
+		status.AcceptedSpec = accepted.DeepCopy()
+	}
+	condStatus := metav1.ConditionTrue
+	if reason != CommittedResourceReasonAccepted {
+		condStatus = metav1.ConditionFalse
+	}
+	status.Conditions = []metav1.Condition{{
+		Type:   CommittedResourceConditionReady,
+		Status: condStatus,
+		Reason: reason,
+	}}
+	return status
+}
+
+func TestComputeStatusSummary(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	in := func(d time.Duration) *time.Time { t := now.Add(d); return &t }
+
+	tests := []struct {
+		name   string
+		spec   CommittedResourceSpec
+		status CommittedResourceStatus
+		want   string
+	}{
+		{
+			name:   "no Ready condition",
+			spec:   makeSpec("2Gi", "fg1", "az1", in(4*time.Hour)),
+			status: CommittedResourceStatus{},
+			want:   "",
+		},
+		{
+			name:   "Accepted, 3 VMs, exp in hours",
+			spec:   makeSpec("2Gi", "fg1", "az1", in(4*time.Hour+30*time.Minute)),
+			status: makeStatus(CommittedResourceReasonAccepted, ptr(makeSpec("2Gi", "fg1", "az1", in(4*time.Hour+30*time.Minute))), []string{"a", "b", "c"}),
+			want:   "Accepted · 3 VMs · exp in 4h 30m",
+		},
+		{
+			name:   "Accepted, 1 VM, singular",
+			spec:   makeSpec("2Gi", "fg1", "az1", in(25*time.Hour+2*time.Minute)),
+			status: makeStatus(CommittedResourceReasonAccepted, ptr(makeSpec("2Gi", "fg1", "az1", in(25*time.Hour+2*time.Minute))), []string{"a"}),
+			want:   "Accepted · 1 VM · exp in 1d 1h",
+		},
+		{
+			name:   "Accepted, 0 VMs, no expiry",
+			spec:   makeSpec("2Gi", "fg1", "az1", nil),
+			status: makeStatus(CommittedResourceReasonAccepted, ptr(makeSpec("2Gi", "fg1", "az1", nil)), nil),
+			want:   "Accepted · 0 VMs · no expiry",
+		},
+		{
+			name: "Accepted with amount diff",
+			spec: makeSpec("5Gi", "fg1", "az1", in(3*24*time.Hour+2*time.Hour)),
+			status: makeStatus(CommittedResourceReasonAccepted,
+				ptr(makeSpec("2Gi", "fg1", "az1", in(3*24*time.Hour+2*time.Hour))),
+				[]string{"a", "b", "c"}),
+			want: "Accepted (amount 2Gi→5Gi) · 3 VMs · exp in 3d 2h",
+		},
+		{
+			name: "Accepted with az and fg diff",
+			spec: func() CommittedResourceSpec {
+				s := makeSpec("2Gi", "fg2", "az2", nil)
+				return s
+			}(),
+			status: makeStatus(CommittedResourceReasonAccepted,
+				ptr(makeSpec("2Gi", "fg1", "az1", nil)),
+				[]string{"a"}),
+			want: "Accepted (fg fg1→fg2; az az1→az2) · 1 VM · no expiry",
+		},
+		{
+			name:   "Reserving with expiry",
+			spec:   makeSpec("2Gi", "fg1", "az1", in(3*24*time.Hour+2*time.Hour)),
+			status: makeStatus(CommittedResourceReasonReserving, ptr(makeSpec("2Gi", "fg1", "az1", in(3*24*time.Hour+2*time.Hour))), nil),
+			want:   "Reserving · exp in 3d 2h",
+		},
+		{
+			name:   "Reserving with amount diff",
+			spec:   makeSpec("5Gi", "fg1", "az1", in(time.Hour+3*time.Minute)),
+			status: makeStatus(CommittedResourceReasonReserving, ptr(makeSpec("2Gi", "fg1", "az1", in(time.Hour+3*time.Minute))), nil),
+			want:   "Reserving (amount 2Gi→5Gi) · exp in 1h 3m",
+		},
+		{
+			name:   "Rejected",
+			spec:   makeSpec("2Gi", "fg1", "az1", in(4*time.Hour)),
+			status: makeStatus(CommittedResourceReasonRejected, ptr(makeSpec("2Gi", "fg1", "az1", in(4*time.Hour))), nil),
+			want:   "Rejected",
+		},
+		{
+			name:   "Planned with expiry in days",
+			spec:   makeSpec("2Gi", "fg1", "az1", in(3*24*time.Hour+2*time.Hour)),
+			status: makeStatus(CommittedResourceReasonPlanned, nil, nil),
+			want:   "Planned · exp in 3d 2h",
+		},
+		{
+			name:   "Planned no expiry",
+			spec:   makeSpec("2Gi", "fg1", "az1", nil),
+			status: makeStatus(CommittedResourceReasonPlanned, nil, nil),
+			want:   "Planned · no expiry",
+		},
+		{
+			name:   "expired EndTime shows expired",
+			spec:   makeSpec("2Gi", "fg1", "az1", in(-time.Hour)),
+			status: makeStatus(CommittedResourceReasonAccepted, ptr(makeSpec("2Gi", "fg1", "az1", in(-time.Hour))), []string{"a"}),
+			want:   "Accepted · 1 VM · expired",
+		},
+		{
+			name:   "sub-minute expiry shows seconds",
+			spec:   makeSpec("2Gi", "fg1", "az1", in(18*time.Second)),
+			status: makeStatus(CommittedResourceReasonAccepted, ptr(makeSpec("2Gi", "fg1", "az1", in(18*time.Second))), nil),
+			want:   "Accepted · 0 VMs · exp in 18s",
+		},
+		{
+			name:   "sub-hour expiry shows minutes and seconds",
+			spec:   makeSpec("2Gi", "fg1", "az1", in(23*time.Minute+5*time.Second)),
+			status: makeStatus(CommittedResourceReasonAccepted, ptr(makeSpec("2Gi", "fg1", "az1", in(23*time.Minute+5*time.Second))), nil),
+			want:   "Accepted · 0 VMs · exp in 23m 5s",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ComputeStatusSummary(tc.spec, tc.status, now)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatRemaining(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{18 * time.Second, "18s"},
+		{59 * time.Second, "59s"},
+		{time.Minute, "1m 0s"},
+		{23*time.Minute + 5*time.Second, "23m 5s"},
+		{59*time.Minute + 59*time.Second, "59m 59s"},
+		{time.Hour, "1h 0m"},
+		{time.Hour + 3*time.Minute, "1h 3m"},
+		{23*time.Hour + 59*time.Minute, "23h 59m"},
+		{24 * time.Hour, "1d 0h"},
+		{3*24*time.Hour + 2*time.Hour, "3d 2h"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.d.String(), func(t *testing.T) {
+			got := formatRemaining(tc.d)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/committed_resource_types.go
+++ b/api/v1alpha1/committed_resource_types.go
@@ -145,6 +145,11 @@ type CommittedResourceStatus struct {
 	// Conditions holds the current status conditions.
 	// +kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// StatusSummary is a compact human-readable summary for kubectl wide view.
+	// Written by the CR controller and refreshed by the usage reconciler.
+	// +kubebuilder:validation:Optional
+	StatusSummary string `json:"statusSummary,omitempty"`
 }
 
 const (
@@ -172,7 +177,7 @@ const (
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".spec.state"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="StartTime",type="date",JSONPath=".spec.startTime",priority=1
-// +kubebuilder:printcolumn:name="EndTime",type="date",JSONPath=".spec.endTime",priority=1
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.statusSummary",priority=1
 
 // CommittedResource is the Schema for the committedresources API
 type CommittedResource struct {

--- a/helm/library/cortex/files/crds/cortex.cloud_committedresources.yaml
+++ b/helm/library/cortex/files/crds/cortex.cloud_committedresources.yaml
@@ -48,10 +48,10 @@ spec:
       name: StartTime
       priority: 1
       type: date
-    - jsonPath: .spec.endTime
-      name: EndTime
+    - jsonPath: .status.statusSummary
+      name: Status
       priority: 1
-      type: date
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -341,6 +341,11 @@ spec:
                 description: LastUsageReconcileAt is when the usage reconciler last
                   updated AssignedInstances and UsedResources.
                 format: date-time
+                type: string
+              statusSummary:
+                description: |-
+                  StatusSummary is a compact human-readable summary for kubectl wide view.
+                  Written by the CR controller and refreshed by the usage reconciler.
                 type: string
               usageObservedGeneration:
                 description: |-

--- a/internal/scheduling/reservations/commitments/committed_resource_controller.go
+++ b/internal/scheduling/reservations/commitments/committed_resource_controller.go
@@ -377,6 +377,7 @@ func (r *CommittedResourceController) setAccepted(ctx context.Context, cr *v1alp
 		LastTransitionTime: now,
 		ObservedGeneration: cr.Generation,
 	})
+	cr.Status.StatusSummary = v1alpha1.ComputeStatusSummary(cr.Spec, cr.Status, now.Time)
 	if err := r.Status().Patch(ctx, cr, client.MergeFrom(old)); err != nil {
 		return client.IgnoreNotFound(err)
 	}
@@ -504,6 +505,7 @@ func (r *CommittedResourceController) setNotReadyRetry(ctx context.Context, cr *
 func (r *CommittedResourceController) patchNotReady(ctx context.Context, cr *v1alpha1.CommittedResource, reason, message string, resetTimer bool) error {
 	old := cr.DeepCopy()
 	setReadyConditionFalse(&cr.Status.Conditions, reason, message, cr.Generation, resetTimer)
+	cr.Status.StatusSummary = v1alpha1.ComputeStatusSummary(cr.Spec, cr.Status, time.Now())
 	if err := r.Status().Patch(ctx, cr, client.MergeFrom(old)); err != nil {
 		return client.IgnoreNotFound(err)
 	}

--- a/internal/scheduling/reservations/commitments/usage_reconciler.go
+++ b/internal/scheduling/reservations/commitments/usage_reconciler.go
@@ -57,6 +57,7 @@ func (r *UsageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			cr.Status.UsedResources = nil
 			cr.Status.LastUsageReconcileAt = nil
 			cr.Status.UsageObservedGeneration = nil
+			cr.Status.StatusSummary = v1alpha1.ComputeStatusSummary(cr.Spec, cr.Status, start)
 			if err := r.Status().Patch(ctx, &cr, client.MergeFrom(old)); err != nil {
 				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
@@ -75,6 +76,7 @@ func (r *UsageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			cr.Status.UsedResources = nil
 			cr.Status.LastUsageReconcileAt = nil
 			cr.Status.UsageObservedGeneration = nil
+			cr.Status.StatusSummary = v1alpha1.ComputeStatusSummary(cr.Spec, cr.Status, start)
 			if err := r.Status().Patch(ctx, &cr, client.MergeFrom(old)); err != nil {
 				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
@@ -222,6 +224,7 @@ func (r *UsageReconciler) writeUsageStatus(ctx context.Context, state *Commitmen
 	}
 	target.Status.LastUsageReconcileAt = &now
 	target.Status.UsageObservedGeneration = &target.Generation
+	target.Status.StatusSummary = v1alpha1.ComputeStatusSummary(target.Spec, target.Status, now.Time)
 
 	return r.Status().Patch(ctx, target, client.MergeFrom(old))
 }


### PR DESCRIPTION
Operators can now see the full placement status of a committed resource at a glance with kubectl get committedresource -o wide.