### PR TITLE
fix(knowledge): use public Limes endpoint in datasource to avoid domain name enforcement 400s

### DIFF
--- a/internal/knowledge/datasources/plugins/openstack/limes/limes_api.go
+++ b/internal/knowledge/datasources/plugins/openstack/limes/limes_api.go
@@ -55,8 +55,9 @@ func (api *limesAPI) Init(ctx context.Context) error {
 	// See: https://github.com/sapcc/limes/blob/5ea068b/docs/users/api-example.md?plain=1#L23
 	provider := api.keystoneClient.Client()
 	serviceType := "resources"
-	sameAsKeystone := api.keystoneClient.Availability()
-	url, err := api.keystoneClient.FindEndpoint(sameAsKeystone, serviceType)
+	// Always use the public endpoint: Limes enforces that requests arrive on its configured public
+	// hostname (LIMES_API_DOMAIN_NAME_V1) and rejects internal-URL requests with 400.
+	url, err := api.keystoneClient.FindEndpoint("public", serviceType)
 	if err != nil {
 		return err
 	}

--- a/internal/knowledge/datasources/plugins/openstack/limes/limes_api_test.go
+++ b/internal/knowledge/datasources/plugins/openstack/limes/limes_api_test.go
@@ -20,6 +20,29 @@ func setupLimesMockServer(handler http.HandlerFunc) (*httptest.Server, keystone.
 	return server, &testlibKeystone.MockKeystoneClient{Url: server.URL + "/"}
 }
 
+func TestLimesAPI_Init_UsesPublicEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+
+	var gotAvailability string
+	k := &testlibKeystone.MockKeystoneClient{
+		Url: server.URL + "/",
+		FindEndpointOverride: func(availability, serviceType string) {
+			if serviceType == "resources" {
+				gotAvailability = availability
+			}
+		},
+	}
+
+	api := NewLimesAPI(datasources.Monitor{}, k, v1alpha1.LimesDatasource{}).(*limesAPI)
+	if err := api.Init(t.Context()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAvailability != "public" {
+		t.Errorf("expected public availability for Limes endpoint, got %q", gotAvailability)
+	}
+}
+
 func TestNewLimesAPI(t *testing.T) {
 	mon := datasources.Monitor{}
 	k := &testlibKeystone.MockKeystoneClient{}

--- a/internal/scheduling/reservations/commitments/client.go
+++ b/internal/scheduling/reservations/commitments/client.go
@@ -89,7 +89,8 @@ func (c *commitmentsClient) Init(ctx context.Context, client client.Client, conf
 		Microversion:   "2.61",
 	}
 
-	// Get the limes endpoint.
+	// Get the limes endpoint — always use public: Limes enforces that requests arrive on its
+	// configured public hostname (LIMES_API_DOMAIN_NAME_V1) and rejects internal-URL requests with 400.
 	url = must.Return(c.provider.EndpointLocator(gophercloud.EndpointOpts{
 		Type:         "resources",
 		Availability: "public",

--- a/pkg/keystone/testing/mock.go
+++ b/pkg/keystone/testing/mock.go
@@ -10,8 +10,9 @@ import (
 )
 
 type MockKeystoneClient struct {
-	Url             string
-	EndpointLocator gophercloud.EndpointLocator
+	Url                  string
+	EndpointLocator      gophercloud.EndpointLocator
+	FindEndpointOverride func(availability, serviceType string)
 }
 
 func (m *MockKeystoneClient) Authenticate(ctx context.Context) error {
@@ -25,6 +26,9 @@ func (m *MockKeystoneClient) Client() *gophercloud.ProviderClient {
 }
 
 func (m *MockKeystoneClient) FindEndpoint(availability, serviceType string) (string, error) {
+	if m.FindEndpointOverride != nil {
+		m.FindEndpointOverride(availability, serviceType)
+	}
 	return m.Url, nil
 }
 


### PR DESCRIPTION
- After Limes rolled out domain name enforcement (sapcc/limes#909), requests with a non-matching `Host` header are rejected with HTTP 400
- Fixed by hardcoding `public` availability for the Limes endpoint lookup in `limes_api.go`, consistent with what the commitment syncer already does