### PR TITLE
feat: add cache monitoring

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -393,8 +393,11 @@ func main() {
 	}
 	multiclusterClientConfig := conf.GetConfigOrDie[multicluster.ClientConfig]()
 
+	var cacheMonitor *cache.Monitor
+	var cacheWrapper *cache.Wrapper
 	if c := conf.GetConfigOrDie[cache.RootConfig](); c.Cache.Enabled {
-		cacheWrapper := cache.NewWrapper(mgr, c.Cache)
+		cacheMonitor = cache.NewMonitor("cortex_")
+		cacheWrapper = cache.NewWrapper(mgr, c.Cache, cacheMonitor)
 		multiclusterClient.Wrappers = append(multiclusterClient.Wrappers, cacheWrapper)
 	}
 	if err := multiclusterClient.InitFromConf(ctx, mgr, multiclusterClientConfig); err != nil {
@@ -408,6 +411,9 @@ func main() {
 	metrics.Registry = monitoring.WrapRegistry(metrics.Registry, metricsConfig)
 	metrics.Registry.MustRegister(&logMetricsMonitor)
 	metrics.Registry.MustRegister(multiclusterMonitor)
+	if cacheMonitor != nil {
+		metrics.Registry.MustRegister(cacheMonitor)
+	}
 
 	// TODO: Remove me after scheduling pipeline steps don't require DB connections anymore.
 	metrics.Registry.MustRegister(&db.Monitor)

--- a/helm/bundles/cortex-nova/templates/alerts.yaml
+++ b/helm/bundles/cortex-nova/templates/alerts.yaml
@@ -750,6 +750,36 @@ spec:
           object was created out-of-band on the wrong cluster. Investigate the
           affected resources and the routing configuration.
 
+    - alert: CortexNovaCacheOverlayNotDraining
+      # The pending-cache overlay holds writes only until the informer observes
+      # them, which normally happens within milliseconds. A plain gauge sampled
+      # at scrape time would therefore almost always read zero, so the monitor
+      # exposes a high-watermark (reset on each scrape) instead. A watermark that
+      # stays above the threshold across every scrape in the `for` window means
+      # entries are piling up rather than draining — i.e. eviction is broken
+      # (informer lag, UID mismatch, or TTL fallback firing).
+      expr: |
+        max by (gvk, host) (cortex_cache_overlay_entries_max{service="cortex-nova-metrics"}) > {{ .Values.alerts.thresholds.cacheOverlayMaxEntries }}
+      for: 5m
+      labels:
+        context: multicluster
+        dashboard: cortex-status-dashboard/cortex-status-dashboard
+        service: cortex
+        severity: warning
+        support_group: workload-management
+      annotations:
+        summary: "Cache overlay for `{{ "{{" }} $labels.gvk {{ "}}" }}` is not draining"
+        description: >
+          The in-process cache overlay for `{{ "{{" }} $labels.gvk {{ "}}" }}`
+          on host `{{ "{{" }} $labels.host {{ "}}" }}` has held entries above the
+          configured threshold across the whole alert window. The overlay is only
+          meant to bridge the short gap between a write and the informer observing
+          it, so it should drain back to zero within milliseconds. A sustained
+          non-zero high-watermark indicates entries are not being evicted —
+          typically informer lag, a UID mismatch between the write and the observed
+          object, or the TTL fallback repeatedly firing. Investigate the informer
+          for this GVK/cluster and the overlay eviction logs.
+
     {{- if .Values.kvm.enabled }}
     - alert: CortexNovaHostReservationsOversubscribed
       # Fires when the sum of running VM allocations + reservation blocks (committed +
@@ -783,7 +813,7 @@ spec:
           failover) on host {{ "{{" }} $labels.compute_host {{ "}}" }} exceeds its effective
           capacity for {{ "{{" }} $labels.resource {{ "}}" }} by {{ "{{" }} $value | humanize {{ "}}" }}.
           This means the host is over-subscribed and committed resource or failover guarantees may not be
-          satisfied. Common causes: VM migrations with slot not yet reclaimed, outdated/stale reservations, or out of sync issues. 
+          satisfied. Common causes: VM migrations with slot not yet reclaimed, outdated/stale reservations, or out of sync issues.
           If problem remains, inspect the reservations on this host and check the CR/failover controller logs.
     - alert: CortexCommittedResourceHostOversubscribed
       expr: max by (host, az, resource) (cortex_committed_resource_host_oversubscribed) > 0

--- a/helm/bundles/cortex-nova/templates/alerts.yaml
+++ b/helm/bundles/cortex-nova/templates/alerts.yaml
@@ -751,15 +751,13 @@ spec:
           affected resources and the routing configuration.
 
     - alert: CortexNovaCacheOverlayNotDraining
-      # The pending-cache overlay holds writes only until the informer observes
-      # them, which normally happens within milliseconds. A plain gauge sampled
-      # at scrape time would therefore almost always read zero, so the monitor
-      # exposes a high-watermark (reset on each scrape) instead. A watermark that
-      # stays above the threshold across every scrape in the `for` window means
-      # entries are piling up rather than draining — i.e. eviction is broken
-      # (informer lag, UID mismatch, or TTL fallback firing).
+      # The cache overlay holds writes only until the informer observes
+      # them, which normally happens within milliseconds. If the current entry
+      # count stays above the threshold for the entire `for` window, entries are
+      # piling up rather than draining — i.e. eviction is broken (informer lag,
+      # UID mismatch, or TTL fallback firing).
       expr: |
-        max by (gvk, host) (cortex_cache_overlay_entries_max{service="cortex-nova-metrics"}) > {{ .Values.alerts.thresholds.cacheOverlayMaxEntries }}
+        max by (gvk, host) (cortex_cache_overlay_entries{service="cortex-nova-metrics"}) > {{ .Values.alerts.thresholds.cacheOverlayMaxEntries }}
       for: 5m
       labels:
         context: multicluster
@@ -775,7 +773,7 @@ spec:
           configured threshold across the whole alert window. The overlay is only
           meant to bridge the short gap between a write and the informer observing
           it, so it should drain back to zero within milliseconds. A sustained
-          non-zero high-watermark indicates entries are not being evicted —
+          non-zero current size indicates entries are not being evicted —
           typically informer lag, a UID mismatch between the write and the observed
           object, or the TTL fallback repeatedly firing. Investigate the informer
           for this GVK/cluster and the overlay eviction logs.

--- a/helm/bundles/cortex-nova/values.yaml
+++ b/helm/bundles/cortex-nova/values.yaml
@@ -22,6 +22,11 @@ alerts:
     highMemoryMiB: 6000
     # Reconcile-duration threshold for CortexNovaReconcileDurationHigher10Min in seconds.
     reconcileDurationSeconds: 600
+    # High-watermark of cache overlay entries above which
+    # CortexNovaCacheOverlayNotDraining fires. The overlay is expected to drain
+    # back to zero within milliseconds, so any sustained non-zero watermark
+    # indicates eviction is not keeping up.
+    cacheOverlayMaxEntries: 50
 
 serviceMonitor:
   extraLabels: {}

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -76,6 +76,13 @@ type Overlay struct {
 	ttl           time.Duration
 	gvks          map[schema.GroupVersionKind]bool
 
+	// monitor observes the overlay size per GVK. It may be nil (metrics off);
+	// noteSizeLocked and Monitor.observeSize are nil-safe. host identifies this
+	// overlay's cluster (its rest config Host) so a single shared Monitor can
+	// distinguish home from remotes.
+	monitor *Monitor
+	host    string
+
 	mu       sync.RWMutex
 	byGVK    map[schema.GroupVersionKind]map[client.ObjectKey]*entry
 	indexers map[schema.GroupVersionKind]map[string]client.IndexerFunc
@@ -99,7 +106,11 @@ type Overlay struct {
 // eviction handlers (reading informers from inner.GetCache()) and runs the TTL
 // cleanup loop. The caller MUST add it to the manager. It does NOT re-Start the
 // inner cluster — the manager owns the inner cluster's lifecycle separately.
-func WrapCluster(inner cluster.Cluster, conf Config) (cluster.Cluster, manager.Runnable, error) {
+//
+// monitor observes the overlay size per GVK and may be nil (metrics off). It is
+// internal to this package (only Wrapper and tests call WrapCluster), so this
+// signature does not touch the multicluster client.
+func WrapCluster(inner cluster.Cluster, conf Config, monitor *Monitor) (cluster.Cluster, manager.Runnable, error) {
 	scheme := inner.GetScheme()
 	gvks, err := resolveGVKs(scheme, conf.GVKs)
 	if err != nil {
@@ -115,6 +126,8 @@ func WrapCluster(inner cluster.Cluster, conf Config) (cluster.Cluster, manager.R
 		scheme:        scheme,
 		ttl:           ttl,
 		gvks:          gvks,
+		monitor:       monitor,
+		host:          inner.GetConfig().Host,
 		byGVK:         make(map[schema.GroupVersionKind]map[client.ObjectKey]*entry),
 		indexers:      make(map[schema.GroupVersionKind]map[string]client.IndexerFunc),
 		writeLocks:    newKeyedMutex(),
@@ -186,6 +199,7 @@ func (c *Overlay) upsert(gvk schema.GroupVersionKind, obj client.Object) {
 		deleted:         false,
 		expiresAt:       time.Now().Add(c.ttl),
 	}
+	c.noteSizeLocked(gvk)
 }
 
 // tombstone marks the object as deleted in the overlay so it is filtered out
@@ -201,6 +215,7 @@ func (c *Overlay) tombstone(gvk schema.GroupVersionKind, obj client.Object) {
 		deleted:         true,
 		expiresAt:       time.Now().Add(c.ttl),
 	}
+	c.noteSizeLocked(gvk)
 }
 
 // evictIfSeen removes the overlay entry for obj if the informer-observed object
@@ -227,6 +242,7 @@ func (c *Overlay) evictIfSeen(gvk schema.GroupVersionKind, obj client.Object) {
 		return
 	}
 	delete(entries, key)
+	c.noteSizeLocked(gvk)
 }
 
 // getEntry returns the overlay entry for the key, if present.
@@ -245,11 +261,16 @@ func (c *Overlay) getEntry(gvk schema.GroupVersionKind, key client.ObjectKey) (*
 func (c *Overlay) cleanupExpired(now time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for _, entries := range c.byGVK {
+	for gvk, entries := range c.byGVK {
+		changed := false
 		for key, e := range entries {
 			if now.After(e.expiresAt) {
 				delete(entries, key)
+				changed = true
 			}
+		}
+		if changed {
+			c.noteSizeLocked(gvk)
 		}
 	}
 }
@@ -270,6 +291,12 @@ func (c *Overlay) ensureGVK(gvk schema.GroupVersionKind) {
 	if c.byGVK[gvk] == nil {
 		c.byGVK[gvk] = make(map[client.ObjectKey]*entry)
 	}
+}
+
+// noteSizeLocked reports the current overlay size for the GVK to the monitor.
+// Callers must hold c.mu. Nil-safe when there is no monitor.
+func (c *Overlay) noteSizeLocked(gvk schema.GroupVersionKind) {
+	c.monitor.observeSize(c.host, gvk, len(c.byGVK[gvk]))
 }
 
 // overlayList merges the overlay entries for the GVK into the informer result,
@@ -463,6 +490,7 @@ func (c *Overlay) DeleteAllOf(ctx context.Context, obj client.Object, opts ...cl
 			expiresAt:       time.Now().Add(c.ttl),
 		}
 	}
+	c.noteSizeLocked(gvk)
 	return nil
 }
 

--- a/pkg/cache/client_test.go
+++ b/pkg/cache/client_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	toolscachek8s "k8s.io/client-go/tools/cache"
 	ccache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -109,11 +110,19 @@ type fakeCluster struct {
 	client client.Client
 	cache  *fakeCache
 	scheme *runtime.Scheme
+	host   string
 }
 
 func (f *fakeCluster) GetClient() client.Client   { return f.client }
 func (f *fakeCluster) GetCache() ccache.Cache     { return f.cache }
 func (f *fakeCluster) GetScheme() *runtime.Scheme { return f.scheme }
+func (f *fakeCluster) GetConfig() *rest.Config {
+	host := f.host
+	if host == "" {
+		host = "test-host"
+	}
+	return &rest.Config{Host: host}
+}
 
 // fakeClient exposes the underlying informer so eviction tests can fire events,
 // while itself acting as a cluster.Cluster wrapping the fake client.Client.
@@ -270,7 +279,7 @@ func clusterFor(t *testing.T, inner client.Client) cluster.Cluster {
 // cachingFrom builds a *Overlay over the given cluster.Cluster.
 func cachingFrom(t *testing.T, cl cluster.Cluster, conf Config) *Overlay {
 	t.Helper()
-	wrapped, runnable, err := WrapCluster(cl, conf)
+	wrapped, runnable, err := WrapCluster(cl, conf, nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -321,7 +330,7 @@ func waitFor(t *testing.T, cond func() bool) {
 func TestNewUnknownGVKError(t *testing.T) {
 	_, _, err := WrapCluster(newTestClient(t).fakeCluster, Config{
 		GVKs: []string{"cortex.cloud/v1alpha1/DoesNotExist"},
-	})
+	}, nil)
 	if err == nil {
 		t.Fatalf("expected error for unknown GVK, got nil")
 	}
@@ -348,7 +357,7 @@ func TestNewExplicitTTL(t *testing.T) {
 
 func TestNewWrapsClusterClientAndIndexer(t *testing.T) {
 	inner := newTestClient(t)
-	wrapped, runnable, err := WrapCluster(inner.fakeCluster, reservationConfig())
+	wrapped, runnable, err := WrapCluster(inner.fakeCluster, reservationConfig(), nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/pkg/cache/cluster.go
+++ b/pkg/cache/cluster.go
@@ -37,19 +37,30 @@ func (w *overlayCluster) GetFieldIndexer() client.FieldIndexer { return w.cache 
 // manager at construction time because the ClusterWrapper interface does not
 // pass a manager to WrapCluster.
 type Wrapper struct {
-	mgr  manager.Manager
-	conf Config
+	mgr     manager.Manager
+	conf    Config
+	monitor *Monitor
 }
 
 // NewWrapper returns a Wrapper that applies the overlay cache to any cluster
 // passed to WrapCluster, registering the overlay's lifecycle Runnable with mgr.
-func NewWrapper(mgr manager.Manager, conf Config) *Wrapper { return &Wrapper{mgr, conf} }
+// The monitor is shared across every wrapped cluster and is supplied by the
+// caller (so this library package hardcodes no project-specific metric prefix);
+// it may be nil to disable overlay size metrics. Register it on the metrics
+// registry from the caller.
+func NewWrapper(mgr manager.Manager, conf Config, monitor *Monitor) *Wrapper {
+	return &Wrapper{
+		mgr:     mgr,
+		conf:    conf,
+		monitor: monitor,
+	}
+}
 
 // WrapCluster applies the overlay cache to cl, registers the overlay's lifecycle
 // Runnable with the captured manager, and returns the wrapped cluster.
 // Satisfies multicluster.ClusterWrapper structurally.
 func (w *Wrapper) WrapCluster(cl cluster.Cluster) (cluster.Cluster, error) {
-	wrapped, cleanUpRunnable, err := WrapCluster(cl, w.conf)
+	wrapped, cleanUpRunnable, err := WrapCluster(cl, w.conf, w.monitor)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/monitor.go
+++ b/pkg/cache/monitor.go
@@ -1,0 +1,111 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// gvkHostKey identifies one overlay-size series: a cached GVK on a specific
+// cluster (identified by its rest config Host). One Monitor is shared across
+// all overlays (home + remotes), so the host discriminates between them.
+type gvkHostKey struct {
+	gvk  schema.GroupVersionKind
+	host string
+}
+
+// sizeStat holds the current and high-watermark entry counts for one series.
+type sizeStat struct {
+	current int
+	max     int
+}
+
+// Monitor is a standalone prometheus.Collector that tracks the overlay's
+// per-(gvk, host) entry count. It exposes both the current size and a
+// high-watermark that is reset to the current size on every Collect, so
+// transient spikes are captured even when the overlay is empty at scrape time.
+//
+// Overlay entries are extremely short-lived (evicted within milliseconds once
+// the informer observes the write), so a plain gauge sampled at scrape time
+// would almost always read zero. A consistently non-zero high-watermark is a
+// strong signal that eviction is broken (informer lag, UID mismatch, TTL
+// fallback firing).
+type Monitor struct {
+	maxDesc     *prometheus.Desc
+	currentDesc *prometheus.Desc
+
+	mu    sync.Mutex
+	stats map[gvkHostKey]*sizeStat
+}
+
+// NewMonitor returns a Monitor whose metric names are prefixed with prefix
+// (e.g. "cortex_" yields "cortex_cache_overlay_entries").
+func NewMonitor(prefix string) *Monitor {
+	labels := []string{"gvk", "host"}
+	return &Monitor{
+		maxDesc: prometheus.NewDesc(
+			prefix+"cache_overlay_entries_max",
+			"High-watermark of pending-cache overlay entries (live + tombstone) "+
+				"per gvk and host since the last scrape; reset on each scrape.",
+			labels, nil,
+		),
+		currentDesc: prometheus.NewDesc(
+			prefix+"cache_overlay_entries",
+			"Current number of pending-cache overlay entries (live + tombstone) "+
+				"per gvk and host at scrape time.",
+			labels, nil,
+		),
+		stats: make(map[gvkHostKey]*sizeStat),
+	}
+}
+
+// observeSize records that the overlay for (host, gvk) currently holds n
+// entries, bumping the high-watermark if n exceeds it. It is called by the
+// Overlay under its own lock after every entry-count change. Nil-safe: a nil
+// receiver (cache running without a monitor) is a no-op.
+func (m *Monitor) observeSize(host string, gvk schema.GroupVersionKind, n int) {
+	if m == nil {
+		return
+	}
+	key := gvkHostKey{gvk: gvk, host: host}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := m.stats[key]
+	if s == nil {
+		s = &sizeStat{}
+		m.stats[key] = s
+	}
+	s.current = n
+	if n > s.max {
+		s.max = n
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (m *Monitor) Describe(ch chan<- *prometheus.Desc) {
+	ch <- m.maxDesc
+	ch <- m.currentDesc
+}
+
+// Collect implements prometheus.Collector. It emits the current size and the
+// high-watermark for every observed series, then resets each high-watermark to
+// the current size so the next scrape measures a fresh window.
+func (m *Monitor) Collect(ch chan<- prometheus.Metric) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, s := range m.stats {
+		gvkStr := key.gvk.GroupVersion().String() + "/" + key.gvk.Kind
+		ch <- prometheus.MustNewConstMetric(
+			m.currentDesc, prometheus.GaugeValue, float64(s.current), gvkStr, key.host,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			m.maxDesc, prometheus.GaugeValue, float64(s.max), gvkStr, key.host,
+		)
+		// Reset the window: the next scrape measures the peak since now.
+		s.max = s.current
+	}
+}

--- a/pkg/cache/monitor_test.go
+++ b/pkg/cache/monitor_test.go
@@ -1,0 +1,177 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// gvkString mirrors the label the Monitor emits for a GVK.
+func gvkString(gvk schema.GroupVersionKind) string {
+	return gvk.GroupVersion().String() + "/" + gvk.Kind
+}
+
+// gaugeValue gathers the monitor via a registry and returns the value of the
+// named metric for the given gvk/host labels. It reports whether a series with
+// those labels was found.
+func gaugeValue(t *testing.T, m *Monitor, name, gvk, host string) (float64, bool) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(m); err != nil {
+		t.Fatalf("register monitor: %v", err)
+	}
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, met := range f.GetMetric() {
+			if labelMatches(met, gvk, host) {
+				return met.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func labelMatches(met *dto.Metric, gvk, host string) bool {
+	var gotGVK, gotHost string
+	for _, l := range met.GetLabel() {
+		switch l.GetName() {
+		case "gvk":
+			gotGVK = l.GetValue()
+		case "host":
+			gotHost = l.GetValue()
+		}
+	}
+	return gotGVK == gvk && gotHost == host
+}
+
+const (
+	maxMetric     = "cortex_cache_overlay_entries_max"
+	currentMetric = "cortex_cache_overlay_entries"
+)
+
+// TestMonitorWatermarkBeforeScrape checks the max reflects the peak on the very
+// first scrape, even after entries are evicted below it.
+func TestMonitorWatermarkBeforeScrape(t *testing.T) {
+	m := NewMonitor("cortex_")
+	gvk := reservationGVK()
+	host := "cluster-a"
+	gvkStr := gvkString(gvk)
+
+	m.observeSize(host, gvk, 1)
+	m.observeSize(host, gvk, 2)
+	m.observeSize(host, gvk, 3)
+	m.observeSize(host, gvk, 1) // evicted back down
+
+	if got, ok := gaugeValue(t, m, maxMetric, gvkStr, host); !ok || got != 3 {
+		t.Fatalf("max: got %v (found=%v), want 3", got, ok)
+	}
+}
+
+// TestMonitorCollectResetsWindow verifies the high-watermark resets to the
+// current size after a Collect, so the next scrape measures a fresh window.
+func TestMonitorCollectResetsWindow(t *testing.T) {
+	m := NewMonitor("cortex_")
+	gvk := reservationGVK()
+	host := "cluster-a"
+	gvkStr := gvkString(gvk)
+
+	m.observeSize(host, gvk, 3)
+	m.observeSize(host, gvk, 1)
+
+	// First scrape sees the peak of 3 and resets max to current (1).
+	if got, _ := gaugeValue(t, m, maxMetric, gvkStr, host); got != 3 {
+		t.Fatalf("first scrape max: got %v, want 3", got)
+	}
+	// Second scrape (no further writes) reports max == current == 1.
+	max, _ := gaugeValue(t, m, maxMetric, gvkStr, host)
+	cur, _ := gaugeValue(t, m, currentMetric, gvkStr, host)
+	if max != cur || max != 1 {
+		t.Fatalf("second scrape: max=%v current=%v, want both 1", max, cur)
+	}
+}
+
+// TestMonitorCurrentTracksLiveSize verifies the current gauge follows the real
+// entry count as writes and evictions happen through the Overlay.
+func TestMonitorCurrentTracksLiveSize(t *testing.T) {
+	m := NewMonitor("cortex_")
+	c := cachingFrom(t, newTestClient(t).fakeCluster, reservationConfig())
+	c.monitor = m
+	c.host = "cluster-a"
+	gvk := reservationGVK()
+	gvkStr := gvkString(gvk)
+
+	// Add two live entries.
+	c.upsert(gvk, newReservation("res-1", "az-1", "1"))
+	c.upsert(gvk, newReservation("res-2", "az-1", "1"))
+	if got, ok := gaugeValue(t, m, currentMetric, gvkStr, "cluster-a"); !ok || got != 2 {
+		t.Fatalf("after upserts: got %v (found=%v), want 2", got, ok)
+	}
+
+	// Evict both via informer-observed objects at a >= ResourceVersion.
+	c.evictIfSeen(gvk, newReservation("res-1", "az-1", "1"))
+	c.evictIfSeen(gvk, newReservation("res-2", "az-1", "1"))
+	if got, _ := gaugeValue(t, m, currentMetric, gvkStr, "cluster-a"); got != 0 {
+		t.Fatalf("after evictions: got %v, want 0", got)
+	}
+}
+
+// TestMonitorCountsTombstones verifies both live entries and tombstones are
+// counted in the overlay size.
+func TestMonitorCountsTombstones(t *testing.T) {
+	m := NewMonitor("cortex_")
+	c := cachingFrom(t, newTestClient(t).fakeCluster, reservationConfig())
+	c.monitor = m
+	c.host = "cluster-a"
+	gvk := reservationGVK()
+	gvkStr := gvkString(gvk)
+
+	c.upsert(gvk, newReservation("res-live", "az-1", "1"))
+	c.tombstone(gvk, newReservation("res-dead", "az-1", "1"))
+	if got, ok := gaugeValue(t, m, currentMetric, gvkStr, "cluster-a"); !ok || got != 2 {
+		t.Fatalf("live+tombstone: got %v (found=%v), want 2", got, ok)
+	}
+}
+
+// TestMonitorPerHostSeparation verifies that two overlays sharing one Monitor
+// but reporting different hosts produce distinct series.
+func TestMonitorPerHostSeparation(t *testing.T) {
+	m := NewMonitor("cortex_")
+	gvk := reservationGVK()
+	gvkStr := gvkString(gvk)
+
+	m.observeSize("cluster-a", gvk, 5)
+	m.observeSize("cluster-b", gvk, 2)
+
+	if got, ok := gaugeValue(t, m, currentMetric, gvkStr, "cluster-a"); !ok || got != 5 {
+		t.Fatalf("cluster-a: got %v (found=%v), want 5", got, ok)
+	}
+	if got, ok := gaugeValue(t, m, currentMetric, gvkStr, "cluster-b"); !ok || got != 2 {
+		t.Fatalf("cluster-b: got %v (found=%v), want 2", got, ok)
+	}
+}
+
+// TestMonitorNilSafe verifies that a nil *Monitor and an Overlay with no monitor
+// do not panic on size observation.
+func TestMonitorNilSafe(t *testing.T) {
+	var m *Monitor
+	m.observeSize("host", reservationGVK(), 3) // must not panic
+
+	// An Overlay built with a nil monitor (via WrapCluster(..., nil)) must not
+	// panic when its entry count changes.
+	c := cachingFrom(t, newTestClient(t).fakeCluster, reservationConfig())
+	if c.monitor != nil {
+		t.Fatalf("expected nil monitor on default overlay")
+	}
+	c.upsert(reservationGVK(), newReservation("res-nil", "az-1", "1"))
+}

--- a/pkg/cache/monitor_test.go
+++ b/pkg/cache/monitor_test.go
@@ -94,10 +94,10 @@ func TestMonitorCollectResetsWindow(t *testing.T) {
 		t.Fatalf("first scrape max: got %v, want 3", got)
 	}
 	// Second scrape (no further writes) reports max == current == 1.
-	max, _ := gaugeValue(t, m, maxMetric, gvkStr, host)
+	maxOverTime, _ := gaugeValue(t, m, maxMetric, gvkStr, host)
 	cur, _ := gaugeValue(t, m, currentMetric, gvkStr, host)
-	if max != cur || max != 1 {
-		t.Fatalf("second scrape: max=%v current=%v, want both 1", max, cur)
+	if maxOverTime != cur || maxOverTime != 1 {
+		t.Fatalf("second scrape: max=%v current=%v, want both 1", maxOverTime, cur)
 	}
 }
 


### PR DESCRIPTION
Adds a high-watermark size metric for the pending-cache overlay. Because overlay entries are evicted within milliseconds, a plain gauge would almost always read zero and give no signal. So `cache.Monitor` tracks the peak entry count per (gvk, host) between scrapes and resets it on each Collect, alongside the current size at scrape.

- `cortex_cache_overlay_entries_max{gvk,host}` - high-watermark since last scrape (reset on scrape)
- `cortex_cache_overlay_entries{gvk,host} ` - current entry count

With that we can track that if the eviction is working as intended or if there is a memory leak