### PR TITLE
fix: update Go version in Dockerfile to 1.27 and remove go constraints

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,6 @@
   ],
   "commitMessageAction": "Renovate: Update",
   "constraints": {
-    "go": "1.26",
     "python": "3.13"
   },
   "dependencyDashboardOSVVulnerabilitySummary": "all",
@@ -73,12 +72,6 @@
     }
   ],
   "packageRules": [
-    {
-      "matchPackageNames": [
-        "golang"
-      ],
-      "allowedVersions": "1.26.x"
-    },
     {
       "matchPackageNames": [
         "postgresql-18"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM golang:1.27 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 # Path of our go.mod


### PR DESCRIPTION
`go mod tidy` bumped go.mod to `1.27` as a side effect of a go-bits update, but the Dockerfile and Renovate config were still locked to 1.26, breaking Docker builds. I don't see any reason why we should limit the go version at all, so I removed these constraints.