### PR TITLE
fix: kvm-report-capacity to ignore VM allocations

### DIFF
--- a/helm/bundles/cortex-nova/templates/pipelines_kvm.yaml
+++ b/helm/bundles/cortex-nova/templates/pipelines_kvm.yaml
@@ -624,6 +624,7 @@ spec:
         VM allocations and all reservation types are ignored to represent an
         empty datacenter scenario.
       params:
+        - {key: ignoreAllocations, boolValue: true}
         - {key: ignoredReservationTypes, stringListValue: ["CommittedResourceReservation", "FailoverReservation"]}
     - name: filter_has_requested_traits
       description: |


### PR DESCRIPTION
Restore ignoreAllocations: true on filter_has_enough_capacity so that TotalCapacityVMSlots reflects true empty-datacenter capacity. This was removed in bab31994 due to webhook rejection.