### PR TITLE
fix(reservations): use correct namespace for domain resolver keystone…

### DIFF
--- a/helm/bundles/cortex-nova/values.yaml
+++ b/helm/bundles/cortex-nova/values.yaml
@@ -185,9 +185,6 @@ cortex-scheduling-controllers:
       keystoneSecretRef:
         name: cortex-nova-openstack-keystone
         namespace: cortex-nova
-      # ssoSecretRef:
-      #   name: cortex-nova-openstack-sso
-      #   namespace: cortex-nova
     committedResourceController:
       # Back-off interval while CommittedResource placement is pending or failed (base for exponential backoff)
       requeueIntervalRetry: "1m"

--- a/helm/bundles/cortex-nova/values.yaml
+++ b/helm/bundles/cortex-nova/values.yaml
@@ -184,10 +184,10 @@ cortex-scheduling-controllers:
       # Must match the credentials used by the commitments syncer.
       keystoneSecretRef:
         name: cortex-nova-openstack-keystone
-        namespace: default
+        namespace: cortex-nova
       # ssoSecretRef:
       #   name: cortex-nova-openstack-sso
-      #   namespace: default
+      #   namespace: cortex-nova
     committedResourceController:
       # Back-off interval while CommittedResource placement is pending or failed (base for exponential backoff)
       requeueIntervalRetry: "1m"


### PR DESCRIPTION
…SecretRef

The secret lives in cortex-nova, not default.