### PR TITLE
feat: enhance multicluster client 'no cluster matched' error log messages

### DIFF
--- a/pkg/multicluster/client.go
+++ b/pkg/multicluster/client.go
@@ -245,8 +245,15 @@ func (c *Client) clusterForWrite(gvk schema.GroupVersionKind, obj any) (cluster.
 				return r.cluster, nil
 			}
 		}
-		// No match — collect route key and candidate labels for the error.
-		selector, _ := router.extractClusterSelector(obj)
+		// No remote match — fall back to home if the GVK is also configured there.
+		if c.homeGVKs[gvk] {
+			return c.HomeCluster, nil
+		}
+		// No match and no home fallback — return an error.
+		selector, err := router.extractClusterSelector(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract cluster selector for GVK %s: %w", gvk, err)
+		}
 		return nil, &NoClusterMatchedError{GVK: gvk, ClusterSelector: selector}
 	}
 

--- a/pkg/multicluster/client.go
+++ b/pkg/multicluster/client.go
@@ -246,8 +246,8 @@ func (c *Client) clusterForWrite(gvk schema.GroupVersionKind, obj any) (cluster.
 			}
 		}
 		// No match — collect route key and candidate labels for the error.
-		routeKey, _ := router.extractClusterSelector(obj)
-		return nil, &NoClusterMatchedError{GVK: gvk, RouteKey: routeKey}
+		selector, _ := router.extractClusterSelector(obj)
+		return nil, &NoClusterMatchedError{GVK: gvk, ClusterSelector: selector}
 	}
 
 	// No remotes configured for this GVK — fall back to home if available.
@@ -275,13 +275,12 @@ func IsDuplicateError(err error) bool {
 // happens in multi-AZ setups where the resource targets an AZ that has no
 // configured cluster.
 type NoClusterMatchedError struct {
-	GVK        schema.GroupVersionKind
-	RouteKey   string
-	Candidates []string
+	GVK             schema.GroupVersionKind
+	ClusterSelector string
 }
 
 func (e *NoClusterMatchedError) Error() string {
-	return fmt.Sprintf("no cluster matched for GVK %s: route key %q did not match any candidate %v", e.GVK, e.RouteKey, e.Candidates)
+	return fmt.Sprintf("no cluster matched for GVK %s: cluster selector %q did not match any candidate", e.GVK, e.ClusterSelector)
 }
 
 // IsNoClusterMatchedError returns true if the error indicates that no

--- a/pkg/multicluster/client.go
+++ b/pkg/multicluster/client.go
@@ -245,9 +245,12 @@ func (c *Client) clusterForWrite(gvk schema.GroupVersionKind, obj any) (cluster.
 				return r.cluster, nil
 			}
 		}
+		// No match — collect route key and candidate labels for the error.
+		routeKey, _ := router.extractClusterSelector(obj)
+		return nil, &NoClusterMatchedError{GVK: gvk, RouteKey: routeKey}
 	}
 
-	// If we couldn't find a matching remote cluster (not configured or not found) but the GVK is configured for home, return the home cluster.
+	// No remotes configured for this GVK — fall back to home if available.
 	if c.homeGVKs[gvk] {
 		return c.HomeCluster, nil
 	}
@@ -272,11 +275,13 @@ func IsDuplicateError(err error) bool {
 // happens in multi-AZ setups where the resource targets an AZ that has no
 // configured cluster.
 type NoClusterMatchedError struct {
-	GVK schema.GroupVersionKind
+	GVK        schema.GroupVersionKind
+	RouteKey   string
+	Candidates []string
 }
 
 func (e *NoClusterMatchedError) Error() string {
-	return fmt.Sprintf("no cluster matched for GVK %s", e.GVK)
+	return fmt.Sprintf("no cluster matched for GVK %s: route key %q did not match any candidate %v", e.GVK, e.RouteKey, e.Candidates)
 }
 
 // IsNoClusterMatchedError returns true if the error indicates that no

--- a/pkg/multicluster/client_test.go
+++ b/pkg/multicluster/client_test.go
@@ -132,6 +132,26 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 // testRouter is a simple ResourceRouter for testing.
 type testRouter struct{}
 
+func (r testRouter) Match(obj any, labels map[string]string) (bool, error) {
+	az, ok := labels["az"]
+	if !ok {
+		return false, nil
+	}
+	objAZ, err := r.extractClusterSelector(obj)
+	if err != nil {
+		return false, err
+	}
+	return objAZ == az, nil
+}
+
+func (r testRouter) extractClusterSelector(obj any) (string, error) {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		return "", errors.New("object is not a ConfigMap")
+	}
+	return cm.Labels["az"], nil
+}
+
 // alwaysMatchRouter matches any object to any cluster.
 type alwaysMatchRouter struct{}
 
