### PR TITLE
fix: update python dependency rule (again)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -135,13 +135,10 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["python"],
-      "allowedVersions": "3.13.x"
-    },
-    {
       "matchManagers": ["github-actions"],
-      "matchPackageNames": ["actions/setup-python"],
-      "allowedVersions": "3.13.x"
+      "matchDepNames": ["python"],
+      "separateMultipleMinor": true,
+      "dependencyDashboardApproval": true
     },
     {
       "matchFileNames": [".github/actions/setup-claude-code-action/action.yml"],


### PR DESCRIPTION
See: https://github.com/renovatebot/renovate/discussions/35309

This should not open PRs anymore. Instead it should create an AI in the dependency dashboard that can manually be triggered to update the python version if we want to.