### PR TITLE
Support ingress in cortex-shim library chart

### DIFF
--- a/helm/library/cortex-shim/templates/ingress.yaml
+++ b/helm/library/cortex-shim/templates/ingress.yaml
@@ -1,0 +1,24 @@
+# Copyright SAP SE
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.namePrefix }}-shim-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    {{- if .Values.ingress.rules }}
+    {{- toYaml .Values.ingress.rules | nindent 4 }}
+    {{- end }}
+  tls:
+    {{- if .Values.ingress.tls }}
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/helm/library/cortex-shim/values.yaml
+++ b/helm/library/cortex-shim/values.yaml
@@ -41,6 +41,19 @@ deployment:
   terminationGracePeriodSeconds: 10
   serviceAccountName: shim
 
+# [INGRESS]: To enable an ingress resource for the placement shim set true
+ingress:
+  # Enable or disable the ingress resource for the placement shim.
+  enabled: true
+  # Which ingress controller to use.
+  className: nginx
+  # Override this default set of annotations if needed.
+  annotations:
+    # Enables https://github.com/sapcc/disco
+    disco: "true"
+    # Enables automatic TLS certificate provisioning via cert-manager.
+    kubernetes.io/tls-acme: "true"
+
 # [METRICS]: Set to true to generate manifests for exporting metrics.
 # To disable metrics export set false, and remove the container args
 # "--metrics-bind-address=:2112" and "--metrics-secure=false".


### PR DESCRIPTION
The OpenStack Keystone service catalog contains internal, admin, and public endpoints. While for internal and admin endpoints of the Cortex Placement Shim we can use an internal URL via cluster- internal DNS, for the public endpoint that'll be accessed by clients like the CLI, we need an Ingress resource.

Note that Ingress is chosen over HTTPRoute (part of the Gateway API) for now because we didn't migrate there yet.