### PR TITLE
fix(CR): subtract reservation CPU blocks when counting placeable slots

### DIFF
--- a/internal/scheduling/reservations/capacity/controller.go
+++ b/internal/scheduling/reservations/capacity/controller.go
@@ -238,10 +238,10 @@ func (c *Reconciler) reconcileAll(ctx context.Context) error {
 
 	azs := availabilityZones(hvList.Items)
 
-	blockedByReservations, err := c.blockedMemoryByHost(ctx)
+	blockedByReservations, err := c.blockedResourcesByHost(ctx)
 	if err != nil {
-		logger.Error(err, "failed to compute blocked memory by host, placeable slot counts may be overstated")
-		blockedByReservations = map[string]int64{}
+		logger.Error(err, "failed to compute blocked resources by host, placeable slot counts may be overstated")
+		blockedByReservations = map[string]map[string]int64{}
 	}
 
 	usageByKey := c.computeVMUsage(ctx, flavorGroups, hvList.Items)
@@ -320,9 +320,10 @@ func (c *Reconciler) computeVMUsage(
 }
 
 // hvRemainingResources returns remaining schedulable resources after subtracting
-// current allocations and (for memory) active reservation blocks.
+// current allocations and active reservation blocks.
+// blockedResources uses ResourceMemory/ResourceCores keys.
 // Returns nil if the hypervisor has no capacity data.
-func hvRemainingResources(hv hv1.Hypervisor, blockedMemBytes int64) map[string]int64 {
+func hvRemainingResources(hv hv1.Hypervisor, blockedResources map[string]int64) map[string]int64 {
 	effCap := hv.Status.EffectiveCapacity
 	if effCap == nil {
 		effCap = hv.Status.Capacity
@@ -338,7 +339,7 @@ func hvRemainingResources(hv hv1.Hypervisor, blockedMemBytes int64) map[string]i
 		if alloc, ok := hv.Status.Allocation[hv1.ResourceMemory]; ok {
 			mem -= alloc.Value()
 		}
-		mem -= blockedMemBytes
+		mem -= blockedResources[ResourceMemory]
 		if mem < 0 {
 			mem = 0
 		}
@@ -350,6 +351,7 @@ func hvRemainingResources(hv hv1.Hypervisor, blockedMemBytes int64) map[string]i
 		if alloc, ok := hv.Status.Allocation[hv1.ResourceCPU]; ok {
 			cpu -= alloc.Value()
 		}
+		cpu -= blockedResources[ResourceCores]
 		if cpu < 0 {
 			cpu = 0
 		}
@@ -367,7 +369,7 @@ func (c *Reconciler) probeGroup(
 	groupData compute.FlavorGroupFeature,
 	az string,
 	hvByName map[string]hv1.Hypervisor,
-	blockedByReservations map[string]int64,
+	blockedByReservations map[string]map[string]int64,
 ) (probeGroupResult, error) {
 
 	logger := LoggerFromContext(ctx)
@@ -445,7 +447,7 @@ func (c *Reconciler) probeGroup(
 func buildSplitInputs(
 	results []probeGroupResult,
 	hvByName map[string]hv1.Hypervisor,
-	blockedByReservations map[string]int64,
+	blockedByReservations map[string]map[string]int64,
 	az string,
 	logger logr.Logger,
 ) (groupInputs []GroupInput, hosts map[string]HostState) {
@@ -502,7 +504,7 @@ func (c *Reconciler) reconcileAZ(
 	az string,
 	flavorGroups map[string]compute.FlavorGroupFeature,
 	hvByName map[string]hv1.Hypervisor,
-	blockedByReservations map[string]int64,
+	blockedByReservations map[string]map[string]int64,
 	usageByKey map[vmUsageKey]vmUsage,
 ) {
 
@@ -706,7 +708,7 @@ func (c *Reconciler) probeScheduler(
 	az, pipeline string,
 	hvByName map[string]hv1.Hypervisor,
 	ignoreAllocations bool,
-	blockedByReservations map[string]int64,
+	blockedByReservations map[string]map[string]int64,
 ) (capacity, hosts int64, candidateHosts []string, err error) {
 
 	flavorBytes := int64(flavor.MemoryMB) * 1024 * 1024 //nolint:gosec
@@ -793,15 +795,16 @@ func (c *Reconciler) probeScheduler(
 	return capacity, hosts, candidateHosts, nil
 }
 
-// blockedMemoryByHost returns total reservation-blocked bytes per host.
+// blockedResourcesByHost returns total reservation-blocked resources per host.
 // Both TargetHost and Status.Host are blocked; migration blocks both simultaneously.
-func (c *Reconciler) blockedMemoryByHost(ctx context.Context) (map[string]int64, error) {
+// The inner map uses ResourceMemory and ResourceCores keys.
+func (c *Reconciler) blockedResourcesByHost(ctx context.Context) (map[string]map[string]int64, error) {
 	var list v1alpha1.ReservationList
 	if err := c.client.List(ctx, &list); err != nil {
 		return nil, fmt.Errorf("failed to list reservations: %w", err)
 	}
 
-	blocked := make(map[string]int64)
+	blocked := make(map[string]map[string]int64)
 	for i := range list.Items {
 		res := &list.Items[i]
 
@@ -817,13 +820,16 @@ func (c *Reconciler) blockedMemoryByHost(ctx context.Context) (map[string]int64,
 		}
 
 		resourcesToBlock := reservations.UnusedReservationCapacity(res, false)
-		memQty, ok := resourcesToBlock[hv1.ResourceMemory]
-		if !ok {
-			continue
-		}
-		memBytes := memQty.Value()
 		for host := range hostsToBlock {
-			blocked[host] += memBytes
+			if blocked[host] == nil {
+				blocked[host] = make(map[string]int64)
+			}
+			if qty, ok := resourcesToBlock[hv1.ResourceMemory]; ok {
+				blocked[host][ResourceMemory] += qty.Value()
+			}
+			if qty, ok := resourcesToBlock[hv1.ResourceCPU]; ok {
+				blocked[host][ResourceCores] += qty.Value()
+			}
 		}
 	}
 	return blocked, nil

--- a/internal/scheduling/reservations/capacity/controller_test.go
+++ b/internal/scheduling/reservations/capacity/controller_test.go
@@ -225,7 +225,7 @@ func TestReconcileAZ_CreatesCRD(t *testing.T) {
 
 	ctrl.reconcileAZ(context.Background(), az,
 		map[string]compute.FlavorGroupFeature{groupName: groupData},
-		hvByName, map[string]int64{}, map[vmUsageKey]vmUsage{})
+		hvByName, map[string]map[string]int64{}, map[vmUsageKey]vmUsage{})
 
 	var crd v1alpha1.FlavorGroupCapacity
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: crdNameFor(groupName, az)}, &crd); err != nil {
@@ -297,7 +297,7 @@ func TestReconcileAZ_SkipsCRDWriteOnSchedulerError(t *testing.T) {
 
 	ctrl.reconcileAZ(context.Background(), az,
 		map[string]compute.FlavorGroupFeature{groupName: groupData},
-		map[string]hv1.Hypervisor{}, map[string]int64{}, map[vmUsageKey]vmUsage{})
+		map[string]hv1.Hypervisor{}, map[string]map[string]int64{}, map[vmUsageKey]vmUsage{})
 
 	// Stale probes → CRD must NOT be written; last good state is preserved.
 	var list v1alpha1.FlavorGroupCapacityList
@@ -369,7 +369,7 @@ func TestReconcileAZ_MarksExistingCRDNotReadyOnSchedulerError(t *testing.T) {
 
 	ctrl.reconcileAZ(context.Background(), az,
 		map[string]compute.FlavorGroupFeature{groupName: groupData},
-		hvByName, map[string]int64{}, map[vmUsageKey]vmUsage{})
+		hvByName, map[string]map[string]int64{}, map[vmUsageKey]vmUsage{})
 
 	var crd v1alpha1.FlavorGroupCapacity
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: crdName}, &crd); err != nil {
@@ -434,9 +434,9 @@ func TestReconcileAZ_IdempotentUpdate(t *testing.T) {
 	groups := map[string]compute.FlavorGroupFeature{groupName: groupData}
 
 	// First call
-	ctrl.reconcileAZ(context.Background(), az, groups, hvByName, map[string]int64{}, map[vmUsageKey]vmUsage{})
+	ctrl.reconcileAZ(context.Background(), az, groups, hvByName, map[string]map[string]int64{}, map[vmUsageKey]vmUsage{})
 	// Second call — should not error on the already-existing CRD.
-	ctrl.reconcileAZ(context.Background(), az, groups, hvByName, map[string]int64{}, map[vmUsageKey]vmUsage{})
+	ctrl.reconcileAZ(context.Background(), az, groups, hvByName, map[string]map[string]int64{}, map[vmUsageKey]vmUsage{})
 
 	var crd v1alpha1.FlavorGroupCapacity
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: crdName}, &crd); err != nil {
@@ -984,7 +984,7 @@ func TestComputeVMUsage_ZerosOutWhenAllVMsRemoved(t *testing.T) {
 	}
 
 	// Now run reconcileAZ to verify the CRD gets zeroed out.
-	ctrl.reconcileAZ(context.Background(), az, groups, hvByName, map[string]int64{}, usageByKey)
+	ctrl.reconcileAZ(context.Background(), az, groups, hvByName, map[string]map[string]int64{}, usageByKey)
 
 	var crd v1alpha1.FlavorGroupCapacity
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: crdName}, &crd); err != nil {
@@ -1032,8 +1032,8 @@ func TestProbeScheduler_SubtractsReservationBlocksWhenNotIgnored(t *testing.T) {
 	}
 
 	// Placeable probe with 1 reservation block: 3 - 1 (alloc) - 1 (reservation) = 1 slot.
-	blockedByReservations := map[string]int64{
-		"host-1": memBytes, // 1 reservation blocking 1 slot's worth of memory
+	blockedByReservations := map[string]map[string]int64{
+		"host-1": {ResourceMemory: memBytes}, // 1 reservation blocking 1 slot's worth of memory
 	}
 	placeableCap, _, _, err := c.probeScheduler(context.Background(), flavor, "az-a", "placeable-pipeline", hvByName, false, blockedByReservations)
 	if err != nil {


### PR DESCRIPTION
Fixes capacity slot counting to use both memory and CPU as binding constraints, not memory alone.