### PR TITLE
feat: add physical host size label to vmware capacity metrics

### DIFF
--- a/internal/knowledge/extractor/plugins/compute/host_details.go
+++ b/internal/knowledge/extractor/plugins/compute/host_details.go
@@ -42,6 +42,11 @@ type HostDetails struct {
 	DisabledReason *string `db:"disabled_reason"`
 	// Comma separated list of pinned projects of the ComputeHost.
 	PinnedProjects *string `db:"pinned_projects"`
+	// Physical size category of a single host inside a VMware building block,
+	// derived from the memory inventory and rounded to the nearest TiB
+	// (e.g. "4TiB"), or to the nearest GiB (e.g. "512GiB") when smaller than
+	// 1 TiB. Only meaningful for VMware hosts; "unknown" otherwise.
+	PhysicalHostSize string `db:"physical_host_size"`
 }
 
 type HostDetailsExtractor struct {

--- a/internal/knowledge/extractor/plugins/compute/host_details.sql
+++ b/internal/knowledge/extractor/plugins/compute/host_details.sql
@@ -1,5 +1,6 @@
 WITH host_traits AS (
     SELECT
+        h.id AS hypervisor_id,
         h.service_host,
         h.hypervisor_type,
         h.running_vms,
@@ -10,7 +11,23 @@ WITH host_traits AS (
     FROM openstack_hypervisors h
     LEFT JOIN openstack_resource_provider_traits t
         ON h.id = t.resource_provider_uuid
-    GROUP BY h.service_host, h.hypervisor_type, h.running_vms, h.state, h.status, h.service_disabled_reason
+    GROUP BY h.id, h.service_host, h.hypervisor_type, h.running_vms, h.state, h.status, h.service_disabled_reason
+),
+-- Physical memory size (in MiB) of a single host inside a VMware building block.
+-- A building block pools multiple physical hosts into one resource provider, so
+-- the per-host memory size is recovered from the pooled memory inventory:
+--   amount_hosts        = (total - reserved) / max_unit
+--   physical_host_size  = max_unit + reserved / amount_hosts   (in MiB)
+host_physical_memory AS (
+    SELECT
+        i.resource_provider_uuid,
+        i.max_unit
+            + i.reserved / ((i.total - i.reserved) / CAST(i.max_unit AS FLOAT))
+            AS physical_size_mb
+    FROM openstack_resource_provider_inventory_usages i
+    WHERE i.inventory_class_name = 'MEMORY_MB'
+        AND i.max_unit > 0
+        AND (i.total - i.reserved) > 0
 )
 SELECT
     ht.service_host AS compute_host,
@@ -49,5 +66,17 @@ SELECT
         WHEN ht.status != 'enabled' THEN '[disabled] ' || COALESCE(ht.service_disabled_reason, '--')
         WHEN ht.state != 'up' THEN '[down] ' || COALESCE(ht.service_disabled_reason, '--')
         ELSE NULL
-    END AS disabled_reason
-FROM host_traits ht;
+    END AS disabled_reason,
+    -- Physical host size category. The size is first rounded to whole GiB; if
+    -- that is at least 1024 GiB it is reported in TiB ("<n>TiB"), otherwise in
+    -- GiB ("<n>GiB"). Rounding to GiB first avoids a value like 1023.6 GiB being
+    -- shown as "1024GiB" instead of "1TiB".
+    CASE
+        WHEN hpm.physical_size_mb IS NULL THEN 'unknown'
+        WHEN ROUND(hpm.physical_size_mb / 1024.0) >= 1024
+        THEN CAST(CAST(ROUND(ROUND(hpm.physical_size_mb / 1024.0) / 1024.0) AS INTEGER) AS TEXT) || 'TiB'
+        ELSE CAST(CAST(ROUND(hpm.physical_size_mb / 1024.0) AS INTEGER) AS TEXT) || 'GiB'
+    END AS physical_host_size
+FROM host_traits ht
+LEFT JOIN host_physical_memory hpm
+    ON ht.hypervisor_id = hpm.resource_provider_uuid;

--- a/internal/knowledge/extractor/plugins/compute/host_details_test.go
+++ b/internal/knowledge/extractor/plugins/compute/host_details_test.go
@@ -38,6 +38,7 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 	if err := testDB.CreateTable(
 		testDB.AddTable(nova.Hypervisor{}),
 		testDB.AddTable(placement.Trait{}),
+		testDB.AddTable(placement.InventoryUsage{}),
 	); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -69,6 +70,10 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 		&nova.Hypervisor{ID: "uuid5", ServiceHost: "node003-bb03", HypervisorType: "test", RunningVMs: 2, State: "up", Status: "disabled", ServiceDisabledReason: new("example reason")},
 		// Host with disabled trait
 		&nova.Hypervisor{ID: "uuid6", ServiceHost: "node004-bb03", HypervisorType: "test", RunningVMs: 2, State: "up", Status: "enabled", ServiceDisabledReason: new("example reason")},
+		// VMware host with a sub-TiB physical host size
+		&nova.Hypervisor{ID: "uuid7", ServiceHost: "nova-compute-bb04", HypervisorType: "vcenter", RunningVMs: 1, State: "up", Status: "enabled"},
+		// VMware host just under 1 TiB that rounds up to a full TiB
+		&nova.Hypervisor{ID: "uuid8", ServiceHost: "nova-compute-bb05", HypervisorType: "vcenter", RunningVMs: 1, State: "up", Status: "enabled"},
 	}
 
 	if err := testDB.Insert(hypervisors...); err != nil {
@@ -94,6 +99,42 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
+	// Memory inventory for the VMware building block host (uuid1). The building
+	// block pools 3 physical hosts of 4 TiB each (4 TiB = 4194304 MiB):
+	//   amount_hosts       = (total - reserved) / max_unit = 12582912 / 4194304 = 3
+	//   physical_host_size = max_unit + reserved / amount_hosts = 4194304 MiB = 4 TiB
+	inventories := []any{
+		&placement.InventoryUsage{
+			ResourceProviderUUID: "uuid1",
+			InventoryClassName:   "MEMORY_MB",
+			Total:                12582912,
+			Reserved:             0,
+			MaxUnit:              4194304,
+		},
+		// Building block of 2 physical hosts of 512 GiB each (512 GiB = 524288 MiB):
+		//   amount_hosts       = (1048576 - 0) / 524288 = 2
+		//   physical_host_size = 524288 MiB = 512 GiB (< 1 TiB, reported in GiB)
+		&placement.InventoryUsage{
+			ResourceProviderUUID: "uuid7",
+			InventoryClassName:   "MEMORY_MB",
+			Total:                1048576,
+			Reserved:             0,
+			MaxUnit:              524288,
+		},
+		// Single host of 1048064 MiB (1023.5 GiB) which rounds to 1024 GiB and is
+		// therefore reported as "1TiB" rather than "1024GiB".
+		&placement.InventoryUsage{
+			ResourceProviderUUID: "uuid8",
+			InventoryClassName:   "MEMORY_MB",
+			Total:                1048064,
+			Reserved:             0,
+			MaxUnit:              1048064,
+		},
+	}
+	if err := testDB.Insert(inventories...); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
 	hostAvailabilityZones, err := v1alpha1.BoxFeatureList([]any{
 		&HostAZ{AvailabilityZone: new("az1"), ComputeHost: "nova-compute-bb01"},
 		&HostAZ{AvailabilityZone: nil, ComputeHost: "node001-bb02"},
@@ -101,6 +142,8 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 		&HostAZ{AvailabilityZone: new("az2"), ComputeHost: "ironic-host-01"},
 		&HostAZ{AvailabilityZone: new("az2"), ComputeHost: "node003-bb03"},
 		&HostAZ{AvailabilityZone: new("az2"), ComputeHost: "node004-bb03"},
+		&HostAZ{AvailabilityZone: new("az1"), ComputeHost: "nova-compute-bb04"},
+		&HostAZ{AvailabilityZone: new("az1"), ComputeHost: "nova-compute-bb05"},
 	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -141,6 +184,7 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 			DisabledReason:   nil,
 			RunningVMs:       0,
 			PinnedProjects:   nil,
+			PhysicalHostSize: "unknown",
 		},
 		{
 			ComputeHost:      "node001-bb02",
@@ -155,6 +199,7 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 			DisabledReason:   new("[down] --"),
 			RunningVMs:       3,
 			PinnedProjects:   nil,
+			PhysicalHostSize: "unknown",
 		},
 		{
 			ComputeHost:      "node002-bb03",
@@ -169,6 +214,7 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 			DisabledReason:   nil,
 			RunningVMs:       2,
 			PinnedProjects:   nil,
+			PhysicalHostSize: "unknown",
 		},
 		{
 			ComputeHost:      "node003-bb03",
@@ -183,6 +229,7 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 			DisabledReason:   new("[disabled] example reason"),
 			RunningVMs:       2,
 			PinnedProjects:   nil,
+			PhysicalHostSize: "unknown",
 		},
 		{
 			ComputeHost:      "node004-bb03",
@@ -197,6 +244,7 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 			DisabledReason:   new("[disabled] example reason"),
 			RunningVMs:       2,
 			PinnedProjects:   nil,
+			PhysicalHostSize: "unknown",
 		},
 		{
 			ComputeHost:      "nova-compute-bb01",
@@ -211,6 +259,37 @@ func TestHostDetailsExtractor_Extract(t *testing.T) {
 			DisabledReason:   nil,
 			RunningVMs:       5,
 			PinnedProjects:   new("project-123,project-456"),
+			PhysicalHostSize: "4TiB",
+		},
+		{
+			ComputeHost:      "nova-compute-bb04",
+			AvailabilityZone: "az1",
+			CPUArchitecture:  "cascade-lake",
+			HypervisorType:   "vcenter",
+			HypervisorFamily: "vmware",
+			WorkloadType:     "general-purpose",
+			Enabled:          true,
+			Decommissioned:   false,
+			ExternalCustomer: false,
+			DisabledReason:   nil,
+			RunningVMs:       1,
+			PinnedProjects:   nil,
+			PhysicalHostSize: "512GiB",
+		},
+		{
+			ComputeHost:      "nova-compute-bb05",
+			AvailabilityZone: "az1",
+			CPUArchitecture:  "cascade-lake",
+			HypervisorType:   "vcenter",
+			HypervisorFamily: "vmware",
+			WorkloadType:     "general-purpose",
+			Enabled:          true,
+			Decommissioned:   false,
+			ExternalCustomer: false,
+			DisabledReason:   nil,
+			RunningVMs:       1,
+			PinnedProjects:   nil,
+			PhysicalHostSize: "1TiB",
 		},
 	}
 

--- a/internal/knowledge/kpis/plugins/infrastructure/shared.go
+++ b/internal/knowledge/kpis/plugins/infrastructure/shared.go
@@ -40,6 +40,10 @@ func (h vmwareHost) getHostLabels() []string {
 	if h.DisabledReason != nil {
 		disabledReason = *h.DisabledReason
 	}
+	physicalHostSize := h.PhysicalHostSize
+	if physicalHostSize == "" {
+		physicalHostSize = "unknown"
+	}
 	return []string{
 		h.AvailabilityZone,
 		h.ComputeHost,
@@ -51,6 +55,7 @@ func (h vmwareHost) getHostLabels() []string {
 		disabledReason,
 		strconv.FormatBool(pinnedProjects),
 		pinnedProjectIds,
+		physicalHostSize,
 	}
 }
 
@@ -65,6 +70,7 @@ var vmwareHostLabels = []string{
 	"disabled_reason",
 	"pinned_projects",
 	"pinned_project_ids",
+	"physical_host_size",
 }
 
 var kvmHostLabels = []string{

--- a/internal/knowledge/kpis/plugins/infrastructure/shared_test.go
+++ b/internal/knowledge/kpis/plugins/infrastructure/shared_test.go
@@ -44,6 +44,7 @@ func mockVMwareHostLabels(computeHost, az string) map[string]string {
 		"disabled_reason":    "-",
 		"pinned_projects":    "false",
 		"pinned_project_ids": "",
+		"physical_host_size": "unknown",
 	}
 }
 
@@ -68,7 +69,7 @@ func TestVMwareHost_GetHostLabels(t *testing.T) {
 				DisabledReason:   nil,
 				PinnedProjects:   nil,
 			}},
-			want: []string{"az1", "nova-compute-1", "cascade-lake", "general-purpose", "true", "false", "false", "-", "false", ""},
+			want: []string{"az1", "nova-compute-1", "cascade-lake", "general-purpose", "true", "false", "false", "-", "false", "", "unknown"},
 		},
 		{
 			name: "disabled reason set",
@@ -77,7 +78,7 @@ func TestVMwareHost_GetHostLabels(t *testing.T) {
 				ComputeHost:      "nova-compute-2",
 				DisabledReason:   str("scheduled-maintenance"),
 			}},
-			want: []string{"az2", "nova-compute-2", "", "", "false", "false", "false", "scheduled-maintenance", "false", ""},
+			want: []string{"az2", "nova-compute-2", "", "", "false", "false", "false", "scheduled-maintenance", "false", "", "unknown"},
 		},
 		{
 			name: "pinned projects set",
@@ -86,7 +87,7 @@ func TestVMwareHost_GetHostLabels(t *testing.T) {
 				ComputeHost:      "nova-compute-3",
 				PinnedProjects:   str("proj-a,proj-b"),
 			}},
-			want: []string{"az1", "nova-compute-3", "", "", "false", "false", "false", "-", "true", "proj-a,proj-b"},
+			want: []string{"az1", "nova-compute-3", "", "", "false", "false", "false", "-", "true", "proj-a,proj-b", "unknown"},
 		},
 		{
 			name: "decommissioned and external customer",
@@ -96,7 +97,16 @@ func TestVMwareHost_GetHostLabels(t *testing.T) {
 				Decommissioned:   true,
 				ExternalCustomer: true,
 			}},
-			want: []string{"az3", "nova-compute-4", "", "", "false", "true", "true", "-", "false", ""},
+			want: []string{"az3", "nova-compute-4", "", "", "false", "true", "true", "-", "false", "", "unknown"},
+		},
+		{
+			name: "physical host size set",
+			host: vmwareHost{compute.HostDetails{
+				AvailabilityZone: "az1",
+				ComputeHost:      "nova-compute-5",
+				PhysicalHostSize: "4TiB",
+			}},
+			want: []string{"az1", "nova-compute-5", "", "", "false", "false", "false", "-", "false", "", "4TiB"},
 		},
 	}
 


### PR DESCRIPTION
Adds a `physical_host_size` label to the VMware host capacity metrics so hosts can be filtered by their physical memory size category (e.g. 4TiB, 8TiB). A VMware building block groups multiple physical hosts into a single placement resource provider, so the per-host size is recovered from the pooled memory inventory using 

`available_ram = total - reserved`
`amount_hosts = available_ram / max_unit` 
`physical_host_size = max_unit + reserved / amount_hosts`. 

The size is computed in the host-details extractor, rounded to whole GiB, and reported as..

.. TiB when it reaches 1024 GiB 
.. or GiB otherwise (falling back to unknown when inventory is missing).