### PR TITLE
fix: bump datasource parallel reconciles to 3 to reduce queue lag

### DIFF
--- a/helm/bundles/cortex-nova/values.yaml
+++ b/helm/bundles/cortex-nova/values.yaml
@@ -263,6 +263,7 @@ cortex-knowledge-controllers:
       labels:
         <<: *cortexMonitoringLabels
         component: nova-knowledge
+    openstackDatasourceControllerParallelReconciles: 3
     enabledControllers:
       - datasource-controllers
       - knowledge-controllers


### PR DESCRIPTION
Addresses flaky CortexNovaExistingDatasourcesLackingBehind alerts caused
by nova-servers blocking the single-threaded reconcile queue when it
takes long to sync.
