### PR TITLE
Renovate: fix postgres FROM digest autoreplace template [skip ci]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,9 +47,9 @@
     {
       "customType": "regex",
       "fileMatch": ["^postgres/Dockerfile$"],
-      "matchStrings": ["FROM (?<depName>[^:\\n]+):(?<currentValue>[^@\\n]+)@sha256:(?<currentDigest>[a-f0-9]+)"],
+      "matchStrings": ["FROM (?<depName>[^:\\n]+):(?<currentValue>[^@\\n]+)@(?<currentDigest>sha256:[a-f0-9]+)"],
       "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "FROM {{{depName}}}:{{{newValue}}}@sha256:{{{newDigest}}}"
+      "autoReplaceStringTemplate": "FROM {{{depName}}}:{{{newValue}}}@{{{newDigest}}}"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
Even after adding an autoReplaceStringTemplate the update kept failing with:

  DEBUG: Could not extract postgres/Dockerfile (manager=regex)
         after autoreplace. Did the autoreplace make the file
         unparseable?

Root cause: the docker datasource's newDigest already contains the 'sha256:' prefix, so the previous template

  FROM {{{depName}}}:{{{newValue}}}@sha256:{{{newDigest}}}

produced a duplicated prefix, e.g.
  FROM debian:trixie-slim@sha256:sha256:b6e2a152...
which then failed re-extraction.

Fix: include 'sha256:' inside the currentDigest capture group and emit only newDigest in the replacement template.