### PR TITLE
fix: persist pipeline results before history upsert

### DIFF
--- a/internal/scheduling/cinder/filter_weigher_pipeline_controller.go
+++ b/internal/scheduling/cinder/filter_weigher_pipeline_controller.go
@@ -112,6 +112,12 @@ func (c *FilterWeigherPipelineController) process(ctx context.Context, decision 
 	}
 
 	result, err := pipeline.Run(request)
+	// Persist the result on the decision before upserting history so that
+	// CreateOrUpdateHistory can observe the target host and ordered hosts.
+	// On error the result is empty/meaningless, so only set it on success.
+	if err == nil {
+		decision.Status.Result = &result
+	}
 	if !request.Options.SkipHistory {
 		if upsertErr := c.HistoryManager.CreateOrUpdateHistory(ctx, decision, nil, err); upsertErr != nil {
 			log.Error(upsertErr, "failed to create/update history")
@@ -121,7 +127,6 @@ func (c *FilterWeigherPipelineController) process(ctx context.Context, decision 
 		log.Error(err, "failed to run pipeline")
 		return err
 	}
-	decision.Status.Result = &result
 	log.Info("decision processed successfully", "duration", time.Since(startedAt))
 	return nil
 }

--- a/internal/scheduling/lib/history_client_test.go
+++ b/internal/scheduling/lib/history_client_test.go
@@ -215,10 +215,10 @@ func TestHistoryClient_CreateOrUpdateHistory(t *testing.T) {
 		// assertions on the history list (archived entries only).
 		expectHistoryLen int
 		// assertions on the current decision.
-		expectTargetHost  *string
-		expectSuccessful  bool
-		expectCondStatus  metav1.ConditionStatus
-		expectReason      string
+		expectTargetHost *string
+		expectSuccessful bool
+		expectCondStatus metav1.ConditionStatus
+		expectReason     string
 		// expectMessageContains, if set, asserts the Ready condition message
 		// surfaces this substring (used to check the pipeline-error path tells
 		// the user why scheduling failed).

--- a/internal/scheduling/lib/history_client_test.go
+++ b/internal/scheduling/lib/history_client_test.go
@@ -219,8 +219,12 @@ func TestHistoryClient_CreateOrUpdateHistory(t *testing.T) {
 		expectSuccessful  bool
 		expectCondStatus  metav1.ConditionStatus
 		expectReason      string
-		checkExplanation  func(t *testing.T, explanation string)
-		checkCurrentHosts func(t *testing.T, hosts []string)
+		// expectMessageContains, if set, asserts the Ready condition message
+		// surfaces this substring (used to check the pipeline-error path tells
+		// the user why scheduling failed).
+		expectMessageContains string
+		checkExplanation      func(t *testing.T, explanation string)
+		checkCurrentHosts     func(t *testing.T, hosts []string)
 	}{
 		{
 			name: "create new history",
@@ -362,6 +366,9 @@ func TestHistoryClient_CreateOrUpdateHistory(t *testing.T) {
 			expectSuccessful: false,
 			expectCondStatus: metav1.ConditionFalse,
 			expectReason:     v1alpha1.HistoryReasonPipelineRunFailed,
+			// The Ready condition message must tell the user the pipeline
+			// errored and why, so devops can troubleshoot from the CRD status.
+			expectMessageContains: "pipeline run failed: no hosts available",
 			checkExplanation: func(t *testing.T, explanation string) {
 				if !strings.Contains(explanation, "no hosts available") {
 					t.Errorf("expected explanation to contain error text, got: %q", explanation)
@@ -545,6 +552,9 @@ func TestHistoryClient_CreateOrUpdateHistory(t *testing.T) {
 			}
 			if readyCond.Reason != tt.expectReason {
 				t.Errorf("condition reason = %q, want %q", readyCond.Reason, tt.expectReason)
+			}
+			if tt.expectMessageContains != "" && !strings.Contains(readyCond.Message, tt.expectMessageContains) {
+				t.Errorf("condition message = %q, want it to contain %q", readyCond.Message, tt.expectMessageContains)
 			}
 
 			// Verify explanation.

--- a/internal/scheduling/machines/filter_weigher_pipeline_controller.go
+++ b/internal/scheduling/machines/filter_weigher_pipeline_controller.go
@@ -135,6 +135,12 @@ func (c *FilterWeigherPipelineController) process(ctx context.Context, decision 
 	// Execute the scheduling pipeline. Options not set: machine scheduling always records history.
 	request := ironcore.MachinePipelineRequest{Pools: pools.Items}
 	result, err := pipeline.Run(request)
+	// Persist the result on the decision before upserting history so that
+	// CreateOrUpdateHistory can observe the target host and ordered hosts.
+	// On error the result is empty/meaningless, so only set it on success.
+	if err == nil {
+		decision.Status.Result = &result
+	}
 	if !request.Options.SkipHistory {
 		if upsertErr := c.HistoryManager.CreateOrUpdateHistory(ctx, decision, nil, err); upsertErr != nil {
 			log.Error(upsertErr, "failed to create/update history")
@@ -144,7 +150,6 @@ func (c *FilterWeigherPipelineController) process(ctx context.Context, decision 
 		log.V(1).Error(err, "failed to run scheduler pipeline")
 		return errors.New("failed to run scheduler pipeline")
 	}
-	decision.Status.Result = &result
 	log.Info("decision processed successfully", "duration", time.Since(startedAt))
 
 	// Set the machine pool ref on the machine.

--- a/internal/scheduling/manila/filter_weigher_pipeline_controller.go
+++ b/internal/scheduling/manila/filter_weigher_pipeline_controller.go
@@ -112,6 +112,12 @@ func (c *FilterWeigherPipelineController) process(ctx context.Context, decision 
 	}
 
 	result, err := pipeline.Run(request)
+	// Persist the result on the decision before upserting history so that
+	// CreateOrUpdateHistory can observe the target host and ordered hosts.
+	// On error the result is empty/meaningless, so only set it on success.
+	if err == nil {
+		decision.Status.Result = &result
+	}
 	if !request.Options.SkipHistory {
 		if upsertErr := c.HistoryManager.CreateOrUpdateHistory(ctx, decision, nil, err); upsertErr != nil {
 			log.Error(upsertErr, "failed to create/update history")
@@ -121,7 +127,6 @@ func (c *FilterWeigherPipelineController) process(ctx context.Context, decision 
 		log.Error(err, "failed to run pipeline")
 		return err
 	}
-	decision.Status.Result = &result
 	log.Info("decision processed successfully", "duration", time.Since(startedAt))
 	return nil
 }

--- a/internal/scheduling/nova/filter_weigher_pipeline_controller.go
+++ b/internal/scheduling/nova/filter_weigher_pipeline_controller.go
@@ -199,6 +199,12 @@ func (c *FilterWeigherPipelineController) process(ctx context.Context, decision 
 	}
 
 	result, err := pipeline.Run(request)
+	// Persist the result on the decision before upserting history so that
+	// CreateOrUpdateHistory can observe the target host and ordered hosts.
+	// On error the result is empty/meaningless, so only set it on success.
+	if err == nil {
+		decision.Status.Result = &result
+	}
 	if !request.Options.SkipHistory {
 		c.upsertHistory(ctx, decision, err)
 	}
@@ -206,7 +212,6 @@ func (c *FilterWeigherPipelineController) process(ctx context.Context, decision 
 		log.Error(err, "failed to run pipeline")
 		return &request, err
 	}
-	decision.Status.Result = &result
 	meta.SetStatusCondition(&decision.Status.Conditions, metav1.Condition{
 		Type:    v1alpha1.DecisionConditionReady,
 		Status:  metav1.ConditionTrue,

--- a/internal/scheduling/nova/filter_weigher_pipeline_controller_test.go
+++ b/internal/scheduling/nova/filter_weigher_pipeline_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -406,6 +407,9 @@ func TestFilterWeigherPipelineController_ProcessNewDecisionFromAPI(t *testing.T)
 		expectHistoryCreated bool
 		expectUpdatedStatus  bool
 		errorContains        string
+		// verifyHistory, if set, is invoked with the persisted History CRD so
+		// tests can assert the decision was written through correctly.
+		verifyHistory func(t *testing.T, history *v1alpha1.History)
 	}{
 		{
 			name: "successful processing with decision creation enabled",
@@ -453,6 +457,36 @@ func TestFilterWeigherPipelineController_ProcessNewDecisionFromAPI(t *testing.T)
 			expectResult:         true,
 			expectHistoryCreated: true,
 			expectUpdatedStatus:  true,
+			// Regression guard: the History CRD must reflect the actual
+			// decision (target host selected, ordered hosts, Ready=True).
+			// Previously the result was written to the decision *after* the
+			// history upsert, so history always recorded a failed decision
+			// with no target host.
+			verifyHistory: func(t *testing.T, history *v1alpha1.History) {
+				cur := history.Status.Current
+				if !cur.Successful {
+					t.Errorf("expected history current.successful=true, got false")
+				}
+				if cur.TargetHost == nil {
+					t.Errorf("expected history current.targetHost to be set, got nil")
+				}
+				if len(cur.OrderedHosts) == 0 {
+					t.Errorf("expected history current.orderedHosts to be populated, got empty")
+				}
+				if cur.Explanation == "" {
+					t.Errorf("expected history current.explanation to be set, got empty")
+				}
+				ready := meta.FindStatusCondition(history.Status.Conditions, v1alpha1.HistoryConditionReady)
+				if ready == nil {
+					t.Fatalf("expected Ready condition to be set")
+				}
+				if ready.Status != metav1.ConditionTrue {
+					t.Errorf("expected Ready condition status True, got %s", ready.Status)
+				}
+				if ready.Reason != v1alpha1.HistoryReasonSchedulingSucceeded {
+					t.Errorf("expected Ready reason %q, got %q", v1alpha1.HistoryReasonSchedulingSucceeded, ready.Reason)
+				}
+			},
 		},
 		{
 			name: "successful processing with decision creation disabled",
@@ -729,6 +763,9 @@ func TestFilterWeigherPipelineController_ProcessNewDecisionFromAPI(t *testing.T)
 						t.Fatal("timed out waiting for history CRD to be created")
 					}
 					time.Sleep(5 * time.Millisecond)
+				}
+				if tt.verifyHistory != nil {
+					tt.verifyHistory(t, &histories.Items[0])
 				}
 			} else {
 				var histories v1alpha1.HistoryList

--- a/internal/scheduling/pods/filter_weigher_pipeline_controller.go
+++ b/internal/scheduling/pods/filter_weigher_pipeline_controller.go
@@ -149,6 +149,12 @@ func (c *FilterWeigherPipelineController) process(ctx context.Context, decision 
 	// Execute the scheduling pipeline. Options not set: pod scheduling always records history.
 	request := pods.PodPipelineRequest{Nodes: nodes.Items, Pod: *pod}
 	result, err := pipeline.Run(request)
+	// Persist the result on the decision before upserting history so that
+	// CreateOrUpdateHistory can observe the target host and ordered hosts.
+	// On error the result is empty/meaningless, so only set it on success.
+	if err == nil {
+		decision.Status.Result = &result
+	}
 	if !request.Options.SkipHistory {
 		if upsertErr := c.HistoryManager.CreateOrUpdateHistory(ctx, decision, nil, err); upsertErr != nil {
 			log.Error(upsertErr, "failed to create/update history")
@@ -158,7 +164,6 @@ func (c *FilterWeigherPipelineController) process(ctx context.Context, decision 
 		log.V(1).Error(err, "failed to run scheduler pipeline")
 		return errors.New("failed to run scheduler pipeline")
 	}
-	decision.Status.Result = &result
 	log.Info("decision processed successfully", "duration", time.Since(startedAt))
 
 	// Assign the first node returned by the pipeline using a Binding.


### PR DESCRIPTION
A refactor in the past led to the history creation being before the result was written to the decision object. That caused all our histories to report no host found.

I adjusted that and added some tests to catch something like this earlier next time.