### PR TITLE
Filter kvm hypervisors for non-kvm images

### DIFF
--- a/api/external/nova/messages.go
+++ b/api/external/nova/messages.go
@@ -315,6 +315,46 @@ type NovaImageMeta struct {
 	Properties      NovaObject[map[string]any] `json:"properties"`
 }
 
+type NovaImageMetaHVType string
+
+const (
+	NovaImageMetaHVTypeVMware    NovaImageMetaHVType = "vmware"
+	NovaImageMetaHVTypeBaremetal NovaImageMetaHVType = "baremetal"
+	NovaImageMetaHVTypeKVM       NovaImageMetaHVType = "kvm"
+)
+
+// GetHypervisorType determines the hypervisor type based on the image properties.
+func (m NovaImageMeta) GetHypervisorType() (NovaImageMetaHVType, error) {
+	if m.Properties.Data == nil {
+		return "", errors.New("image properties are not set")
+	}
+	keys := []string{
+		"img_hv_type",     // Used by kvm images
+		"hypervisor_type", // Used by other images (e.g., VMware)
+	}
+	for _, key := range keys {
+		val, ok := m.Properties.Data[key]
+		if !ok {
+			continue
+		}
+		str, ok := val.(string)
+		if !ok {
+			return "", fmt.Errorf("hypervisor type in image properties is not a string: %v", val)
+		}
+		switch strings.ToLower(str) {
+		case "vmware":
+			return NovaImageMetaHVTypeVMware, nil
+		case "baremetal":
+			return NovaImageMetaHVTypeBaremetal, nil
+		case "kvm":
+			return NovaImageMetaHVTypeKVM, nil
+		default:
+			return "", fmt.Errorf("unsupported hypervisor type in image properties: %s", str)
+		}
+	}
+	return "", errors.New("hypervisor type not found in image properties")
+}
+
 // Nova flavor metadata for the specified VM.
 type NovaFlavor struct {
 	ID          int               `json:"id"`

--- a/api/external/nova/messages.go
+++ b/api/external/nova/messages.go
@@ -329,7 +329,9 @@ func (m NovaImageMeta) GetHypervisorType() (NovaImageMetaHVType, error) {
 		return "", errors.New("image properties are not set")
 	}
 	keys := []string{
-		"img_hv_type",     // Used by kvm images
+		// See https://github.com/sapcc/nova/blob/27eb1f0/nova/scheduler/filters/image_props_filter.py#L55
+		"img_hv_type", // Used by kvm images
+		// See https://github.com/sapcc/nova/blob/27eb1f0/doc/source/admin/configuration/hypervisor-vmware.rst#tag-vmware-images
 		"hypervisor_type", // Used by other images (e.g., VMware)
 	}
 	for _, key := range keys {

--- a/api/external/nova/messages_test.go
+++ b/api/external/nova/messages_test.go
@@ -491,3 +491,81 @@ func TestNovaSpecUnmarshal(t *testing.T) {
 		t.Errorf("Expected NumInstances to be 1, got %d", spec.Spec.Data.NumInstances)
 	}
 }
+
+func TestNovaImageMeta_GetHypervisorType(t *testing.T) {
+	tests := []struct {
+		name        string
+		properties  map[string]any
+		propsNil    bool
+		expected    NovaImageMetaHVType
+		expectError bool
+	}{
+		{
+			name:       "kvm via img_hv_type",
+			properties: map[string]any{"img_hv_type": "kvm"},
+			expected:   NovaImageMetaHVTypeKVM,
+		},
+		{
+			name:       "vmware via hypervisor_type",
+			properties: map[string]any{"hypervisor_type": "vmware"},
+			expected:   NovaImageMetaHVTypeVMware,
+		},
+		{
+			name:       "baremetal via hypervisor_type",
+			properties: map[string]any{"hypervisor_type": "baremetal"},
+			expected:   NovaImageMetaHVTypeBaremetal,
+		},
+		{
+			name:       "case insensitive",
+			properties: map[string]any{"img_hv_type": "KVM"},
+			expected:   NovaImageMetaHVTypeKVM,
+		},
+		{
+			name:       "img_hv_type takes precedence over hypervisor_type",
+			properties: map[string]any{"img_hv_type": "kvm", "hypervisor_type": "vmware"},
+			expected:   NovaImageMetaHVTypeKVM,
+		},
+		{
+			name:        "properties nil",
+			propsNil:    true,
+			expectError: true,
+		},
+		{
+			name:        "no hypervisor key present",
+			properties:  map[string]any{"other_key": "value"},
+			expectError: true,
+		},
+		{
+			name:        "unsupported hypervisor type",
+			properties:  map[string]any{"img_hv_type": "xen"},
+			expectError: true,
+		},
+		{
+			name:        "value not a string",
+			properties:  map[string]any{"img_hv_type": 42},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := NovaImageMeta{}
+			if !tt.propsNil {
+				meta.Properties = NovaObject[map[string]any]{Data: tt.properties}
+			}
+			got, err := meta.GetHypervisorType()
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected an error, got nil (result: %q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}

--- a/helm/bundles/cortex-nova/templates/alerts.yaml
+++ b/helm/bundles/cortex-nova/templates/alerts.yaml
@@ -303,6 +303,28 @@ spec:
           configuration. It is recommended to investigate the
           pipeline status and logs for more details.
 
+    - alert: CortexNovaImagePropertiesHypervisorTypeUndetermined
+      expr: |
+        sum by (pipeline, step) (rate(cortex_filter_weigher_pipeline_step_events_total{service="cortex-nova-metrics", event="image_properties_hv_type_undetermined"}[5m])) > 0.1
+      for: 15m
+      labels:
+        context: scheduling
+        dashboard: cortex-status-dashboard/cortex-status-dashboard
+        service: cortex
+        severity: warning
+        support_group: workload-management
+        playbook: docs/support/playbook/cortex/alerts/scheduling
+      annotations:
+        summary: "Nova scheduling frequently cannot determine the hypervisor type from image properties"
+        description: >
+          The `filter_image_properties` step in pipeline `{{ "{{" }} $labels.pipeline {{ "}}" }}`
+          is frequently unable to determine the hypervisor type from the image properties
+          of incoming scheduling requests. In this case the filter is skipped and all hosts
+          are returned, so kvm-only images may be placed on non-kvm hypervisors (or vice
+          versa). This may indicate that images are missing the expected hypervisor
+          type property, or that the property format has changed. Investigate the
+          image metadata of the affected requests.
+
     {{- if .Values.kvm.enabled }}
     - alert: CortexNovaDoesntFindValidKVMHosts
       expr: sum by (az, hvtype) (increase(cortex_vm_faults{hvtype=~"CH|QEMU",faultmsg=~".*No valid host was found.*",faultmsg!~".*No such host.*"}[5m])) > 0

--- a/helm/bundles/cortex-nova/templates/pipelines_kvm.yaml
+++ b/helm/bundles/cortex-nova/templates/pipelines_kvm.yaml
@@ -26,6 +26,11 @@ spec:
         This step will consider the `ignore_hosts` and `force_hosts` instructions
         from the nova scheduler request spec to filter out or exclusively allow
         certain hosts.
+    - name: filter_image_properties
+      description: |
+        This step will filter out hosts for which the hypervisor type does not match
+        the one specified in the image properties, for example, filtering out all
+        known KVM hypervisors if the image requires a different hypervisor type.
     - name: filter_status_conditions
       description: |
         This step will filter out hosts for which the hypervisor status conditions
@@ -178,6 +183,11 @@ spec:
         This step will consider the `ignore_hosts` and `force_hosts` instructions
         from the nova scheduler request spec to filter out or exclusively allow
         certain hosts.
+    - name: filter_image_properties
+      description: |
+        This step will filter out hosts for which the hypervisor type does not match
+        the one specified in the image properties, for example, filtering out all
+        known KVM hypervisors if the image requires a different hypervisor type.
     - name: filter_status_conditions
       description: |
         This step will filter out hosts for which the hypervisor status conditions
@@ -629,6 +639,11 @@ spec:
         This step will consider the `ignore_hosts` and `force_hosts` instructions
         from the nova scheduler request spec to filter out or exclusively allow
         certain hosts.
+    - name: filter_image_properties
+      description: |
+        This step will filter out hosts for which the hypervisor type does not match
+        the one specified in the image properties, for example, filtering out all
+        known KVM hypervisors if the image requires a different hypervisor type.
     - name: filter_status_conditions
       description: |
         This step will filter out hosts for which the hypervisor status conditions
@@ -781,6 +796,11 @@ spec:
         This step will consider the `ignore_hosts` and `force_hosts` instructions
         from the nova scheduler request spec to filter out or exclusively allow
         certain hosts.
+    - name: filter_image_properties
+      description: |
+        This step will filter out hosts for which the hypervisor type does not match
+        the one specified in the image properties, for example, filtering out all
+        known KVM hypervisors if the image requires a different hypervisor type.
     - name: filter_status_conditions
       description: |
         This step will filter out hosts for which the hypervisor status conditions

--- a/internal/scheduling/lib/filter_weigher_pipeline_monitor.go
+++ b/internal/scheduling/lib/filter_weigher_pipeline_monitor.go
@@ -22,6 +22,8 @@ type FilterWeigherPipelineMonitor struct {
 	stepReorderingsObserver *prometheus.HistogramVec
 	// A histogram to observe the impact of the step on the hosts.
 	stepImpactObserver *prometheus.HistogramVec
+	// A counter for named events reported by a step during its run.
+	stepEventCounter *prometheus.CounterVec
 	// A histogram to measure how long the pipeline takes to run in total.
 	pipelineRunTimer *prometheus.HistogramVec
 	// A histogram to observe the number of hosts going into the scheduler pipeline.
@@ -64,6 +66,10 @@ func NewPipelineMonitor() FilterWeigherPipelineMonitor {
 			Help:    "Impact of the step on the hosts",
 			Buckets: prometheus.ExponentialBucketsRange(0.01, 1000, 20),
 		}, []string{"pipeline", "step", "stat", "unit"}),
+		stepEventCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_filter_weigher_pipeline_step_events_total",
+			Help: "Number of named events reported by a scheduler pipeline step",
+		}, []string{"pipeline", "step", "event"}),
 		pipelineRunTimer: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "cortex_filter_weigher_pipeline_run_duration_seconds",
 			Help:    "Duration of scheduler pipeline run",
@@ -121,6 +127,7 @@ func (m *FilterWeigherPipelineMonitor) Describe(ch chan<- *prometheus.Desc) {
 	m.stepRemovedHostsObserver.Describe(ch)
 	m.stepReorderingsObserver.Describe(ch)
 	m.stepImpactObserver.Describe(ch)
+	m.stepEventCounter.Describe(ch)
 	m.pipelineRunTimer.Describe(ch)
 	m.hostNumberInObserver.Describe(ch)
 	m.hostNumberOutObserver.Describe(ch)
@@ -133,6 +140,7 @@ func (m *FilterWeigherPipelineMonitor) Collect(ch chan<- prometheus.Metric) {
 	m.stepRemovedHostsObserver.Collect(ch)
 	m.stepReorderingsObserver.Collect(ch)
 	m.stepImpactObserver.Collect(ch)
+	m.stepEventCounter.Collect(ch)
 	m.pipelineRunTimer.Collect(ch)
 	m.hostNumberInObserver.Collect(ch)
 	m.hostNumberOutObserver.Collect(ch)

--- a/internal/scheduling/lib/filter_weigher_pipeline_step_monitor.go
+++ b/internal/scheduling/lib/filter_weigher_pipeline_step_monitor.go
@@ -36,6 +36,8 @@ type FilterWeigherPipelineStepMonitor[RequestType FilterWeigherPipelineRequest] 
 	stepReorderingsObserver *prometheus.HistogramVec
 	// A metric measuring the impact of the step on the hosts.
 	stepImpactObserver *prometheus.HistogramVec
+	// A counter for named events reported by the step during its run.
+	stepEventCounter *prometheus.CounterVec
 }
 
 // Schedule using the wrapped step and measure the time it takes.
@@ -58,6 +60,7 @@ func monitorStep[RequestType FilterWeigherPipelineRequest](stepName string, m Fi
 		removedHostsObserver:    removedHostsObserver,
 		stepReorderingsObserver: m.stepReorderingsObserver,
 		stepImpactObserver:      m.stepImpactObserver,
+		stepEventCounter:        m.stepEventCounter,
 	}
 }
 
@@ -82,6 +85,15 @@ func (s *FilterWeigherPipelineStepMonitor[RequestType]) RunWrapped(
 		"scheduler: finished step", "name", s.stepName,
 		"inWeights", inWeights, "outWeights", stepResult.Activations,
 	)
+
+	// Count named events reported by the step during its run.
+	if s.stepEventCounter != nil {
+		for _, event := range stepResult.Events {
+			s.stepEventCounter.
+				WithLabelValues(s.pipelineName, s.stepName, event).
+				Inc()
+		}
+	}
 
 	// Observe how much the step modifies the weights of the hosts.
 	if s.stepHostWeight != nil {

--- a/internal/scheduling/lib/filter_weigher_pipeline_step_monitor_test.go
+++ b/internal/scheduling/lib/filter_weigher_pipeline_step_monitor_test.go
@@ -7,6 +7,9 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 type mockObserver struct {
@@ -52,6 +55,37 @@ func TestStepMonitorRun(t *testing.T) {
 	}
 	if runTimer.Observations[0] <= 0 {
 		t.Errorf("runTimer.Observations[0] = %v, want > 0", runTimer.Observations[0])
+	}
+}
+
+func TestStepMonitorRunEvents(t *testing.T) {
+	stepEventCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_filter_weigher_pipeline_step_events_total",
+		Help: "Number of named events reported by a scheduler pipeline step",
+	}, []string{"pipeline", "step", "event"})
+	monitor := &FilterWeigherPipelineStepMonitor[mockFilterWeigherPipelineRequest]{
+		stepName:         "mock_step",
+		pipelineName:     "mock_pipeline",
+		stepEventCounter: stepEventCounter,
+	}
+	step := &mockWeigher[mockFilterWeigherPipelineRequest]{
+		RunFunc: func(traceLog *slog.Logger, request mockFilterWeigherPipelineRequest) (*FilterWeigherPipelineStepResult, error) {
+			return &FilterWeigherPipelineStepResult{
+				Activations: map[string]float64{"host1": 0.0},
+				Events:      []string{"hypervisor_type_undetermined"},
+			}, nil
+		},
+	}
+	request := mockFilterWeigherPipelineRequest{
+		Hosts:   []string{"host1"},
+		Weights: map[string]float64{"host1": 0.0},
+	}
+	if _, err := monitor.RunWrapped(slog.Default(), request, step); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	got := testutil.ToFloat64(stepEventCounter.WithLabelValues("mock_pipeline", "mock_step", "hypervisor_type_undetermined"))
+	if got != 1 {
+		t.Errorf("stepEventCounter = %v, want 1", got)
 	}
 }
 

--- a/internal/scheduling/lib/filter_weigher_pipeline_step_result.go
+++ b/internal/scheduling/lib/filter_weigher_pipeline_step_result.go
@@ -23,6 +23,13 @@ type FilterWeigherPipelineStepResult struct {
 	// These statistics are used to display the step's effect on the hosts.
 	// For example: max cpu contention: before [ 100%, 50%, 40% ], after [ 40%, 50%, 100% ]
 	Statistics map[string]FilterWeigherPipelineStepStatistics
+
+	// Named events reported by the step during its run, e.g.
+	// "hypervisor_type_undetermined". Each event is counted by the pipeline
+	// monitor as cortex_filter_weigher_pipeline_step_events_total, labeled by
+	// pipeline, step and event. Use this to expose noteworthy step conditions
+	// (skipped filtering, missing data, ...) as Prometheus metrics.
+	Events []string
 }
 
 type FilterWeigherPipelineStepStatistics struct {

--- a/internal/scheduling/nova/plugins/filters/filter_image_properties.go
+++ b/internal/scheduling/nova/plugins/filters/filter_image_properties.go
@@ -1,0 +1,50 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+import (
+	"context"
+	"log/slog"
+
+	api "github.com/cobaltcore-dev/cortex/api/external/nova"
+	"github.com/cobaltcore-dev/cortex/internal/scheduling/lib"
+	hv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
+)
+
+type FilterImagePropertiesStep struct {
+	lib.BaseFilter[api.ExternalSchedulerRequest, lib.EmptyFilterWeigherPipelineStepOpts]
+}
+
+// Filter hosts based on image properties given in the request spec.
+func (s *FilterImagePropertiesStep) Run(traceLog *slog.Logger, request api.ExternalSchedulerRequest) (*lib.FilterWeigherPipelineStepResult, error) {
+	result := s.IncludeAllHostsFromRequest(request)
+	// If the image properties indicate any other hypervisor type than kvm,
+	// we filter out all known kvm hypervisors.
+	hvType, err := request.Spec.Data.Image.Data.GetHypervisorType()
+	if err != nil {
+		// Hypervisor type could not be determined. In this case, just
+		// ignore the filter and return all hosts.
+		traceLog.Warn("could not determine hypervisor type from image properties",
+			"error", err)
+		return result, nil
+	}
+	if hvType != api.NovaImageMetaHVTypeKVM {
+		traceLog.Info("filtering out all known kvm hypervisors since image properties indicate a different hypervisor type",
+			"image_hypervisor_type", hvType)
+		hvs := new(hv1.HypervisorList)
+		if err := s.Client.List(context.Background(), hvs); err != nil {
+			traceLog.Error("failed to list hypervisors", "error", err)
+			return nil, err
+		}
+		for _, hv := range hvs.Items {
+			delete(result.Activations, hv.Name)
+			traceLog.Info("filtering host which is kvm hypervisor", "host", hv.Name)
+		}
+	}
+	return result, nil
+}
+
+func init() {
+	Index["filter_image_properties"] = func() NovaFilter { return &FilterImagePropertiesStep{} }
+}

--- a/internal/scheduling/nova/plugins/filters/filter_image_properties.go
+++ b/internal/scheduling/nova/plugins/filters/filter_image_properties.go
@@ -39,7 +39,7 @@ func (s *FilterImagePropertiesStep) Run(traceLog *slog.Logger, request api.Exter
 		}
 		for _, hv := range hvs.Items {
 			delete(result.Activations, hv.Name)
-			traceLog.Info("filtering host which is kvm hypervisor", "host", hv.Name)
+			traceLog.Debug("filtering host which is kvm hypervisor", "host", hv.Name)
 		}
 	}
 	return result, nil

--- a/internal/scheduling/nova/plugins/filters/filter_image_properties.go
+++ b/internal/scheduling/nova/plugins/filters/filter_image_properties.go
@@ -27,6 +27,9 @@ func (s *FilterImagePropertiesStep) Run(traceLog *slog.Logger, request api.Exter
 		// ignore the filter and return all hosts.
 		traceLog.Warn("could not determine hypervisor type from image properties",
 			"error", err)
+		// Expose this event through the step monitor to alert on high-frequency
+		// occurrences of this situation.
+		result.Events = append(result.Events, "image_properties_hv_type_undetermined")
 		return result, nil
 	}
 	if hvType != api.NovaImageMetaHVTypeKVM {

--- a/internal/scheduling/nova/plugins/filters/filter_image_properties_test.go
+++ b/internal/scheduling/nova/plugins/filters/filter_image_properties_test.go
@@ -1,0 +1,115 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+import (
+	"log/slog"
+	"testing"
+
+	api "github.com/cobaltcore-dev/cortex/api/external/nova"
+	hv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// requestWith builds an ExternalSchedulerRequest with the given hosts and image
+// properties.
+func requestWith(hosts []string, properties map[string]any) api.ExternalSchedulerRequest {
+	schedHosts := make([]api.ExternalSchedulerHost, 0, len(hosts))
+	for _, h := range hosts {
+		schedHosts = append(schedHosts, api.ExternalSchedulerHost{ComputeHost: h})
+	}
+	request := api.ExternalSchedulerRequest{Hosts: schedHosts}
+	request.Spec.Data.Image.Data.Properties = api.NovaObject[map[string]any]{Data: properties}
+	return request
+}
+
+func TestFilterImagePropertiesStep_Run(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := hv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// host1 and host2 are known kvm hypervisors, host3 is not registered.
+	hvs := []client.Object{
+		&hv1.Hypervisor{ObjectMeta: v1.ObjectMeta{Name: "host1"}},
+		&hv1.Hypervisor{ObjectMeta: v1.ObjectMeta{Name: "host2"}},
+	}
+
+	tests := []struct {
+		name          string
+		request       api.ExternalSchedulerRequest
+		expectedHosts []string
+		filteredHosts []string
+	}{
+		{
+			name:          "kvm image keeps all hosts",
+			request:       requestWith([]string{"host1", "host2", "host3"}, map[string]any{"img_hv_type": "kvm"}),
+			expectedHosts: []string{"host1", "host2", "host3"},
+			filteredHosts: []string{},
+		},
+		{
+			name:          "vmware image filters out known kvm hypervisors",
+			request:       requestWith([]string{"host1", "host2", "host3"}, map[string]any{"hypervisor_type": "vmware"}),
+			expectedHosts: []string{"host3"},
+			filteredHosts: []string{"host1", "host2"},
+		},
+		{
+			name:          "baremetal image filters out known kvm hypervisors",
+			request:       requestWith([]string{"host1", "host3"}, map[string]any{"img_hv_type": "baremetal"}),
+			expectedHosts: []string{"host3"},
+			filteredHosts: []string{"host1"},
+		},
+		{
+			name:          "undeterminable hypervisor type keeps all hosts",
+			request:       requestWith([]string{"host1", "host2", "host3"}, nil),
+			expectedHosts: []string{"host1", "host2", "host3"},
+			filteredHosts: []string{},
+		},
+		{
+			name:          "unsupported hypervisor type keeps all hosts",
+			request:       requestWith([]string{"host1", "host2"}, map[string]any{"img_hv_type": "xen"}),
+			expectedHosts: []string{"host1", "host2"},
+			filteredHosts: []string{},
+		},
+		{
+			name:          "empty host list",
+			request:       requestWith([]string{}, map[string]any{"hypervisor_type": "vmware"}),
+			expectedHosts: []string{},
+			filteredHosts: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := &FilterImagePropertiesStep{}
+			step.Client = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(hvs...).
+				Build()
+			result, err := step.Run(slog.Default(), tt.request)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			for _, host := range tt.expectedHosts {
+				if _, ok := result.Activations[host]; !ok {
+					t.Errorf("expected host %s to be present in activations", host)
+				}
+			}
+
+			for _, host := range tt.filteredHosts {
+				if _, ok := result.Activations[host]; ok {
+					t.Errorf("expected host %s to be filtered out", host)
+				}
+			}
+
+			if len(result.Activations) != len(tt.expectedHosts) {
+				t.Errorf("expected %d hosts, got %d", len(tt.expectedHosts), len(result.Activations))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a new Nova scheduler filter step, filter_image_properties, which removes known KVM hypervisors from the set of scheduling candidates when the image being booted declares a non-KVM hypervisor type. Some images are pinned to a specific hypervisor such as VMware or baremetal, and scheduling them onto KVM hosts would fail late in the boot process. Filtering these hosts out early during scheduling avoids wasted placement attempts and produces better placement decisions.

To support this, the Nova external API gains a NovaImageMetaHVType type together with constants for the vmware, baremetal, and kvm hypervisor types, and a NovaImageMeta.GetHypervisorType helper that reads the img_hv_type and hypervisor_type image properties and normalizes them into that type. The new FilterImagePropertiesStep uses this helper to decide, per request, whether the image requires a hypervisor type other than KVM, and if so it lists the available hypervisors and drops the known KVM hosts from the activations.

The step is registered in the KVM scheduling pipelines via helm/bundles/cortex-nova/templates/pipelines_kvm.yaml so it takes effect for KVM deployments. Test coverage includes unit tests for the new GetHypervisorType helper and a dedicated test suite for the filter step covering the filtering behavior.

Additionally, the monitoring library for steps is extended such that events can be surfaced as a prometheus metric -- and we now use this to alert if too many images are tried without a hypervisor type in their properties.

Assisted-by: Claude Code:claude-opus-4-1-20250805 [Bash] [Read]
