### PR TITLE
fix: remove unused volumes and volumeMounts for perses-plugins

### DIFF
--- a/tools/perses/values.yaml
+++ b/tools/perses/values.yaml
@@ -4,14 +4,6 @@
 sidecar:
   enabled: true
 
-volumes:
-  - name: perses-plugins
-    emptyDir: {}
-
-volumeMounts:
-  - name: perses-plugins
-    mountPath: /etc/perses/plugins
-
 config:
   provisioning:
     folders:


### PR DESCRIPTION
Perses fails to come up in tilt