### PR TITLE
feat:  add configurable HTTP User-Agent for service identity

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -67,6 +67,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
 	"github.com/cobaltcore-dev/cortex/pkg/monitoring"
 	"github.com/cobaltcore-dev/cortex/pkg/multicluster"
+	"github.com/cobaltcore-dev/cortex/pkg/sso"
 	"github.com/cobaltcore-dev/cortex/pkg/task"
 	hv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
 	"github.com/sapcc/go-bits/httpext"
@@ -90,6 +91,15 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+// UserAgentConfig identifies this cortex deployment to the services it talks
+// to. Rendered by helm from the release name and chart version.
+type UserAgentConfig struct {
+	// Component is the service name, e.g. "cortex-nova".
+	Component string `json:"component,omitempty"`
+	// Version is the deployed version, e.g. "sha-70af93a8".
+	Version string `json:"version,omitempty"`
+}
+
 type MainConfig struct {
 	// ID used to identify leader election participants.
 	LeaderElectionID string `json:"leaderElectionID,omitempty"`
@@ -97,6 +107,8 @@ type MainConfig struct {
 	EnabledControllers []string `json:"enabledControllers"`
 	// List of enabled tasks.
 	EnabledTasks []string `json:"enabledTasks"`
+	// User-Agent sent with all outgoing HTTP requests.
+	UserAgent UserAgentConfig `json:"userAgent,omitempty"`
 }
 
 //nolint:gocyclo
@@ -104,6 +116,15 @@ func main() {
 	ctx := context.Background()
 	mainConfig := conf.GetConfigOrDie[MainConfig]()
 	restConfig := ctrl.GetConfigOrDie()
+
+	// Identify this cortex deployment to the services it talks to via the
+	// User-Agent header, before any HTTP requests are made. The shared
+	// http.DefaultTransport covers http.DefaultClient and any http.Client
+	// without its own transport; SSO clients build their own transport and
+	// are handled separately by pkg/sso.
+	httpext.WrapTransport(&http.DefaultTransport).
+		SetOverrideUserAgent(mainConfig.UserAgent.Component, mainConfig.UserAgent.Version)
+	sso.SetUserAgent(mainConfig.UserAgent.Component, mainConfig.UserAgent.Version)
 
 	// Custom entrypoint for scheduler e2e tests.
 	// Usage: /main <subcommand> [json-override]

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
 	"github.com/cobaltcore-dev/cortex/pkg/monitoring"
 	"github.com/cobaltcore-dev/cortex/pkg/multicluster"
+	"github.com/cobaltcore-dev/cortex/pkg/sso"
 	hv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
 	"github.com/sapcc/go-bits/httpext"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,10 +51,34 @@ func init() {
 	utilruntime.Must(hv1.AddToScheme(scheme))      // Hypervisor crd
 }
 
+// UserAgentConfig identifies this cortex deployment to the services it talks
+// to. Rendered by helm from the release name and chart version.
+type UserAgentConfig struct {
+	// Component is the service name, e.g. "cortex-nova".
+	Component string `json:"component,omitempty"`
+	// Version is the deployed version, e.g. "sha-70af93a8".
+	Version string `json:"version,omitempty"`
+}
+
+type MainConfig struct {
+	// User-Agent sent with all outgoing HTTP requests.
+	UserAgent UserAgentConfig `json:"userAgent,omitempty"`
+}
+
 func main() {
 	ctx := ctrl.SetupSignalHandler()
 
+	mainConfig := conf.GetConfigOrDie[MainConfig]()
 	restConfig := ctrl.GetConfigOrDie()
+
+	// Identify this cortex deployment to the services it talks to via the
+	// User-Agent header, before any HTTP requests are made. The shared
+	// http.DefaultTransport covers http.DefaultClient and any http.Client
+	// without its own transport; SSO clients build their own transport and
+	// are handled separately by pkg/sso.
+	httpext.WrapTransport(&http.DefaultTransport).
+		SetOverrideUserAgent(mainConfig.UserAgent.Component, mainConfig.UserAgent.Version)
+	sso.SetUserAgent(mainConfig.UserAgent.Component, mainConfig.UserAgent.Version)
 
 	var metricsAddr string
 	var apiBindAddr string

--- a/helm/library/cortex/templates/manager/manager.yaml
+++ b/helm/library/cortex/templates/manager/manager.yaml
@@ -133,6 +133,14 @@ data:
     {{- if .Values.conf }}
     {{- $mergedConf = mergeOverwrite .Values.conf $mergedConf }}
     {{- end }}
+    {{- /* Default the outgoing HTTP User-Agent so every deployment is        */ -}}
+    {{- /* identifiable by the services it talks to: component from the        */ -}}
+    {{- /* release name, version from the chart appVersion (the image tag).    */ -}}
+    {{- $userAgent := dict "component" .Release.Name "version" .Chart.AppVersion }}
+    {{- if hasKey $mergedConf "userAgent" }}
+    {{- $userAgent = mergeOverwrite $userAgent $mergedConf.userAgent }}
+    {{- end }}
+    {{- $_ := set $mergedConf "userAgent" $userAgent }}
     {{ toJson $mergedConf }}
 ---
 apiVersion: v1

--- a/helm/library/cortex/values.yaml
+++ b/helm/library/cortex/values.yaml
@@ -109,6 +109,13 @@ conf:
   schedulingDomain: cortex
   # Used to differentiate different cortex deployments in the same cluster (e.g. leader election ID)
   leaderElectionID: cortex-unknown
+  # User-Agent sent with all outgoing HTTP requests, identifying this cortex
+  # deployment to the services it talks to. When unset, it defaults to the
+  # release name and chart appVersion (e.g. component "cortex-nova",
+  # version "sha-70af93a8"), producing "cortex-nova/sha-70af93a8".
+  # userAgent:
+  #   component: cortex-nova
+  #   version: v1.2.3
   enabledControllers:
     # The explanation controller is available for all decision resources.
     - explanation-controller

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sapcc/go-bits/httpext"
 	"k8s.io/apimachinery/pkg/api/resource"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -178,20 +177,8 @@ type resourceClassesConfig struct {
 	ConfigMapName string `json:"configMapName"`
 }
 
-// userAgentConfig identifies this cortex deployment to the services it talks
-// to. Rendered by helm from the release name and chart version.
-type userAgentConfig struct {
-	// Component is the service name, e.g. "cortex-nova".
-	Component string `json:"component,omitempty"`
-	// Version is the deployed version, e.g. "sha-70af93a8".
-	Version string `json:"version,omitempty"`
-}
-
 // config holds configuration for the placement shim.
 type config struct {
-	// UserAgent sent with all outgoing HTTP requests, identifying this cortex
-	// deployment to the services it talks to.
-	UserAgent userAgentConfig `json:"userAgent,omitempty"`
 	// SSO is an optional configuration for the certificates the http client
 	// should use when talking to the placement API over ingress with single-sign-on.
 	SSO *sso.SSOConfig `json:"sso,omitempty"`
@@ -545,14 +532,6 @@ func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err erro
 	if err := s.config.validate(); err != nil {
 		return err
 	}
-
-	// Identify this cortex deployment to the services it talks to via the
-	// User-Agent header, before any HTTP requests are made. The shared
-	// http.DefaultTransport is covered here; the shim's own placement
-	// transport is wrapped separately via sso.WrapUserAgent below.
-	httpext.WrapTransport(&http.DefaultTransport).
-		SetOverrideUserAgent(s.config.UserAgent.Component, s.config.UserAgent.Version)
-	sso.SetUserAgent(s.config.UserAgent.Component, s.config.UserAgent.Version)
 
 	// Parse the body log size limit from config (default 4Ki).
 	bodyLogQty := s.config.MaxBodyLogSize

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sapcc/go-bits/httpext"
 	"k8s.io/apimachinery/pkg/api/resource"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -177,8 +178,20 @@ type resourceClassesConfig struct {
 	ConfigMapName string `json:"configMapName"`
 }
 
+// userAgentConfig identifies this cortex deployment to the services it talks
+// to. Rendered by helm from the release name and chart version.
+type userAgentConfig struct {
+	// Component is the service name, e.g. "cortex-nova".
+	Component string `json:"component,omitempty"`
+	// Version is the deployed version, e.g. "sha-70af93a8".
+	Version string `json:"version,omitempty"`
+}
+
 // config holds configuration for the placement shim.
 type config struct {
+	// UserAgent sent with all outgoing HTTP requests, identifying this cortex
+	// deployment to the services it talks to.
+	UserAgent userAgentConfig `json:"userAgent,omitempty"`
 	// SSO is an optional configuration for the certificates the http client
 	// should use when talking to the placement API over ingress with single-sign-on.
 	SSO *sso.SSOConfig `json:"sso,omitempty"`
@@ -379,7 +392,7 @@ func (s *Shim) initHTTPClient(ctx context.Context) error {
 	transport.ResponseHeaderTimeout = 60 * time.Second
 	transport.ExpectContinueTimeout = 1 * time.Second
 	transport.IdleConnTimeout = 90 * time.Second
-	s.httpClient = &http.Client{Transport: transport, Timeout: 60 * time.Second}
+	s.httpClient = &http.Client{Transport: sso.WrapUserAgent(transport), Timeout: 60 * time.Second}
 
 	setupLog.Info("Testing connection to placement API", "url", s.config.PlacementURL)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.config.PlacementURL, http.NoBody)
@@ -532,6 +545,14 @@ func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err erro
 	if err := s.config.validate(); err != nil {
 		return err
 	}
+
+	// Identify this cortex deployment to the services it talks to via the
+	// User-Agent header, before any HTTP requests are made. The shared
+	// http.DefaultTransport is covered here; the shim's own placement
+	// transport is wrapped separately via sso.WrapUserAgent below.
+	httpext.WrapTransport(&http.DefaultTransport).
+		SetOverrideUserAgent(s.config.UserAgent.Component, s.config.UserAgent.Version)
+	sso.SetUserAgent(s.config.UserAgent.Component, s.config.UserAgent.Version)
 
 	// Parse the body log size limit from config (default 4Ki).
 	bodyLogQty := s.config.MaxBodyLogSize

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -16,6 +16,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// userAgent is the User-Agent value set on every outgoing HTTP request made
+// through clients created by this package, identifying cortex as the caller.
+// It defaults to "cortex" and can be overridden once at process startup via
+// SetUserAgent (e.g. "cortex-nova/sha-70af93a8").
+var userAgent = "cortex"
+
+// SetUserAgent sets the User-Agent that this package's HTTP clients send. The
+// component and version are combined as "component/version"; if version is
+// empty, only the component is used. An empty component leaves the default
+// ("cortex") unchanged.
+func SetUserAgent(component, version string) {
+	if component == "" {
+		return
+	}
+	if version == "" {
+		userAgent = component
+		return
+	}
+	userAgent = component + "/" + version
+}
+
 // Configuration for single-sign-on (SSO).
 type SSOConfig struct {
 	Cert    string `json:"cert,omitempty"`
@@ -34,6 +55,28 @@ type requestLogger struct {
 func (lrt *requestLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	slog.Info("making http request", "url", req.URL.String())
 	return lrt.T.RoundTrip(req)
+}
+
+// Custom HTTP round tripper that sets the cortex User-Agent on every request,
+// identifying cortex as the caller. SSO clients build their own transport and
+// therefore need this, as they don't share http.DefaultTransport.
+type userAgentTransport struct {
+	T http.RoundTripper
+}
+
+// RoundTrip sets the User-Agent header to the cortex user agent. The request
+// is cloned so the caller's request is not mutated.
+func (uat *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("User-Agent", userAgent)
+	return uat.T.RoundTrip(req)
+}
+
+// WrapUserAgent wraps the given RoundTripper so that every request carries the
+// cortex User-Agent header. Use it for hand-built transports that neither go
+// through NewHTTPClient nor the shared http.DefaultTransport.
+func WrapUserAgent(rt http.RoundTripper) http.RoundTripper {
+	return &userAgentTransport{T: rt}
 }
 
 // Kubernetes connector which initializes the sso connection from a secret.
@@ -110,5 +153,5 @@ func NewHTTPClient(conf SSOConfig) (*http.Client, error) {
 	if conf.Cert == "" {
 		slog.Debug("making http requests without SSO")
 	}
-	return &http.Client{Transport: &requestLogger{T: transport}}, nil
+	return &http.Client{Transport: &userAgentTransport{T: &requestLogger{T: transport}}}, nil
 }

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -8,6 +8,73 @@ import (
 	"testing"
 )
 
+// captureTransport records the last request it saw and returns a canned response.
+type captureTransport struct{ last *http.Request }
+
+func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.last = req
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+}
+
+func TestSetUserAgent(t *testing.T) {
+	old := userAgent
+	defer func() { userAgent = old }()
+
+	tests := []struct {
+		name      string
+		component string
+		version   string
+		want      string
+	}{
+		{name: "ComponentAndVersion", component: "cortex-nova", version: "sha-abc", want: "cortex-nova/sha-abc"},
+		{name: "ComponentOnly", component: "cortex-nova", version: "", want: "cortex-nova"},
+		{name: "EmptyComponentKeepsDefault", component: "", version: "sha-abc", want: "cortex"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userAgent = "cortex"
+			SetUserAgent(tt.component, tt.version)
+			if userAgent != tt.want {
+				t.Errorf("userAgent = %q, want %q", userAgent, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserAgentTransport(t *testing.T) {
+	old := userAgent
+	userAgent = "cortex-nova/test"
+	defer func() { userAgent = old }()
+
+	tests := []struct {
+		name       string
+		incomingUA string
+	}{
+		{name: "NoExistingUA", incomingUA: ""},
+		{name: "OverridesExistingUA", incomingUA: "gophercloud/2.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capture := &captureTransport{}
+			uat := &userAgentTransport{T: capture}
+			req, _ := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			if tt.incomingUA != "" {
+				req.Header.Set("User-Agent", tt.incomingUA)
+			}
+			if _, err := uat.RoundTrip(req); err != nil {
+				t.Fatalf("RoundTrip() error = %v", err)
+			}
+			if got := capture.last.Header.Get("User-Agent"); got != "cortex-nova/test" {
+				t.Errorf("User-Agent = %q, want %q", got, "cortex-nova/test")
+			}
+			// The original request must not be mutated.
+			if got := req.Header.Get("User-Agent"); got != tt.incomingUA {
+				t.Errorf("original request User-Agent mutated: got %q, want %q", got, tt.incomingUA)
+			}
+		})
+	}
+}
+
 func TestNewHTTPClient(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -154,14 +221,19 @@ nyCru8FaKdd+A5MBMSTb8MX0LcnWvdQ=
 		t.Fatalf("NewHTTPClient() error = %v, want no error", err)
 	}
 
-	transport, ok := client.Transport.(*requestLogger)
+	transport, ok := client.Transport.(*userAgentTransport)
 	if !ok {
-		t.Fatalf("Expected transport to be of type *requestLogger, got %T", client.Transport)
+		t.Fatalf("Expected transport to be of type *userAgentTransport, got %T", client.Transport)
 	}
 
-	httpTransport, ok := transport.T.(*http.Transport)
+	logger, ok := transport.T.(*requestLogger)
 	if !ok {
-		t.Fatalf("Expected inner transport to be of type *http.Transport, got %T", transport.T)
+		t.Fatalf("Expected transport to be of type *requestLogger, got %T", transport.T)
+	}
+
+	httpTransport, ok := logger.T.(*http.Transport)
+	if !ok {
+		t.Fatalf("Expected inner transport to be of type *http.Transport, got %T", logger.T)
 	}
 
 	if httpTransport.TLSClientConfig == nil {

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -57,7 +57,10 @@ func TestUserAgentTransport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			capture := &captureTransport{}
 			uat := &userAgentTransport{T: capture}
-			req, _ := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			req, err := http.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
+			if err != nil {
+				t.Fatalf("NewRequest() error = %v", err)
+			}
 			if tt.incomingUA != "" {
 				req.Header.Set("User-Agent", tt.incomingUA)
 			}


### PR DESCRIPTION
Cortex previously made outgoing HTTP requests without identifying itself, so receiving services couldn't tell who was calling them. This PR adds a unified, configurable User-Agent (e.g. `cortex-nova/sha-70af93a8`) to all outgoing requests, set per deployment via values.yaml.

The tricky part is that cortex has two kinds of HTTP clients. Most requests go through the shared http.DefaultTransport (via http.DefaultClient or plain &http.Client{}), which we cover in one shot at startup with `httpext.WrapTransport(&http.DefaultTransport).SetOverrideUserAgent(...)` (from `sapcc/go-bits`). The SSO clients however, build their own transport and therefore don't share the default one — so they need a separate mechanism. For those, pkg/sso sets the header on its own transport via sso.SetUserAgent(...), with sso.WrapUserAgent(rt) for hand-built transports.

The User-Agent is configured as two fields (component + version) rather than a single string, so they map cleanly onto the component/version format of the go-bits lib without any join-then-split. The Helm library chart defaults them to the release name and chart appVersion (the deployed image tag), and bundles can override as needed.