### PR TITLE
Preserve input weight ordering when no weighers are configured

### DIFF
--- a/internal/scheduling/lib/filter_weigher_pipeline.go
+++ b/internal/scheduling/lib/filter_weigher_pipeline.go
@@ -274,7 +274,16 @@ func (p *filterWeigherPipeline[RequestType]) Run(request RequestType) (v1alpha1.
 	traceLog.Info("scheduler: starting pipeline", "hosts", hostsIn)
 
 	// Normalize the input weights so we can apply step weights meaningfully.
-	inWeights := p.normalizeInputWeights(request.GetWeights())
+	// Only do this if there are weighers to combine with: tanh saturates large
+	// inputs (e.g. Nova's 50/55/60) to ~1.0, which would destroy the original
+	// ordering. With no weighers configured, the normalized map flows straight
+	// to the sort, so we must keep the raw values to preserve that ordering.
+	var inWeights map[string]float64
+	if len(p.weighers) > 0 {
+		inWeights = p.normalizeInputWeights(request.GetWeights())
+	} else {
+		inWeights = maps.Clone(request.GetWeights())
+	}
 	traceLog.Info("scheduler: input weights", "weights", inWeights)
 
 	// Run filters first to reduce the number of hosts.

--- a/internal/scheduling/lib/filter_weigher_pipeline_test.go
+++ b/internal/scheduling/lib/filter_weigher_pipeline_test.go
@@ -88,6 +88,41 @@ func TestPipeline_Run(t *testing.T) {
 	}
 }
 
+func TestPipeline_Run_NoWeighers_PreservesInputOrdering(t *testing.T) {
+	// With no weighers configured, the tanh normalization would saturate
+	// large input weights to ~1.0 and destroy the requester's ordering. The
+	// pipeline must skip normalization in that case so the original ordering
+	// flows through to the sort.
+	pipeline := &filterWeigherPipeline[mockFilterWeigherPipelineRequest]{}
+
+	request := mockFilterWeigherPipelineRequest{
+		Hosts: []string{"host1", "host2", "host3"},
+		Weights: map[string]float64{
+			"host1": 50.0,
+			"host2": 55.0,
+			"host3": 60.0,
+		},
+	}
+
+	// Run many times to surface any non-determinism from map iteration order.
+	expected := []string{"host3", "host2", "host1"}
+	for i := range 50 {
+		result, err := pipeline.Run(request)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(result.OrderedHosts) != len(expected) {
+			t.Fatalf("expected %d results, got %d", len(expected), len(result.OrderedHosts))
+		}
+		for j, host := range expected {
+			if result.OrderedHosts[j] != host {
+				t.Fatalf("iter %d: expected host %s at position %d, got %s (order=%v)",
+					i, host, j, result.OrderedHosts[j], result.OrderedHosts)
+			}
+		}
+	}
+}
+
 func TestPipeline_NormalizeNovaWeights(t *testing.T) {
 	p := &filterWeigherPipeline[mockFilterWeigherPipelineRequest]{}
 


### PR DESCRIPTION
filterWeigherPipeline.Run always applied math.Tanh to the requester-supplied input weights via normalizeInputWeights. With high Nova-style values (e.g. 50, 55, 60) the tanh output saturates to ~1.0 within machine epsilon for every input — already at tanh(20) the result is indistinguishable from 1.0 in float64. When the pipeline has no weighers configured, those saturated values flowed straight into sortHostsByWeights, whose comparator is not stable under ties, so Go's sort.Slice returned an order driven by randomized map iteration and the requester's original host ordering was lost.

The fix gates normalizeInputWeights on len(p.weighers) > 0 inside Run. When weighers are configured the behavior is unchanged: input weights are tanh-normalized so they live on a comparable scale with the (also tanh-bounded) weigher contributions. When no weighers are configured there is nothing on the other side of the scale to combine with, so we clone the raw request weights and keep the original ordering intact. Filters do not contribute weights — they only remove hosts — so they are deliberately not part of the condition.

Covered by TestPipeline_Run_NoWeighers_PreservesInputOrdering, which runs the empty pipeline 50 times against weights {host1: 50, host2: 55, host3: 60} and asserts the descending order [host3, host2, host1] holds every iteration; without the fix this test fails intermittently due to map iteration order.

Assisted-by: Claude Code:claude-opus-4-5 [Bash] [Read]