@@ -139,20 +159,8 @@ func (r alwaysMatchRouter) Match(any, map[string]string) (bool, error) {
 	return true, nil
 }
 
-func (r testRouter) Match(obj any, labels map[string]string) (bool, error) {
-	cm, ok := obj.(*corev1.ConfigMap)
-	if !ok {
-		return false, nil
-	}
-	az, ok := labels["az"]
-	if !ok {
-		return false, nil
-	}
-	objAZ, ok := cm.Labels["az"]
-	if !ok {
-		return false, nil
-	}
-	return objAZ == az, nil
+func (r alwaysMatchRouter) extractClusterSelector(obj any) (string, error) {
+	return "", nil
 }
 
 var configMapGVK = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}

--- a/pkg/multicluster/routers.go
+++ b/pkg/multicluster/routers.go
@@ -28,10 +28,35 @@ var DefaultResourceRouters = map[schema.GroupVersionKind]ResourceRouter{
 // by matching the resource content against the cluster's labels.
 type ResourceRouter interface {
 	Match(obj any, labels map[string]string) (bool, error)
+	// extractClusterSelector extracts the routing key from the object (e.g. availability zone).
+	// Used to enrich error messages when no cluster matches.
+	extractClusterSelector(obj any) (string, error)
 }
 
 // HypervisorResourceRouter routes hypervisors to clusters based on availability zone.
 type HypervisorResourceRouter struct{}
+
+func (h HypervisorResourceRouter) extractClusterSelector(obj any) (string, error) {
+	switch v := obj.(type) {
+	case *hv1.Hypervisor:
+		if v == nil {
+			return "", errors.New("object is nil")
+		}
+		az, ok := v.Labels[corev1.LabelTopologyZone]
+		if !ok {
+			return "", errors.New("hypervisor does not have availability zone label")
+		}
+		return az, nil
+	case hv1.Hypervisor:
+		az, ok := v.Labels[corev1.LabelTopologyZone]
+		if !ok {
+			return "", errors.New("hypervisor does not have availability zone label")
+		}
+		return az, nil
+	default:
+		return "", errors.New("object is not a Hypervisor")
+	}
+}
 
 func (h HypervisorResourceRouter) Match(obj any, labels map[string]string) (bool, error) {
 	var hv hv1.Hypervisor
@@ -61,6 +86,26 @@ func (h HypervisorResourceRouter) Match(obj any, labels map[string]string) (bool
 // ReservationsResourceRouter routes reservations to clusters based on availability zone.
 type ReservationsResourceRouter struct{}
 
+func (r ReservationsResourceRouter) extractClusterSelector(obj any) (string, error) {
+	switch v := obj.(type) {
+	case *v1alpha1.Reservation:
+		if v == nil {
+			return "", errors.New("object is nil")
+		}
+		if v.Spec.AvailabilityZone == "" {
+			return "", errors.New("reservation does not have availability zone in spec")
+		}
+		return v.Spec.AvailabilityZone, nil
+	case v1alpha1.Reservation:
+		if v.Spec.AvailabilityZone == "" {
+			return "", errors.New("reservation does not have availability zone in spec")
+		}
+		return v.Spec.AvailabilityZone, nil
+	default:
+		return "", errors.New("object is not a Reservation")
+	}
+}
+
 func (r ReservationsResourceRouter) Match(obj any, labels map[string]string) (bool, error) {
 	var res v1alpha1.Reservation
 
@@ -89,6 +134,26 @@ func (r ReservationsResourceRouter) Match(obj any, labels map[string]string) (bo
 // CommittedResourceRouter routes committed resources to clusters based on availability zone.
 type CommittedResourceRouter struct{}
 
+func (c CommittedResourceRouter) extractClusterSelector(obj any) (string, error) {
+	switch v := obj.(type) {
+	case *v1alpha1.CommittedResource:
+		if v == nil {
+			return "", errors.New("object is nil")
+		}
+		if v.Spec.AvailabilityZone == "" {
+			return "", errors.New("committed resource does not have availability zone in spec")
+		}
+		return v.Spec.AvailabilityZone, nil
+	case v1alpha1.CommittedResource:
+		if v.Spec.AvailabilityZone == "" {
+			return "", errors.New("committed resource does not have availability zone in spec")
+		}
+		return v.Spec.AvailabilityZone, nil
+	default:
+		return "", errors.New("object is not a CommittedResource")
+	}
+}
+
 func (c CommittedResourceRouter) Match(obj any, labels map[string]string) (bool, error) {
 	var cr v1alpha1.CommittedResource
 
@@ -115,6 +180,26 @@ func (c CommittedResourceRouter) Match(obj any, labels map[string]string) (bool,
 
 // FlavorGroupCapacityResourceRouter routes flavor group capacity CRDs to clusters based on availability zone.
 type FlavorGroupCapacityResourceRouter struct{}
+
+func (f FlavorGroupCapacityResourceRouter) extractClusterSelector(obj any) (string, error) {
+	switch v := obj.(type) {
+	case *v1alpha1.FlavorGroupCapacity:
+		if v == nil {
+			return "", errors.New("object is nil")
+		}
+		if v.Spec.AvailabilityZone == "" {
+			return "", errors.New("flavor group capacity does not have availability zone in spec")
+		}
+		return v.Spec.AvailabilityZone, nil
+	case v1alpha1.FlavorGroupCapacity:
+		if v.Spec.AvailabilityZone == "" {
+			return "", errors.New("flavor group capacity does not have availability zone in spec")
+		}
+		return v.Spec.AvailabilityZone, nil
+	default:
+		return "", errors.New("object is not a FlavorGroupCapacity")
+	}
+}
 
 func (f FlavorGroupCapacityResourceRouter) Match(obj any, labels map[string]string) (bool, error) {
 	var fgc v1alpha1.FlavorGroupCapacity
@@ -143,6 +228,26 @@ func (f FlavorGroupCapacityResourceRouter) Match(obj any, labels map[string]stri
 // HistoryResourceRouter routes histories to clusters based on availability zone.
 type HistoryResourceRouter struct{}
 
+func (h HistoryResourceRouter) extractClusterSelector(obj any) (string, error) {
+	switch v := obj.(type) {
+	case *v1alpha1.History:
+		if v == nil {
+			return "", errors.New("object is nil")
+		}
+		if v.Spec.AvailabilityZone == nil || *v.Spec.AvailabilityZone == "" {
+			return "", errors.New("history does not have availability zone in spec")
+		}
+		return *v.Spec.AvailabilityZone, nil
+	case v1alpha1.History:
+		if v.Spec.AvailabilityZone == nil || *v.Spec.AvailabilityZone == "" {
+			return "", errors.New("history does not have availability zone in spec")
+		}
+		return *v.Spec.AvailabilityZone, nil
+	default:
+		return "", errors.New("object is not a History")
+	}
+}
+
 func (h HistoryResourceRouter) Match(obj any, labels map[string]string) (bool, error) {
 	var hist v1alpha1.History
 
@@ -169,6 +274,26 @@ func (h HistoryResourceRouter) Match(obj any, labels map[string]string) (bool, e
 
 // ProjectQuotaResourceRouter routes project quotas to clusters based on availability zone.
 type ProjectQuotaResourceRouter struct{}
+
+func (p ProjectQuotaResourceRouter) extractClusterSelector(obj any) (string, error) {
+	switch v := obj.(type) {
+	case *v1alpha1.ProjectQuota:
+		if v == nil {
+			return "", errors.New("object is nil")
+		}
+		if v.Spec.AvailabilityZone == "" {
+			return "", errors.New("project quota does not have availability zone in spec")
+		}
+		return v.Spec.AvailabilityZone, nil
+	case v1alpha1.ProjectQuota:
+		if v.Spec.AvailabilityZone == "" {
+			return "", errors.New("project quota does not have availability zone in spec")
+		}
+		return v.Spec.AvailabilityZone, nil
+	default:
+		return "", errors.New("object is not a ProjectQuota")
+	}
+}
 
 func (p ProjectQuotaResourceRouter) Match(obj any, labels map[string]string) (bool, error) {
 	var pq v1alpha1.ProjectQuota


### PR DESCRIPTION
- Add `extractClusterSelector` method to routers that get the attribute to match on based on the provided object
- Use this method for the error log message


```txt
# Before
no cluster matched for GVK cortex.cloud/v1alpha1, Kind=History

# Now
no cluster matched for GVK cortex.cloud/v1alpha1, Kind=History: cluster selector `qa-ber-1` did not match any candidate 
```