### PR TITLE
fix: issues introduced with new linter version

### DIFF
--- a/internal/knowledge/datasources/plugins/openstack/controller_test.go
+++ b/internal/knowledge/datasources/plugins/openstack/controller_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cobaltcore-dev/cortex/api/v1alpha1"
 
-	"github.com/cobaltcore-dev/cortex/internal/knowledge/datasources"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,10 +28,9 @@ func TestOpenStackDatasourceReconciler_Creation(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	reconciler := &OpenStackDatasourceReconciler{
-		Client:  client,
-		Scheme:  scheme,
-		Monitor: datasources.Monitor{},
-		conf:    config{SchedulingDomain: "test-operator"},
+		Client: client,
+		Scheme: scheme,
+		conf:   config{SchedulingDomain: "test-operator"},
 	}
 
 	if reconciler.Client == nil {

--- a/internal/knowledge/datasources/plugins/prometheus/controller_test.go
+++ b/internal/knowledge/datasources/plugins/prometheus/controller_test.go
@@ -29,10 +29,9 @@ func TestPrometheusDatasourceReconciler_Creation(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	reconciler := &PrometheusDatasourceReconciler{
-		Client:  client,
-		Scheme:  scheme,
-		conf:    config{SchedulingDomain: "test-operator"},
-		Monitor: datasources.Monitor{},
+		Client: client,
+		Scheme: scheme,
+		conf:   config{SchedulingDomain: "test-operator"},
 	}
 
 	if reconciler.Client == nil {

--- a/internal/scheduling/nova/cr_metrics_test.go
+++ b/internal/scheduling/nova/cr_metrics_test.go
@@ -235,14 +235,12 @@ func TestLogNoHostFound(t *testing.T) {
 			reg.MustRegister(counter)
 
 			controller := &FilterWeigherPipelineController{
-				BasePipelineController: lib.BasePipelineController[lib.FilterWeigherPipeline[api.ExternalSchedulerRequest]]{
-					Client: fakeClient,
-				},
 				CRRecorder: crs.Recorder{
 					Client:             fakeClient,
 					NoHostFoundCounter: counter,
 				},
 			}
+			controller.Client = fakeClient
 
 			requestFlavorName := flavorName
 			if tt.payg {

--- a/internal/scheduling/nova/external_scheduler_api.go
+++ b/internal/scheduling/nova/external_scheduler_api.go
@@ -134,7 +134,7 @@ func shuffleTopHosts(hosts []string, k int) []string {
 	}
 	result := make([]string, len(hosts))
 	copy(result, hosts)
-	rand.Shuffle(n, func(i, j int) { //nolint:gosec non-crypto shuffle, safe to suppress
+	rand.Shuffle(n, func(i, j int) { //nolint:gosec // non-crypto shuffle for load balancing
 		result[i], result[j] = result[j], result[i]
 	})
 	slog.Info("shuffled top hosts for evacuation", "k", n, "hosts", result[:n])

--- a/internal/scheduling/nova/external_scheduler_api.go
+++ b/internal/scheduling/nova/external_scheduler_api.go
@@ -134,7 +134,7 @@ func shuffleTopHosts(hosts []string, k int) []string {
 	}
 	result := make([]string, len(hosts))
 	copy(result, hosts)
-	rand.Shuffle(n, func(i, j int) {
+	rand.Shuffle(n, func(i, j int) { //nolint:gosec non-crypto shuffle, safe to suppress
 		result[i], result[j] = result[j], result[i]
 	})
 	slog.Info("shuffled top hosts for evacuation", "k", n, "hosts", result[:n])

--- a/internal/scheduling/reservations/commitments/reservation_controller.go
+++ b/internal/scheduling/reservations/commitments/reservation_controller.go
@@ -199,8 +199,8 @@ func (r *CommitmentReservationController) Reconcile(ctx context.Context, req ctr
 		}
 
 		logger.Info("marked pre-allocated reservation as ready", "host", res.Status.Host)
-		// Requeue immediately to run verification in next reconcile loop
-		return ctrl.Result{RequeueAfter: time.Millisecond}, nil
+		// The status patch triggers a re-reconcile via the Reservation watch; allocation verification runs in that cycle.
+		return ctrl.Result{}, nil
 	}
 
 	// Sync Spec values to Status fields for non-pre-allocated reservations

--- a/internal/scheduling/reservations/commitments/reservation_controller.go
+++ b/internal/scheduling/reservations/commitments/reservation_controller.go
@@ -200,7 +200,7 @@ func (r *CommitmentReservationController) Reconcile(ctx context.Context, req ctr
 
 		logger.Info("marked pre-allocated reservation as ready", "host", res.Status.Host)
 		// Requeue immediately to run verification in next reconcile loop
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Millisecond}, nil
 	}
 
 	// Sync Spec values to Status fields for non-pre-allocated reservations


### PR DESCRIPTION
```txt
"/home/runner/work/cortex/cortex/bin/golangci-lint" run --fix
Error: internal/scheduling/nova/external_scheduler_api.go:137:2: G404: Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand) (gosec)
Error: internal/knowledge/datasources/plugins/openstack/controller_test.go:34:10: unusedwrite: unused write to field Monitor (govet)
Error: internal/knowledge/datasources/plugins/prometheus/controller_test.go:35:10: unusedwrite: unused write to field Monitor (govet)
Error: internal/scheduling/nova/cr_metrics_test.go:238:27: unusedwrite: unused write to field BasePipelineController (govet)
Error: internal/scheduling/reservations/commitments/reservation_controller.go:203:22: SA1019: (sigs.k8s.io/controller-runtime.Result).Requeue is deprecated: Use `RequeueAfter` instead.
```


- added //nolint:gosec to the rand.Shuffle call (non-crypto shuffle, safe to suppress)
- removed Monitor: datasources.Monitor{} zero-value assignment
- removed Monitor: datasources.Monitor{} zero-value assignment
- replaced embedded composite literal with controller.Client = fakeClient after struct creation
- replaced Requeue: true with RequeueAfter: time.Millisecond (effectively immediate, non-deprecated)