### PR TITLE
Fix Renovate config for postgres/Dockerfile and improve schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,8 +3,7 @@
   "extends": [
     "config:recommended",
     "default:pinDigestsDisabled",
-    "mergeConfidence:all-badges",
-    "docker:disable"
+    "mergeConfidence:all-badges"
   ],
   "assignees": [
     "SoWieMarkus"
@@ -70,9 +69,24 @@
       "matchFileNames": [
         "postgres/Dockerfile"
       ],
-      "allowedVersions": "17.x",
-      "automerge": true,
+      "allowedVersions": "18.x",
       "groupName": "postgres Dockerfile"
+    },
+    {
+      "matchFileNames": [
+        "postgres/Dockerfile"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "pinDigest"
+      ],
+      "groupName": "postgres Dockerfile base image",
+      "schedule": [
+        "at any time"
+      ]
     },
     {
       "matchPackageNames": [
@@ -111,8 +125,15 @@
     }
   ],
   "prHourlyLimit": 0,
+  "timezone": "Europe/Berlin",
   "schedule": [
-    "before 8am on Friday"
+    "after 6pm and before 8am every weekday",
+    "every weekend"
   ],
+  "vulnerabilityAlerts": {
+    "schedule": [
+      "at any time"
+    ]
+  },
   "semanticCommits": "disabled"
 }


### PR DESCRIPTION
The base-image digest update for debian:trixie-slim was stuck behind the Friday-only schedule. Address that and clean up two related bugs.

- Remove 'docker:disable' from extends. This shared preset disables the docker datasource and conflicts with the regex manager that tracks the postgres/Dockerfile FROM digest.
- Bump postgres binary allowedVersions 17.x -> 18.x so 18.x updates for ENV PG_VERSION are no longer silently filtered out (the Dockerfile is on PG_MAJOR=18, PG_VERSION=18.4-...).
- Add a packageRule grouping digest/pinDigest updates for postgres/Dockerfile under 'postgres Dockerfile base image' with schedule 'at any time' so base-image digest bumps ship as soon as Renovate detects them. (Automerge intentionally not enabled.)
- Replace the global Friday-only schedule with 'outside German business hours' (Europe/Berlin, after 6pm and before 8am on weekdays + weekends), so updates land more frequently while still avoiding noise during working hours.
- Add top-level vulnerabilityAlerts.schedule = 'at any time' so CVE-driven updates bypass the schedule entirely.