### PR TITLE
fix(renovate): pin python to 3.13 and harden config rules

### DIFF
--- a/.github/actions/setup-claude-code-action/action.yml
+++ b/.github/actions/setup-claude-code-action/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.14"
+        python-version: "3.13"
 
     - name: Install LiteLLM dependencies
       shell: bash

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -131,6 +131,10 @@
     {
       "matchFileNames": [".github/actions/setup-claude-code-action/action.yml"],
       "automerge": false
+    },
+    {
+      "matchFileNames": [".github/renovate.json"],
+      "automerge": false
     }
   ],
   "prHourlyLimit": 0,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
   "commitMessageAction": "Renovate: Update",
   "constraints": {
     "go": "1.26",
-    "python": "3.14"
+    "python": "3.13"
   },
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "osvVulnerabilityAlerts": true,
@@ -62,10 +62,6 @@
     }
   ],
   "packageRules": [
-    {
-      "matchManagers": ["tool-constraint"],
-      "enabled": false
-    },
     {
       "matchPackageNames": [
         "golang"
@@ -125,13 +121,16 @@
       "enabled": false
     },
     {
-      "matchPackageNames": [
-        "python"
-      ],
-      "matchFileNames": [
-        ".github/actions/setup-claude-code-action/**"
-      ],
+      "matchDepTypes": ["tool-constraint"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["python"],
+      "allowedVersions": "3.13.x"
+    },
+    {
+      "matchFileNames": [".github/actions/setup-claude-code-action/action.yml"],
+      "automerge": false
     }
   ],
   "prHourlyLimit": 0,


### PR DESCRIPTION
- Revert python-version to 3.13 in setup-claude-code-action/action.yml for compatibility with upstream anthropics/claude-code-action.
- Revert constraints.python to 3.13 in renovate.json.
- Replace broken 'matchManagers: [tool-constraint]' rule (which never matched anything; tool-constraint is a depType, not a manager id) with 'matchDepTypes: [tool-constraint], enabled: false'. This is the actual root cause that allowed renovate to bump constraints.python from 3.13 to 3.14 in #908.
- Add 'matchPackageNames: [python], allowedVersions: 3.13.x' as a hard version cap.
- Add file-scoped 'automerge: false' rule for .github/actions/setup-claude-code-action/action.yml as a tripwire so any future bump in this file requires manual review.

Rules are placed after the 'External dependencies' catch-all so that later-rule-wins semantics override the catch-all's automerge: true.