### PR TITLE
Support comma-separated and prefixed tenant ids in aggregate filter

### DIFF
--- a/internal/scheduling/nova/plugins/filters/filter_aggregate_metadata.go
+++ b/internal/scheduling/nova/plugins/filters/filter_aggregate_metadata.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log/slog"
 	"slices"
+	"strings"
 
 	api "github.com/cobaltcore-dev/cortex/api/external/nova"
 	"github.com/cobaltcore-dev/cortex/api/v1alpha1"
@@ -40,15 +41,31 @@ func (s *FilterAggregateMetadata) Run(traceLog *slog.Logger, request api.Externa
 	restrictedProjectsByHost := make(map[string][]string)
 	for _, hv := range hvs.Items {
 		for _, aggregate := range hv.Status.Aggregates {
-			tenantID, ok := aggregate.Metadata["filter_tenant_id"]
-			if !ok {
+			// Any metadata key prefixed with "filter_tenant_id" restricts the
+			// aggregate to the referenced projects. Multiple numbered keys (e.g.
+			// filter_tenant_id, filter_tenant_id1, ...) circumvent per-field
+			// database string length limits; each of their values can itself be
+			// a comma-separated list of project ids.
+			foundFilter := false
+			for key, value := range aggregate.Metadata {
+				if !strings.HasPrefix(key, "filter_tenant_id") {
+					continue
+				}
+				foundFilter = true
+				for projectID := range strings.SplitSeq(value, ",") {
+					projectID = strings.TrimSpace(projectID)
+					if projectID == "" {
+						continue
+					}
+					restrictedProjectsByHost[hv.Name] = append(restrictedProjectsByHost[hv.Name], projectID)
+				}
+				traceLog.Info("host is in aggregate with filter_tenant_id, adding restriction",
+					"host", hv.Name, "aggregate", aggregate.Name, "key", key, "tenant_id", value)
+			}
+			if !foundFilter {
 				traceLog.Info("aggregate does not have filter_tenant_id metadata, skipping",
 					"aggregate", aggregate.Name)
-				continue
 			}
-			restrictedProjectsByHost[hv.Name] = append(restrictedProjectsByHost[hv.Name], tenantID)
-			traceLog.Info("host is in aggregate with filter_tenant_id, adding restriction",
-				"host", hv.Name, "aggregate", aggregate.Name, "tenant_id", tenantID)
 		}
 	}
 

--- a/internal/scheduling/nova/plugins/filters/filter_aggregate_metadata_test.go
+++ b/internal/scheduling/nova/plugins/filters/filter_aggregate_metadata_test.go
@@ -316,6 +316,155 @@ func TestFilterAggregateMetadata_Run(t *testing.T) {
 			expectedHosts: []string{"host1"},
 			filteredHosts: []string{},
 		},
+		{
+			name: "Comma-separated filter_tenant_id - project matches one of many",
+			request: api.ExternalSchedulerRequest{
+				Spec: api.NovaObject[api.NovaSpec]{
+					Data: api.NovaSpec{
+						ProjectID: "project-b",
+					},
+				},
+				Hosts: []api.ExternalSchedulerHost{
+					{ComputeHost: "host1"},
+				},
+			},
+			hypervisors: []hv1.Hypervisor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "host1"},
+					Status: hv1.HypervisorStatus{
+						Aggregates: []hv1.Aggregate{{Name: "restricted", Metadata: map[string]string{"filter_tenant_id": "project-a,project-b,project-c"}}},
+					},
+				},
+			},
+			expectedHosts: []string{"host1"},
+			filteredHosts: []string{},
+		},
+		{
+			name: "Comma-separated filter_tenant_id - project matches none",
+			request: api.ExternalSchedulerRequest{
+				Spec: api.NovaObject[api.NovaSpec]{
+					Data: api.NovaSpec{
+						ProjectID: "project-d",
+					},
+				},
+				Hosts: []api.ExternalSchedulerHost{
+					{ComputeHost: "host1"},
+				},
+			},
+			hypervisors: []hv1.Hypervisor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "host1"},
+					Status: hv1.HypervisorStatus{
+						Aggregates: []hv1.Aggregate{{Name: "restricted", Metadata: map[string]string{"filter_tenant_id": "project-a,project-b,project-c"}}},
+					},
+				},
+			},
+			expectedHosts: []string{},
+			filteredHosts: []string{"host1"},
+		},
+		{
+			name: "Comma-separated filter_tenant_id with surrounding whitespace - project matches",
+			request: api.ExternalSchedulerRequest{
+				Spec: api.NovaObject[api.NovaSpec]{
+					Data: api.NovaSpec{
+						ProjectID: "project-b",
+					},
+				},
+				Hosts: []api.ExternalSchedulerHost{
+					{ComputeHost: "host1"},
+				},
+			},
+			hypervisors: []hv1.Hypervisor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "host1"},
+					Status: hv1.HypervisorStatus{
+						Aggregates: []hv1.Aggregate{{Name: "restricted", Metadata: map[string]string{"filter_tenant_id": "project-a, project-b , project-c"}}},
+					},
+				},
+			},
+			expectedHosts: []string{"host1"},
+			filteredHosts: []string{},
+		},
+		{
+			name: "Numbered filter_tenant_id keys - project matches one of the numbered keys",
+			request: api.ExternalSchedulerRequest{
+				Spec: api.NovaObject[api.NovaSpec]{
+					Data: api.NovaSpec{
+						ProjectID: "project-c",
+					},
+				},
+				Hosts: []api.ExternalSchedulerHost{
+					{ComputeHost: "host1"},
+				},
+			},
+			hypervisors: []hv1.Hypervisor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "host1"},
+					Status: hv1.HypervisorStatus{
+						Aggregates: []hv1.Aggregate{{Name: "restricted", Metadata: map[string]string{
+							"filter_tenant_id":  "project-a",
+							"filter_tenant_id1": "project-b",
+							"filter_tenant_id2": "project-c",
+						}}},
+					},
+				},
+			},
+			expectedHosts: []string{"host1"},
+			filteredHosts: []string{},
+		},
+		{
+			name: "Numbered filter_tenant_id keys with comma-separated values - project matches",
+			request: api.ExternalSchedulerRequest{
+				Spec: api.NovaObject[api.NovaSpec]{
+					Data: api.NovaSpec{
+						ProjectID: "project-e",
+					},
+				},
+				Hosts: []api.ExternalSchedulerHost{
+					{ComputeHost: "host1"},
+				},
+			},
+			hypervisors: []hv1.Hypervisor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "host1"},
+					Status: hv1.HypervisorStatus{
+						Aggregates: []hv1.Aggregate{{Name: "restricted", Metadata: map[string]string{
+							"filter_tenant_id":  "project-a,project-b",
+							"filter_tenant_id1": "project-c,project-d",
+							"filter_tenant_id2": "project-e,project-f",
+						}}},
+					},
+				},
+			},
+			expectedHosts: []string{"host1"},
+			filteredHosts: []string{},
+		},
+		{
+			name: "Numbered filter_tenant_id keys - project matches none",
+			request: api.ExternalSchedulerRequest{
+				Spec: api.NovaObject[api.NovaSpec]{
+					Data: api.NovaSpec{
+						ProjectID: "project-z",
+					},
+				},
+				Hosts: []api.ExternalSchedulerHost{
+					{ComputeHost: "host1"},
+				},
+			},
+			hypervisors: []hv1.Hypervisor{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "host1"},
+					Status: hv1.HypervisorStatus{
+						Aggregates: []hv1.Aggregate{{Name: "restricted", Metadata: map[string]string{
+							"filter_tenant_id":  "project-a,project-b",
+							"filter_tenant_id1": "project-c,project-d",
+						}}},
+					},
+				},
+			},
+			expectedHosts: []string{},
+			filteredHosts: []string{"host1"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The filter_aggregate_metadata filter previously assumed the filter_tenant_id aggregate metadata value contained a single project id. That value can actually be a comma-separated list of project ids, all of which should be allowed to spawn in the aggregate. The filter now splits each value on commas, trimming whitespace and skipping empty entries, and treats each project id as an allowed tenant.

Additionally, starting with the Nova epoxy (2025.1) release, aggregate metadata may contain not just filter_tenant_id but also numbered variants sharing the same prefix such as filter_tenant_id1 and filter_tenant_id2, introduced to work around per-field database string length limits. The filter now matches any metadata key carrying the filter_tenant_id prefix, and the values across all matching keys are unioned into the set of allowed projects for the aggregate. Unit tests were extended to cover comma-separated values, numbered prefixed keys, numbered keys with comma-separated values, surrounding whitespace, non-matching projects, and the no-match case.

Assisted-by: Claude Code:claude-opus-latest [Bash]
