### PR TITLE
Make placement shim self-healing and apiserver-decoupled

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -31,6 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -364,6 +365,15 @@ func main() {
 			Metrics:                metricsServerOptions,
 			WebhookServer:          webhookServer,
 			HealthProbeBindAddress: managerProbeAddr,
+			// In self-heal mode the supervisor rebuilds this manager on every
+			// connectivity failure, re-registering the same controller name
+			// ("placement-shim") and its metrics. controller-runtime's
+			// process-global name-uniqueness check would reject the rebuilt
+			// controller ("controller with name ... already exists"), so skip it
+			// here: the collision is intentional and expected across restarts.
+			// The coupled path never rebuilds, so it keeps validation on to catch
+			// a genuine double-registration bug.
+			Controller: config.Controller{SkipNameValidation: &selfHeal},
 			// Kept for consistency with kubebuilder scaffold, but the shim should
 			// always run with leader election disabled.
 			LeaderElection: enableLeaderElection,

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -381,10 +381,16 @@ func main() {
 			// Drive the shim's cache-readiness flag: mark ready once this
 			// manager's cache has synced, and clear it when the cycle returns so
 			// cache-backed handlers degrade to 503 while the manager is down or
-			// restarting. Passthrough handlers ignore the flag.
-			defer placementShim.SetManagerReady(false)
+			// restarting. Passthrough handlers ignore the flag. The goroutine uses
+			// a per-cycle context cancelled on return so WaitForCacheSync cannot
+			// block or set readiness after this manager has already exited.
+			cacheCtx, cancelCacheSync := context.WithCancel(ctx)
+			defer func() {
+				cancelCacheSync()
+				placementShim.SetManagerReady(false)
+			}()
 			go func() {
-				if mgr.GetCache().WaitForCacheSync(ctx) {
+				if mgr.GetCache().WaitForCacheSync(cacheCtx) {
 					placementShim.SetManagerReady(true)
 				}
 			}()

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -378,6 +378,16 @@ func main() {
 			if err := placementShim.SetupControllerWithManager(ctx, mgr, multiclusterClient); err != nil {
 				return fmt.Errorf("unable to set up placement shim controller: %w", err)
 			}
+			// Drive the shim's cache-readiness flag: mark ready once this
+			// manager's cache has synced, and clear it when the cycle returns so
+			// cache-backed handlers degrade to 503 while the manager is down or
+			// restarting. Passthrough handlers ignore the flag.
+			defer placementShim.SetManagerReady(false)
+			go func() {
+				if mgr.GetCache().WaitForCacheSync(ctx) {
+					placementShim.SetManagerReady(true)
+				}
+			}()
 		}
 
 		if metricsCertWatcher != nil {

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -141,10 +141,23 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Check that the metrics and API bind addresses don't overlap.
-	if metricsAddr != "0" && metricsAddr == apiBindAddr {
+	// The probe, API and (when enabled) metrics endpoints each bind their own
+	// listener, so their addresses must all differ. Reject overlaps up front with
+	// a clear message rather than failing later with an opaque bind error. The
+	// metrics address "0" means "no metrics server", so it is exempt.
+	metricsBinds := metricsAddr != "0"
+	switch {
+	case probeAddr == apiBindAddr:
+		err := errors.New("health-probe-bind-address and api-bind-address must not be the same")
+		setupLog.Error(err, "invalid configuration", "health-probe-bind-address", probeAddr, "api-bind-address", apiBindAddr)
+		os.Exit(1)
+	case metricsBinds && metricsAddr == apiBindAddr:
 		err := errors.New("metrics-bind-address and api-bind-address must not be the same")
 		setupLog.Error(err, "invalid configuration", "metrics-bind-address", metricsAddr, "api-bind-address", apiBindAddr)
+		os.Exit(1)
+	case metricsBinds && metricsAddr == probeAddr:
+		err := errors.New("metrics-bind-address and health-probe-bind-address must not be the same")
+		setupLog.Error(err, "invalid configuration", "metrics-bind-address", metricsAddr, "health-probe-bind-address", probeAddr)
 		os.Exit(1)
 	}
 

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -309,15 +309,17 @@ func main() {
 	multiclusterMonitor := multicluster.NewMonitor("cortex_")
 	metrics.Registry.MustRegister(multiclusterMonitor)
 
-	// managerUp reports whether a controller-manager is currently running: 1
-	// while a manager (and its cache) is up, 0 between restarts. It is served
-	// from the outer process so a crash-looping manager can be detected via
-	// alerting without ever crashing the pod. Registered once.
+	// managerUp reports whether a controller-manager with a synced cache is
+	// currently running: 1 once the manager's cache has synced, 0 while it is
+	// being (re)built, has failed, or is between restarts. It is served from the
+	// outer process so a crash-looping manager can be detected via alerting
+	// without ever crashing the pod. Registered once.
 	managerUp := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "cortex_placement_shim_manager_up",
-		Help: "1 while the placement shim controller-manager is running, 0 while it is being (re)built. " +
-			"A value stuck at 0 indicates the manager cannot reach the apiserver / is crash-looping " +
-			"while the shim keeps serving in passthrough mode.",
+		Help: "1 while the placement shim controller-manager is running with a synced cache, 0 while it is " +
+			"being (re)built or has failed. A value that stays low (see the manager-looping alert) indicates " +
+			"the manager cannot reach the apiserver / is crash-looping while the shim keeps serving in " +
+			"passthrough mode.",
 	})
 	metrics.Registry.MustRegister(managerUp)
 
@@ -379,36 +381,47 @@ func main() {
 			if err := placementShim.SetupControllerWithManager(ctx, mgr, multiclusterClient); err != nil {
 				return fmt.Errorf("unable to set up placement shim controller: %w", err)
 			}
-			// Drive the shim's cache-readiness flag: mark ready once this
-			// manager's cache has synced, and clear it when the cycle returns so
-			// cache-backed handlers degrade to 503 while the manager is down or
-			// restarting. Passthrough handlers ignore the flag.
-			//
-			// A per-cycle context (cancelled on return) stops WaitForCacheSync from
-			// blocking across restarts. The mutex + cacheCtx.Err() re-check under
-			// the lock closes the ordering race where the sync goroutine has just
-			// observed a synced cache but the cycle is returning: cancelCacheSync
-			// runs before the defer takes the lock, so whichever critical section
-			// runs first, the goroutine only sets ready=true while the context is
-			// still live, and the deferred ready=false always wins the final state.
-			var readyMu sync.Mutex
-			cacheCtx, cancelCacheSync := context.WithCancel(ctx)
-			defer func() {
-				cancelCacheSync()
-				readyMu.Lock()
+		}
+
+		// Drive the manager_up gauge and (if present) the shim's cache-readiness
+		// flag: mark both once this manager's cache has synced, and clear them
+		// when the cycle returns so cache-backed handlers degrade to 503 while the
+		// manager is down or restarting. Passthrough handlers ignore the flag.
+		// The gauge deliberately tracks a *synced cache*, not merely a running
+		// build: a cycle that fails during construction never flips it to 1, so
+		// the metric (and its alert) reflects a healthy manager rather than "a
+		// cycle is executing".
+		//
+		// A per-cycle context (cancelled on return) stops WaitForCacheSync from
+		// blocking across restarts. The mutex + cacheCtx.Err() re-check under the
+		// lock closes the ordering race where the sync goroutine has just observed
+		// a synced cache but the cycle is returning: cancelCacheSync runs before
+		// the defer takes the lock, so whichever critical section runs first, the
+		// goroutine only marks ready while the context is still live, and the
+		// deferred clear always wins the final state.
+		var readyMu sync.Mutex
+		cacheCtx, cancelCacheSync := context.WithCancel(ctx)
+		defer func() {
+			cancelCacheSync()
+			readyMu.Lock()
+			managerUp.Set(0)
+			if placementShim != nil {
 				placementShim.SetManagerReady(false)
-				readyMu.Unlock()
-			}()
-			go func() {
-				if mgr.GetCache().WaitForCacheSync(cacheCtx) {
-					readyMu.Lock()
-					if cacheCtx.Err() == nil {
+			}
+			readyMu.Unlock()
+		}()
+		go func() {
+			if mgr.GetCache().WaitForCacheSync(cacheCtx) {
+				readyMu.Lock()
+				if cacheCtx.Err() == nil {
+					managerUp.Set(1)
+					if placementShim != nil {
 						placementShim.SetManagerReady(true)
 					}
-					readyMu.Unlock()
 				}
-			}()
-		}
+				readyMu.Unlock()
+			}
+		}()
 
 		if metricsCertWatcher != nil {
 			if err := mgr.Add(metricsCertWatcher); err != nil {
@@ -455,7 +468,6 @@ func main() {
 			MetricsAddr:     managerMetricsAddr,
 			MetricsGatherer: metrics.Registry,
 			Mux:             mux,
-			ManagerUp:       managerUp,
 			BuildAndStart:   buildAndStart,
 		}); err != nil {
 			setupLog.Error(err, "supervisor exited with error")
@@ -465,8 +477,8 @@ func main() {
 	}
 
 	// Coupled mode (--self-heal=false): a manager failure exits the process.
-	// This is the classic behavior kept for parity.
-	managerUp.Set(1)
+	// This is the classic behavior kept for parity. The manager_up gauge is
+	// driven from within buildAndStart (on cache sync), so it is not set here.
 	if err := buildAndStart(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -150,14 +150,22 @@ func main() {
 
 	// In self-heal mode the metrics endpoint is served by the durable outer
 	// process (plain promhttp) so it survives manager restarts, which means it
-	// cannot apply controller-runtime's authn/authz FilterProvider. Secure
-	// metrics are therefore incompatible with self-heal; the shim always runs
-	// with --metrics-secure=false, so reject the combination rather than
-	// silently serving unauthenticated metrics.
-	if selfHeal && secureMetrics && metricsAddr != "0" {
-		err := errors.New("--metrics-secure is not supported with --self-heal; run with --metrics-secure=false or --self-heal=false")
-		setupLog.Error(err, "invalid configuration")
-		os.Exit(1)
+	// cannot apply controller-runtime's authn/authz FilterProvider or serve TLS.
+	// Secure metrics and metrics TLS certs are therefore incompatible with
+	// self-heal; reject them rather than silently serving unauthenticated,
+	// plaintext metrics while a cert path implies otherwise (and needlessly
+	// spinning up a cert watcher that is never applied).
+	if selfHeal && metricsAddr != "0" {
+		switch {
+		case secureMetrics:
+			err := errors.New("--metrics-secure is not supported with --self-heal; run with --metrics-secure=false or --self-heal=false")
+			setupLog.Error(err, "invalid configuration")
+			os.Exit(1)
+		case metricsCertPath != "":
+			err := errors.New("--metrics-cert-path is not supported with --self-heal (the outer metrics server serves plain HTTP and cannot apply the cert); unset it or run with --self-heal=false")
+			setupLog.Error(err, "invalid configuration")
+			os.Exit(1)
+		}
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,8 +18,10 @@ import (
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
 	"github.com/cobaltcore-dev/cortex/pkg/monitoring"
 	"github.com/cobaltcore-dev/cortex/pkg/multicluster"
+	"github.com/cobaltcore-dev/cortex/pkg/shim/supervisor"
 	"github.com/cobaltcore-dev/cortex/pkg/sso"
 	hv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sapcc/go-bits/httpext"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -92,6 +95,7 @@ func main() {
 	var enableHTTP2 bool
 	var enablePlacementShim bool
 	var runPlacementShimE2E bool
+	var selfHeal bool
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -115,6 +119,13 @@ func main() {
 		"If set, the placement API shim handlers are registered on the API server.")
 	flag.BoolVar(&runPlacementShimE2E, "e2e-placement-shim", false,
 		"If set, runs end-to-end tests for the placement shim instead of starting the manager. ")
+	flag.BoolVar(&selfHeal, "self-heal", true,
+		"If set (the default), the controller-manager runs under a supervisor that rebuilds it "+
+			"(cache and controllers) with backoff on failure, while the REST API, liveness probe, and "+
+			"metrics endpoint run in the durable outer process and survive manager restarts. The pod never "+
+			"crashes on apiserver/cache connectivity issues; a looping manager is surfaced via the "+
+			"cortex_placement_shim_manager_up gauge instead. Set --self-heal=false to fall back to the "+
+			"coupled behavior where a manager failure exits the process.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -135,6 +146,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	// In self-heal mode the metrics endpoint is served by the durable outer
+	// process (plain promhttp) so it survives manager restarts, which means it
+	// cannot apply controller-runtime's authn/authz FilterProvider. Secure
+	// metrics are therefore incompatible with self-heal; the shim always runs
+	// with --metrics-secure=false, so reject the combination rather than
+	// silently serving unauthenticated metrics.
+	if selfHeal && secureMetrics && metricsAddr != "0" {
+		err := errors.New("--metrics-secure is not supported with --self-heal; run with --metrics-secure=false or --self-heal=false")
+		setupLog.Error(err, "invalid configuration")
+		os.Exit(1)
+	}
+
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// Custom entrypoint for placement shim e2e tests.
@@ -152,7 +175,12 @@ func main() {
 			setupLog.Error(err, "unable to start e2e manager")
 			os.Exit(1)
 		}
-		multiclusterClient := setupMulticlusterClient(mgrCtx, mgr, restConfig)
+		multiclusterClient, err := setupMulticlusterClient(mgrCtx, mgr, restConfig, multicluster.NewMonitor("cortex_"))
+		if err != nil {
+			setupLog.Error(err, "unable to set up e2e multicluster client")
+			mgrCancel()
+			os.Exit(1)
+		}
 		if err := placement.IndexFields(mgrCtx, multiclusterClient); err != nil {
 			setupLog.Error(err, "unable to set up e2e field indexes")
 			os.Exit(1)
@@ -265,108 +293,174 @@ func main() {
 		})
 	}
 
-	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                metricsServerOptions,
-		WebhookServer:          webhookServer,
-		HealthProbeBindAddress: probeAddr,
-		// Kept for consistency with kubebuilder scaffold, but the shim should
-		// always run with leader election disabled.
-		LeaderElection: enableLeaderElection,
-	})
-	if err != nil {
-		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
-	multiclusterClient := setupMulticlusterClient(ctx, mgr, restConfig)
-
 	// Our custom monitoring registry can add prometheus labels to all metrics.
-	// This is useful to distinguish metrics from different deployments.
+	// This is useful to distinguish metrics from different deployments. This is
+	// process-lifetime state: the registry and its collectors are wrapped and
+	// registered exactly once, so they stay scrapable across manager restarts in
+	// self-heal mode (MustRegister panics on a duplicate).
 	metricsConfig := conf.GetConfigOrDie[monitoring.Config]()
 	metrics.Registry = monitoring.WrapRegistry(metrics.Registry, metricsConfig)
-	metrics.Registry.MustRegister(multiclusterClient.Monitor)
 
-	// API endpoint.
+	// One multicluster Monitor for the whole process. In self-heal mode the
+	// manager (and its multicluster client) is rebuilt per cycle, but the
+	// Monitor collector must be registered only once, so it is owned here and
+	// handed to each client build.
+	multiclusterMonitor := multicluster.NewMonitor("cortex_")
+	metrics.Registry.MustRegister(multiclusterMonitor)
+
+	// managerUp reports whether a controller-manager is currently running: 1
+	// while a manager (and its cache) is up, 0 between restarts. It is served
+	// from the outer process so a crash-looping manager can be detected via
+	// alerting without ever crashing the pod. Registered once.
+	managerUp := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "cortex_placement_shim_manager_up",
+		Help: "1 while the placement shim controller-manager is running, 0 while it is being (re)built. " +
+			"A value stuck at 0 indicates the manager cannot reach the apiserver / is crash-looping " +
+			"while the shim keeps serving in passthrough mode.",
+	})
+	metrics.Registry.MustRegister(managerUp)
+
+	// API endpoint. The mux and the shim's HTTP layer are process-lifetime: the
+	// shim is initialized and its routes and metric collectors registered exactly
+	// once. In self-heal mode the supervisor rebuilds only the manager (cache +
+	// controllers) per cycle; the HTTP layer here is untouched by restarts.
 	mux := http.NewServeMux()
 	var placementShim *placement.Shim
 	if enablePlacementShim {
-		placementShim = &placement.Shim{Client: multiclusterClient}
-		setupLog.Info("Adding placement shim to manager")
-		if err := placementShim.SetupWithManager(ctx, mgr); err != nil {
-			setupLog.Error(err, "unable to set up placement shim")
+		placementShim = &placement.Shim{}
+		if err := placementShim.Init(ctx); err != nil {
+			setupLog.Error(err, "unable to initialize placement shim")
 			os.Exit(1)
 		}
 		metrics.Registry.MustRegister(placementShim)
 		placementShim.RegisterRoutes(mux)
 	}
 
+	// The liveness probe, REST API, and metrics endpoint bind addresses. In
+	// self-heal mode they are owned by the durable outer process (the
+	// supervisor) so they survive manager restarts, and the manager binds none
+	// of them (an empty/"0" address disables the manager-owned server). In
+	// coupled mode the manager owns them, matching the classic behavior.
+	managerProbeAddr := probeAddr
+	managerMetricsAddr := metricsServerOptions.BindAddress
+	if selfHeal {
+		managerProbeAddr = ""
+		metricsServerOptions.BindAddress = "0"
+	}
+
+	// buildAndStart builds a fresh controller-manager (cache + multicluster
+	// client + controllers) and runs it to completion. It is invoked once by the
+	// coupled path and repeatedly by the supervisor in self-heal mode. Transient
+	// errors (e.g. a lost apiserver connection) are returned rather than exiting
+	// the process, so the supervisor can back off and retry. In coupled mode it
+	// also binds the API server and health checks to the manager so a manager
+	// failure exits the process, as before.
+	buildAndStart := func(ctx context.Context) error {
+		mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
+			Scheme:                 scheme,
+			Metrics:                metricsServerOptions,
+			WebhookServer:          webhookServer,
+			HealthProbeBindAddress: managerProbeAddr,
+			// Kept for consistency with kubebuilder scaffold, but the shim should
+			// always run with leader election disabled.
+			LeaderElection: enableLeaderElection,
+		})
+		if err != nil {
+			return fmt.Errorf("unable to create manager: %w", err)
+		}
+
+		multiclusterClient, err := setupMulticlusterClient(ctx, mgr, restConfig, multiclusterMonitor)
+		if err != nil {
+			return fmt.Errorf("unable to set up multicluster client: %w", err)
+		}
+
+		if placementShim != nil {
+			if err := placementShim.SetupControllerWithManager(ctx, mgr, multiclusterClient); err != nil {
+				return fmt.Errorf("unable to set up placement shim controller: %w", err)
+			}
+		}
+
+		if metricsCertWatcher != nil {
+			if err := mgr.Add(metricsCertWatcher); err != nil {
+				return fmt.Errorf("unable to add metrics certificate watcher: %w", err)
+			}
+		}
+		if webhookCertWatcher != nil {
+			if err := mgr.Add(webhookCertWatcher); err != nil {
+				return fmt.Errorf("unable to add webhook certificate watcher: %w", err)
+			}
+		}
+
+		if !selfHeal {
+			// Coupled mode: the manager owns the health checks and the API server,
+			// so the process shares the manager's lifecycle.
+			if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+				return fmt.Errorf("unable to set up health check: %w", err)
+			}
+			if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+				return fmt.Errorf("unable to set up ready check: %w", err)
+			}
+			if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+				setupLog.Info("starting api server", "address", apiBindAddr)
+				return httpext.ListenAndServeContext(ctx, apiBindAddr, mux)
+			})); err != nil {
+				return fmt.Errorf("unable to add api server to manager: %w", err)
+			}
+		}
+
+		setupLog.Info("starting manager")
+		return mgr.Start(ctx)
+	}
+
 	// +kubebuilder:scaffold:builder
 
-	if metricsCertWatcher != nil {
-		setupLog.Info("Adding metrics certificate watcher to manager")
-		if err := mgr.Add(metricsCertWatcher); err != nil {
-			setupLog.Error(err, "unable to add metrics certificate watcher to manager")
+	if selfHeal {
+		// Self-healing mode: the REST API, liveness probe, and metrics endpoint
+		// are bound once in the outer process and survive manager restarts, while
+		// the supervisor rebuilds the manager (and its cache) with backoff on
+		// failure. The pod never crashes on apiserver/cache connectivity issues.
+		if err := supervisor.Run(ctx, supervisor.Options{
+			ProbeAddr:       probeAddr,
+			APIAddr:         apiBindAddr,
+			MetricsAddr:     managerMetricsAddr,
+			MetricsGatherer: metrics.Registry,
+			Mux:             mux,
+			ManagerUp:       managerUp,
+			BuildAndStart:   buildAndStart,
+		}); err != nil {
+			setupLog.Error(err, "supervisor exited with error")
 			os.Exit(1)
 		}
+		return
 	}
 
-	if webhookCertWatcher != nil {
-		setupLog.Info("Adding webhook certificate watcher to manager")
-		if err := mgr.Add(webhookCertWatcher); err != nil {
-			setupLog.Error(err, "unable to add webhook certificate watcher to manager")
-			os.Exit(1)
-		}
-	}
-
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
-	}
-
-	// Couple the API server to the manager lifecycle so the informer cache is
-	// available as soon as the mux starts, and graceful shutdown is handled by
-	// the manager context cancellation.
-	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		setupLog.Info("starting api server", "address", ":8080")
-		return httpext.ListenAndServeContext(ctx, ":8080", mux)
-	})); err != nil {
-		setupLog.Error(err, "unable to add api server to manager")
-		os.Exit(1)
-	}
-
-	setupLog.Info("starting manager")
-	if err := mgr.Start(ctx); err != nil {
+	// Coupled mode (--self-heal=false): a manager failure exits the process.
+	// This is the classic behavior kept for parity.
+	managerUp.Set(1)
+	if err := buildAndStart(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
 }
 
-func setupMulticlusterClient(ctx context.Context, mgr manager.Manager, restConfig *rest.Config) *multicluster.Client {
+func setupMulticlusterClient(ctx context.Context, mgr manager.Manager, restConfig *rest.Config, monitor multicluster.Monitor) (*multicluster.Client, error) {
 	homeCluster, err := cluster.New(restConfig, func(o *cluster.Options) { o.Scheme = scheme })
 	if err != nil {
-		setupLog.Error(err, "unable to create home cluster")
-		os.Exit(1)
+		return nil, fmt.Errorf("unable to create home cluster: %w", err)
 	}
 	if err := mgr.Add(homeCluster); err != nil {
-		setupLog.Error(err, "unable to add home cluster")
-		os.Exit(1)
+		return nil, fmt.Errorf("unable to add home cluster: %w", err)
 	}
 	mcl := &multicluster.Client{
 		HomeCluster:     homeCluster,
 		HomeRestConfig:  restConfig,
 		HomeScheme:      scheme,
 		ResourceRouters: multicluster.DefaultResourceRouters,
-		Monitor:         multicluster.NewMonitor("cortex_"),
+		Monitor:         monitor,
 	}
 	mclConfig := conf.GetConfigOrDie[multicluster.ClientConfig]()
 	if err := mcl.InitFromConf(ctx, mgr, mclConfig); err != nil {
-		setupLog.Error(err, "unable to initialize multicluster client")
-		os.Exit(1)
+		return nil, fmt.Errorf("unable to initialize multicluster client: %w", err)
 	}
-	return mcl
+	return mcl, nil
 }

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/cobaltcore-dev/cortex/api/v1alpha1"
 	"github.com/cobaltcore-dev/cortex/internal/shim/placement"
@@ -381,17 +382,30 @@ func main() {
 			// Drive the shim's cache-readiness flag: mark ready once this
 			// manager's cache has synced, and clear it when the cycle returns so
 			// cache-backed handlers degrade to 503 while the manager is down or
-			// restarting. Passthrough handlers ignore the flag. The goroutine uses
-			// a per-cycle context cancelled on return so WaitForCacheSync cannot
-			// block or set readiness after this manager has already exited.
+			// restarting. Passthrough handlers ignore the flag.
+			//
+			// A per-cycle context (cancelled on return) stops WaitForCacheSync from
+			// blocking across restarts. The mutex + cacheCtx.Err() re-check under
+			// the lock closes the ordering race where the sync goroutine has just
+			// observed a synced cache but the cycle is returning: cancelCacheSync
+			// runs before the defer takes the lock, so whichever critical section
+			// runs first, the goroutine only sets ready=true while the context is
+			// still live, and the deferred ready=false always wins the final state.
+			var readyMu sync.Mutex
 			cacheCtx, cancelCacheSync := context.WithCancel(ctx)
 			defer func() {
 				cancelCacheSync()
+				readyMu.Lock()
 				placementShim.SetManagerReady(false)
+				readyMu.Unlock()
 			}()
 			go func() {
 				if mgr.GetCache().WaitForCacheSync(cacheCtx) {
-					placementShim.SetManagerReady(true)
+					readyMu.Lock()
+					if cacheCtx.Err() == nil {
+						placementShim.SetManagerReady(true)
+					}
+					readyMu.Unlock()
 				}
 			}()
 		}

--- a/helm/bundles/cortex-placement-shim/templates/alerts.yaml
+++ b/helm/bundles/cortex-placement-shim/templates/alerts.yaml
@@ -34,6 +34,30 @@ spec:
           on the shim for resource provider lookups and allocation candidates
           will degrade.
 
+    # Self-healing controller-manager (decoupled from pod liveness)
+    - alert: CortexPlacementShimManagerLooping
+      expr: |
+        cortex_placement_shim_manager_up{service="cortex-placement-shim-metrics-service"} == 0
+      for: 5m
+      labels:
+        context: liveness
+        dashboard: cortex-placement-shim-status-dashboard/cortex-placement-shim-status-dashboard
+        service: cortex
+        severity: warning
+        support_group: workload-management
+        playbook: docs/support/playbook/cortex/alerts/shim-down
+      annotations:
+        summary: "Cortex Placement Shim controller-manager is not running"
+        description: >
+          The Cortex Placement Shim controller-manager has been down for at
+          least 5 minutes while the shim process itself stays up (the pod does
+          not crash by design). This means the manager cannot reach its
+          (local or remote) apiserver and is crash-looping, so the Kubernetes
+          informer cache is stale or empty. Passthrough requests to upstream
+          Placement are unaffected, but any KVM-backend behavior that reads from
+          the cache is degraded. Investigate apiserver connectivity and the shim
+          logs for the self-healing supervisor's restart errors.
+
     # Downstream HTTP errors (client -> shim)
     - alert: CortexPlacementShimDownstreamHttp400sTooHigh
       expr: rate(cortex_placement_shim_downstream_request_duration_seconds_count{service="cortex-placement-shim-metrics-service", responsecode=~"4.."}[5m]) > 0.1

--- a/helm/bundles/cortex-placement-shim/templates/alerts.yaml
+++ b/helm/bundles/cortex-placement-shim/templates/alerts.yaml
@@ -36,8 +36,14 @@ spec:
 
     # Self-healing controller-manager (decoupled from pod liveness)
     - alert: CortexPlacementShimManagerLooping
+      # Average uptime over a 15m window rather than a continuous "== 0": a
+      # crash-looping manager flaps the gauge 0->1->0 on every restart attempt,
+      # which would keep resetting a "== 0 for 5m" timer and never fire. Averaging
+      # catches both a manager that is continuously down (avg 0) and one that is
+      # only briefly healthy each cycle (avg well below 1). 0.9 = healthy less
+      # than ~90% of the window.
       expr: |
-        cortex_placement_shim_manager_up{service="cortex-placement-shim-metrics-service"} == 0
+        avg_over_time(cortex_placement_shim_manager_up{service="cortex-placement-shim-metrics-service"}[15m]) < 0.9
       for: 5m
       labels:
         context: liveness
@@ -49,14 +55,15 @@ spec:
       annotations:
         summary: "Cortex Placement Shim controller-manager is not running"
         description: >
-          The Cortex Placement Shim controller-manager has been down for at
-          least 5 minutes while the shim process itself stays up (the pod does
-          not crash by design). This means the manager cannot reach its
-          (local or remote) apiserver and is crash-looping, so the Kubernetes
-          informer cache is stale or empty. Passthrough requests to upstream
-          Placement are unaffected, but any KVM-backend behavior that reads from
-          the cache is degraded. Investigate apiserver connectivity and the shim
-          logs for the self-healing supervisor's restart errors.
+          The Cortex Placement Shim controller-manager has been up with a synced
+          cache less than 90% of the last 15 minutes while the shim process
+          itself stays up (the pod does not crash by design). This means the
+          manager cannot reach its (local or remote) apiserver and is down or
+          crash-looping, so the Kubernetes informer cache is stale or empty.
+          Passthrough requests to upstream Placement are unaffected, but any
+          KVM-backend behavior that reads from the cache is degraded.
+          Investigate apiserver connectivity and the shim logs for the
+          self-healing supervisor's restart errors.
 
     # Downstream HTTP errors (client -> shim)
     - alert: CortexPlacementShimDownstreamHttp400sTooHigh

--- a/helm/library/cortex-shim/templates/ingress.yaml
+++ b/helm/library/cortex-shim/templates/ingress.yaml
@@ -1,7 +1,7 @@
 # Copyright SAP SE
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.ingress.enabled }}
+{{- if and .Values.ingress.enabled .Values.ingress.rules }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm/library/cortex-shim/values.yaml
+++ b/helm/library/cortex-shim/values.yaml
@@ -41,12 +41,24 @@ deployment:
   terminationGracePeriodSeconds: 10
   serviceAccountName: shim
 
-# [INGRESS]: To enable an ingress resource for the placement shim set true
+# [INGRESS]: To expose the placement shim via an Ingress, set enabled true AND
+# provide ingress.rules. The Ingress is only rendered when both are set: an
+# Ingress with no rules is invalid, and local/dev setups (e.g. tilt) enable the
+# shim without any ingress rules and expect no Ingress to be created.
 ingress:
-  # Enable or disable the ingress resource for the placement shim.
+  # Enable or disable the ingress resource for the placement shim. Note this is
+  # necessary but not sufficient: ingress.rules must also be provided for the
+  # Ingress to be rendered.
   enabled: true
   # Which ingress controller to use.
   className: nginx
+  # The routing rules for the Ingress. Deployments must supply these; there is
+  # no sensible default host, so the library ships this empty and renders no
+  # Ingress until it is set. See networking.k8s.io/v1 Ingress .spec.rules.
+  rules: []
+  # Optional TLS configuration for the Ingress (networking.k8s.io/v1
+  # Ingress .spec.tls). Left empty by default.
+  tls: []
   # Override this default set of annotations if needed.
   annotations:
     # Enables https://github.com/sapcc/disco

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/cobaltcore-dev/cortex/pkg/conf"
@@ -136,10 +137,20 @@ func (c *config) validate() error {
 // watches, however, may be rebuilt underneath it by a self-healing supervisor
 // (see pkg/shim/supervisor), which calls SetupControllerWithManager again for
 // each fresh manager. The HTTP request path is pure passthrough today and does
-// not touch the cache, so it is unaffected by manager restarts.
+// not touch the cache, so it is unaffected by manager restarts. Handlers that
+// do need the cache can gate on ManagerReady, which the supervisor drives via
+// SetManagerReady (true once the cache is synced, false when the manager is
+// down or restarting).
 type Shim struct {
 	client.Client
 	config config
+	// managerReady is true while a controller-manager is running with a synced
+	// cache. It is driven by the self-healing supervisor via SetManagerReady and
+	// read on the request path via ManagerReady so cache-backed handlers can
+	// return 503 while the cache is unavailable. Passthrough handlers ignore it.
+	// It is a pointer to the atomic holder (rather than an embedded atomic value)
+	// so the Shim struct itself stays copy-safe for tests.
+	managerReady *atomic.Bool
 	// HTTP client that can talk to openstack placement, if needed, over
 	// ingress with single-sign-on.
 	httpClient *http.Client
@@ -227,6 +238,25 @@ func (s *Shim) initHTTPClient(ctx context.Context) error {
 	}
 	setupLog.Info("Successfully connected to placement API")
 	return nil
+}
+
+// SetManagerReady records whether a controller-manager with a synced cache is
+// currently running. The self-healing supervisor sets it true once the cache
+// has synced and false when the manager cycle ends (see pkg/shim/supervisor and
+// cmd/shim). It is safe to call concurrently with ManagerReady.
+func (s *Shim) SetManagerReady(ready bool) {
+	if s.managerReady == nil {
+		s.managerReady = &atomic.Bool{}
+	}
+	s.managerReady.Store(ready)
+}
+
+// ManagerReady reports whether a controller-manager with a synced cache is
+// currently running. Cache-backed handlers should gate on it and return 503
+// when it is false; passthrough handlers, which never touch the cache, ignore
+// it. It defaults to false until the supervisor brings the first manager up.
+func (s *Shim) ManagerReady() bool {
+	return s.managerReady != nil && s.managerReady.Load()
 }
 
 // Reconcile is not used by the shim, but must be implemented to satisfy the

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -243,7 +243,9 @@ func (s *Shim) initHTTPClient(ctx context.Context) error {
 // SetManagerReady records whether a controller-manager with a synced cache is
 // currently running. The self-healing supervisor sets it true once the cache
 // has synced and false when the manager cycle ends (see pkg/shim/supervisor and
-// cmd/shim). It is safe to call concurrently with ManagerReady.
+// cmd/shim). It is safe to call concurrently with ManagerReady. The holder is
+// normally allocated in Init before any HTTP handler runs; the nil guard here
+// only covers shims constructed in tests without calling Init.
 func (s *Shim) SetManagerReady(ready bool) {
 	if s.managerReady == nil {
 		s.managerReady = &atomic.Bool{}
@@ -293,6 +295,13 @@ func (s *Shim) predicateRemoteHypervisor() predicate.Predicate {
 // pkg/shim/supervisor).
 func (s *Shim) Init(ctx context.Context) (err error) {
 	setupLog.Info("Initializing placement shim")
+
+	// Allocate the readiness holder before any HTTP handler can run, so the
+	// pointer itself is never written concurrently with ManagerReady reads from
+	// the request path (the API server comes up before the first cache sync).
+	if s.managerReady == nil {
+		s.managerReady = &atomic.Bool{}
+	}
 
 	s.config, err = conf.GetConfig[config]()
 	if err != nil {

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -243,9 +243,14 @@ func (s *Shim) initHTTPClient(ctx context.Context) error {
 // SetManagerReady records whether a controller-manager with a synced cache is
 // currently running. The self-healing supervisor sets it true once the cache
 // has synced and false when the manager cycle ends (see pkg/shim/supervisor and
-// cmd/shim). It is safe to call concurrently with ManagerReady. The holder is
-// normally allocated in Init before any HTTP handler runs; the nil guard here
-// only covers shims constructed in tests without calling Init.
+// cmd/shim).
+//
+// Once Init has run, the holder is allocated and calls to SetManagerReady and
+// ManagerReady are race-free (they only load/store the atomic). The nil guard
+// below is a convenience for shims constructed in tests without Init; in that
+// case the first SetManagerReady is NOT safe to race with a concurrent
+// ManagerReady, since it may write the s.managerReady pointer itself. Production
+// code always goes through Init before serving, so this is not a concern there.
 func (s *Shim) SetManagerReady(ready bool) {
 	if s.managerReady == nil {
 		s.managerReady = &atomic.Bool{}
@@ -257,6 +262,8 @@ func (s *Shim) SetManagerReady(ready bool) {
 // currently running. Cache-backed handlers should gate on it and return 503
 // when it is false; passthrough handlers, which never touch the cache, ignore
 // it. It defaults to false until the supervisor brings the first manager up.
+// Safe to call concurrently once Init has allocated the holder (see
+// SetManagerReady).
 func (s *Shim) ManagerReady() bool {
 	return s.managerReady != nil && s.managerReady.Load()
 }

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -130,6 +130,13 @@ func (c *config) validate() error {
 // Shim is the placement API shim. It holds a controller-runtime client for
 // making Kubernetes API calls and exposes HTTP handlers that mirror the
 // OpenStack Placement API surface.
+//
+// The Shim is process-lifetime: it is built and initialized once (Init) and its
+// HTTP routes are registered once (RegisterRoutes). The controller/cache it
+// watches, however, may be rebuilt underneath it by a self-healing supervisor
+// (see pkg/shim/supervisor), which calls SetupControllerWithManager again for
+// each fresh manager. The HTTP request path is pure passthrough today and does
+// not touch the cache, so it is unaffected by manager restarts.
 type Shim struct {
 	client.Client
 	config config
@@ -222,18 +229,6 @@ func (s *Shim) initHTTPClient(ctx context.Context) error {
 	return nil
 }
 
-// Start is called after the manager has started and the cache is running.
-func (s *Shim) Start(ctx context.Context) error {
-	setupLog.Info("Starting placement shim")
-	if err := s.initHTTPClient(ctx); err != nil {
-		return err
-	}
-	if err := s.initTokenIntrospector(ctx); err != nil {
-		return err
-	}
-	return nil
-}
-
 // Reconcile is not used by the shim, but must be implemented to satisfy the
 // controller-runtime Reconciler interface.
 func (s *Shim) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -257,15 +252,17 @@ func (s *Shim) predicateRemoteHypervisor() predicate.Predicate {
 	})
 }
 
-// SetupWithManager sets up the controller with the manager.
-// It registers watches for the Hypervisor CRD across all clusters and sets up
-// the HTTP client for talking to the placement API.
-func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err error) {
-	setupLog.Info("Setting up placement shim with manager")
-
-	if err := mgr.Add(s); err != nil {
-		return err
-	}
+// Init performs the once-only, manager-independent setup of the shim: it loads
+// and validates the shim config, compiles the auth policies, allocates the
+// Prometheus metric vectors, and initializes the upstream HTTP client and
+// Keystone token introspector. It must be called exactly once per process
+// (before RegisterRoutes and before the metric collectors are registered),
+// because it allocates collectors and the HTTP request path depends on the
+// fields it sets. It is intentionally decoupled from the controller-manager
+// lifecycle so that the HTTP layer survives manager restarts (see
+// pkg/shim/supervisor).
+func (s *Shim) Init(ctx context.Context) (err error) {
+	setupLog.Info("Initializing placement shim")
 
 	s.config, err = conf.GetConfig[config]()
 	if err != nil {
@@ -303,17 +300,31 @@ func (s *Shim) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err erro
 		Buckets: prometheus.DefBuckets,
 	}, []string{"method", "pattern", "responsecode"})
 
-	// Check that the provided client is a multicluster client, since we need
-	// that to watch for hypervisors across clusters.
-	mcl, ok := s.Client.(*multicluster.Client)
-	if !ok {
-		return errors.New("provided client must be a multicluster client")
+	// Initialize the upstream HTTP client and token introspector. These are
+	// safe to set up before any manager exists and do not depend on the cache.
+	if err := s.initHTTPClient(ctx); err != nil {
+		return err
 	}
+	if err := s.initTokenIntrospector(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetupControllerWithManager wires the shim's Hypervisor watch into the given
+// manager, backed by the given multicluster client. It sets up the field
+// indexes and registers a watch across all clusters serving the Hypervisor
+// GVK. Unlike Init, this is called once per manager cycle: the self-healing
+// supervisor rebuilds the manager (and its caches) on connectivity failure and
+// calls this again for the fresh manager. It does NOT touch the HTTP layer,
+// metric collectors, or config.
+func (s *Shim) SetupControllerWithManager(ctx context.Context, mgr ctrl.Manager, mcl *multicluster.Client) error {
+	setupLog.Info("Setting up placement shim controller with manager")
 	if err := IndexFields(ctx, mcl); err != nil {
 		return fmt.Errorf("failed to set up indexes: %w", err)
 	}
 	bldr := multicluster.BuildController(mcl, mgr)
-	bldr, err = bldr.WatchesMulticluster(&hv1.Hypervisor{},
+	bldr, err := bldr.WatchesMulticluster(&hv1.Hypervisor{},
 		s.handleRemoteHypervisor(),
 		s.predicateRemoteHypervisor(),
 	)

--- a/internal/shim/placement/shim.go
+++ b/internal/shim/placement/shim.go
@@ -350,6 +350,14 @@ func (s *Shim) Init(ctx context.Context) (err error) {
 // metric collectors, or config.
 func (s *Shim) SetupControllerWithManager(ctx context.Context, mgr ctrl.Manager, mcl *multicluster.Client) error {
 	setupLog.Info("Setting up placement shim controller with manager")
+	if mcl == nil {
+		return errors.New("multicluster client must not be nil")
+	}
+	// Store the fresh multicluster client as the shim's cache-backed client so
+	// cache-read handlers have a live client for this manager cycle. It is
+	// re-assigned on every rebuild; readiness is gated separately via
+	// SetManagerReady once the cache has synced.
+	s.Client = mcl
 	if err := IndexFields(ctx, mcl); err != nil {
 		return fmt.Errorf("failed to set up indexes: %w", err)
 	}

--- a/internal/shim/placement/shim_test.go
+++ b/internal/shim/placement/shim_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -513,4 +514,29 @@ func TestWrapHandlerWithAuth(t *testing.T) {
 			t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 		}
 	})
+}
+
+// TestManagerReadyConcurrent verifies ManagerReady/SetManagerReady are safe
+// under concurrent access once the holder has been allocated (as Init does
+// before serving). Run with -race to catch pointer/value data races.
+func TestManagerReadyConcurrent(t *testing.T) {
+	s := &Shim{}
+	// Simulate Init allocating the holder before any handler runs.
+	s.SetManagerReady(false)
+	if s.ManagerReady() {
+		t.Fatal("ManagerReady should be false initially")
+	}
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(2)
+		go func() { defer wg.Done(); s.SetManagerReady(true) }()
+		go func() { defer wg.Done(); _ = s.ManagerReady() }()
+	}
+	wg.Wait()
+
+	s.SetManagerReady(true)
+	if !s.ManagerReady() {
+		t.Fatal("ManagerReady should be true after SetManagerReady(true)")
+	}
 }

--- a/pkg/shim/supervisor/supervisor.go
+++ b/pkg/shim/supervisor/supervisor.go
@@ -207,9 +207,16 @@ func Run(ctx context.Context, o Options) error {
 func runManagerCycle(ctx context.Context, o *Options, healthyResetAfter time.Duration, backoff *wait.Backoff) {
 	start := time.Now()
 	log.Info("starting manager")
-	if err := o.BuildAndStart(ctx); err != nil {
+	err := o.BuildAndStart(ctx)
+	switch {
+	case err != nil && ctx.Err() != nil:
+		// The loop is shutting down (outer context cancelled): BuildAndStart
+		// returning an error here is just the manager unwinding, not a failure to
+		// restart. Log it quietly so it does not look like a real restart error.
+		log.Info("manager exited during shutdown", "cause", err.Error())
+	case err != nil:
 		log.Error(err, "manager exited with error; will restart")
-	} else {
+	default:
 		log.Info("manager exited")
 	}
 	if time.Since(start) >= healthyResetAfter {

--- a/pkg/shim/supervisor/supervisor.go
+++ b/pkg/shim/supervisor/supervisor.go
@@ -21,9 +21,10 @@
 //     up, so pod liveness reflects the process, not the apiserver.
 //   - It runs a supervision loop that builds and starts a fresh manager (and
 //     its caches) via a caller-supplied BuildAndStart function, and restarts it
-//     with capped, jittered backoff whenever it returns. A looping manager is
-//     surfaced via the ManagerUp gauge (1 while a manager is running, 0
-//     otherwise) rather than by crashing the pod.
+//     with capped, jittered backoff whenever it returns, rather than crashing
+//     the pod. Surfacing a looping manager as a metric is left to the caller,
+//     since only it can observe when the manager's cache has actually synced
+//     (BuildAndStart running is not the same as a healthy manager).
 //
 // The package is deliberately shim-agnostic so future shims can reuse it.
 package supervisor
@@ -65,9 +66,6 @@ type Options struct {
 	// Mux serves the REST API on APIAddr. Its routes must be registered before
 	// Run is called; the supervisor never mutates it. Required.
 	Mux *http.ServeMux
-	// ManagerUp is set to 1 while a manager is running and 0 between restarts.
-	// Optional; nil disables the gauge.
-	ManagerUp prometheus.Gauge
 	// Backoff controls the wait between manager restarts. The zero value uses
 	// DefaultBackoff. The backoff is reset after a manager has stayed up longer
 	// than HealthyResetAfter, so a brief blip does not inflate the delay before
@@ -200,15 +198,13 @@ func Run(ctx context.Context, o Options) error {
 	}
 }
 
-// runManagerCycle runs a single manager lifecycle: it sets the ManagerUp gauge,
-// runs BuildAndStart to completion, and clears the gauge on return. If the
-// manager stayed up longer than healthyResetAfter, the backoff is reset so the
-// next outage starts from the initial delay.
+// runManagerCycle runs a single manager lifecycle: it runs BuildAndStart to
+// completion. If the manager stayed up longer than healthyResetAfter, the
+// backoff is reset so the next outage starts from the initial delay. The caller
+// is responsible for any "manager healthy" metric, since only it can observe
+// when the manager's cache has actually synced (a running BuildAndStart is not
+// the same as a healthy manager).
 func runManagerCycle(ctx context.Context, o *Options, healthyResetAfter time.Duration, backoff *wait.Backoff) {
-	if o.ManagerUp != nil {
-		o.ManagerUp.Set(1)
-		defer o.ManagerUp.Set(0)
-	}
 	start := time.Now()
 	log.Info("starting manager")
 	if err := o.BuildAndStart(ctx); err != nil {

--- a/pkg/shim/supervisor/supervisor.go
+++ b/pkg/shim/supervisor/supervisor.go
@@ -31,6 +31,7 @@ package supervisor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -103,6 +104,10 @@ func Run(ctx context.Context, o Options) error {
 	if o.ProbeAddr == "" || o.APIAddr == "" || o.Mux == nil || o.BuildAndStart == nil {
 		return errors.New("supervisor: ProbeAddr, APIAddr, Mux and BuildAndStart are required")
 	}
+	metricsEnabled := o.MetricsAddr != "" && o.MetricsAddr != "0"
+	if metricsEnabled && o.MetricsGatherer == nil {
+		return errors.New("supervisor: MetricsGatherer is required when MetricsAddr is set")
+	}
 	backoff := o.Backoff
 	if backoff.Duration == 0 {
 		backoff = DefaultBackoff
@@ -112,6 +117,37 @@ func Run(ctx context.Context, o Options) error {
 		healthyResetAfter = DefaultHealthyResetAfter
 	}
 
+	// serverErr carries a bind/serve failure from any outer server. A failure to
+	// open a port (e.g. address in use) is fatal — even while a manager is
+	// running healthily — rather than leaving the process "healthy" while serving
+	// nothing. A clean exit on ctx cancellation reports nil.
+	serverErr := make(chan error, 3)
+	serve := func(name, addr string, handler http.Handler) {
+		go func() {
+			log.Info("starting "+name+" server", "address", addr)
+			err := httpext.ListenAndServeContext(ctx, addr, handler)
+			if err != nil && ctx.Err() == nil {
+				log.Error(err, name+" server exited with error")
+				serverErr <- err
+				return
+			}
+			serverErr <- nil
+		}()
+	}
+
+	// loopCtx is cancelled either when the outer ctx is cancelled or when an
+	// outer server fails, so a bind/serve failure also tears down a running
+	// manager instead of waiting for it to exit on its own.
+	loopCtx, cancelLoop := context.WithCancel(ctx)
+	defer cancelLoop()
+	var fatalErr error
+	go func() {
+		if err := <-serverErr; err != nil {
+			fatalErr = err
+			cancelLoop()
+		}
+	}()
+
 	// Bind the liveness/readiness probe once. It always reports healthy so pod
 	// liveness reflects the process being up, not apiserver reachability.
 	probeMux := http.NewServeMux()
@@ -120,53 +156,45 @@ func Run(ctx context.Context, o Options) error {
 	}
 	probeMux.HandleFunc("/healthz", alwaysOK)
 	probeMux.HandleFunc("/readyz", alwaysOK)
-	go func() {
-		log.Info("starting liveness probe server", "address", o.ProbeAddr)
-		if err := httpext.ListenAndServeContext(ctx, o.ProbeAddr, probeMux); err != nil {
-			log.Error(err, "probe server exited with error")
-		}
-	}()
+	serve("liveness probe", o.ProbeAddr, probeMux)
 
 	// Bind the REST API once so it survives manager restarts.
-	go func() {
-		log.Info("starting api server", "address", o.APIAddr)
-		if err := httpext.ListenAndServeContext(ctx, o.APIAddr, o.Mux); err != nil {
-			log.Error(err, "api server exited with error")
-		}
-	}()
+	serve("api", o.APIAddr, o.Mux)
 
 	// Bind the metrics server once (if configured) so metrics — including
 	// ManagerUp — stay scrapable during a manager restart.
-	if o.MetricsAddr != "" && o.MetricsAddr != "0" && o.MetricsGatherer != nil {
+	if metricsEnabled {
 		metricsMux := http.NewServeMux()
 		metricsMux.Handle("/metrics", promhttp.HandlerFor(
 			o.MetricsGatherer, promhttp.HandlerOpts{},
 		))
-		go func() {
-			log.Info("starting metrics server", "address", o.MetricsAddr)
-			if err := httpext.ListenAndServeContext(ctx, o.MetricsAddr, metricsMux); err != nil {
-				log.Error(err, "metrics server exited with error")
-			}
-		}()
+		serve("metrics", o.MetricsAddr, metricsMux)
 	}
 
 	// Supervision loop: (re)build and start the manager, backing off on each
-	// return, until the outer context is cancelled.
+	// return, until the outer context is cancelled or an outer server fails to
+	// bind/serve.
 	for {
-		// Observe cancellation before doing any work so we never rebuild a
-		// manager during shutdown.
+		// Observe cancellation before doing any work so we never rebuild a manager
+		// during shutdown or after a fatal outer-server failure.
 		select {
-		case <-ctx.Done():
+		case <-loopCtx.Done():
+			if fatalErr != nil {
+				return fmt.Errorf("supervisor: outer server failed: %w", fatalErr)
+			}
 			return nil
 		default:
 		}
 
-		runManagerCycle(ctx, &o, healthyResetAfter, &backoff)
+		runManagerCycle(loopCtx, &o, healthyResetAfter, &backoff)
 
 		delay := backoff.Step()
 		log.Info("manager stopped, backing off before restart", "delay", delay.String())
 		select {
-		case <-ctx.Done():
+		case <-loopCtx.Done():
+			if fatalErr != nil {
+				return fmt.Errorf("supervisor: outer server failed: %w", fatalErr)
+			}
 			return nil
 		case <-time.After(delay):
 		}

--- a/pkg/shim/supervisor/supervisor.go
+++ b/pkg/shim/supervisor/supervisor.go
@@ -117,36 +117,27 @@ func Run(ctx context.Context, o Options) error {
 		healthyResetAfter = DefaultHealthyResetAfter
 	}
 
-	// serverErr carries a bind/serve failure from any outer server. A failure to
-	// open a port (e.g. address in use) is fatal — even while a manager is
-	// running healthily — rather than leaving the process "healthy" while serving
-	// nothing. A clean exit on ctx cancellation reports nil.
-	serverErr := make(chan error, 3)
+	// loopCtx is cancelled when the outer ctx is cancelled, when Run returns, or
+	// when an outer server fails — so a bind/serve failure tears down every outer
+	// server and any running manager instead of leaving some alive. The cancel
+	// cause carries the first fatal server error (if any) back to the loop without
+	// sharing mutable state between goroutines. All outer servers are bound to
+	// loopCtx (not ctx) so they reliably shut down whenever Run exits.
+	loopCtx, cancelLoop := context.WithCancelCause(ctx)
+	defer cancelLoop(nil)
 	serve := func(name, addr string, handler http.Handler) {
 		go func() {
 			log.Info("starting "+name+" server", "address", addr)
-			err := httpext.ListenAndServeContext(ctx, addr, handler)
-			if err != nil && ctx.Err() == nil {
+			err := httpext.ListenAndServeContext(loopCtx, addr, handler)
+			if err != nil && loopCtx.Err() == nil {
+				// A genuine bind/serve failure (not a shutdown triggered by
+				// loopCtx). Make it fatal by cancelling the loop with the error as
+				// the cause.
 				log.Error(err, name+" server exited with error")
-				serverErr <- err
-				return
+				cancelLoop(fmt.Errorf("supervisor: %s server failed: %w", name, err))
 			}
-			serverErr <- nil
 		}()
 	}
-
-	// loopCtx is cancelled either when the outer ctx is cancelled or when an
-	// outer server fails, so a bind/serve failure also tears down a running
-	// manager instead of waiting for it to exit on its own.
-	loopCtx, cancelLoop := context.WithCancel(ctx)
-	defer cancelLoop()
-	var fatalErr error
-	go func() {
-		if err := <-serverErr; err != nil {
-			fatalErr = err
-			cancelLoop()
-		}
-	}()
 
 	// Bind the liveness/readiness probe once. It always reports healthy so pod
 	// liveness reflects the process being up, not apiserver reachability.
@@ -171,6 +162,20 @@ func Run(ctx context.Context, o Options) error {
 		serve("metrics", o.MetricsAddr, metricsMux)
 	}
 
+	// exitErr returns the fatal outer-server error when the loop is ending because
+	// a server failed, and nil for a graceful shutdown (outer ctx cancelled). A
+	// failing server cancels loopCtx with an explicit error cause; a graceful
+	// shutdown cancels the parent ctx, so loopCtx's cause equals the parent's
+	// cause. Comparing the two distinguishes the two cases without treating parent
+	// cancellation as an error.
+	exitErr := func() error {
+		cause := context.Cause(loopCtx)
+		if cause == nil || errors.Is(cause, context.Cause(ctx)) {
+			return nil
+		}
+		return cause
+	}
+
 	// Supervision loop: (re)build and start the manager, backing off on each
 	// return, until the outer context is cancelled or an outer server fails to
 	// bind/serve.
@@ -179,10 +184,7 @@ func Run(ctx context.Context, o Options) error {
 		// during shutdown or after a fatal outer-server failure.
 		select {
 		case <-loopCtx.Done():
-			if fatalErr != nil {
-				return fmt.Errorf("supervisor: outer server failed: %w", fatalErr)
-			}
-			return nil
+			return exitErr()
 		default:
 		}
 
@@ -192,10 +194,7 @@ func Run(ctx context.Context, o Options) error {
 		log.Info("manager stopped, backing off before restart", "delay", delay.String())
 		select {
 		case <-loopCtx.Done():
-			if fatalErr != nil {
-				return fmt.Errorf("supervisor: outer server failed: %w", fatalErr)
-			}
-			return nil
+			return exitErr()
 		case <-time.After(delay):
 		}
 	}

--- a/pkg/shim/supervisor/supervisor.go
+++ b/pkg/shim/supervisor/supervisor.go
@@ -161,17 +161,20 @@ func Run(ctx context.Context, o Options) error {
 	}
 
 	// exitErr returns the fatal outer-server error when the loop is ending because
-	// a server failed, and nil for a graceful shutdown (outer ctx cancelled). A
-	// failing server cancels loopCtx with an explicit error cause; a graceful
-	// shutdown cancels the parent ctx, so loopCtx's cause equals the parent's
-	// cause. Comparing the two distinguishes the two cases without treating parent
-	// cancellation as an error.
+	// a server failed, and nil for a graceful shutdown. The only two ways the loop
+	// ends are: the parent ctx is cancelled (graceful — a rollout/scale-down), or
+	// a server calls cancelLoop with an explicit error cause while the parent is
+	// still live. So the parent's own cancellation is the unambiguous signal for
+	// "graceful": if it is cancelled, return nil; otherwise the loop is ending
+	// because a server failed, so surface that cause.
 	exitErr := func() error {
-		cause := context.Cause(loopCtx)
-		if cause == nil || errors.Is(cause, context.Cause(ctx)) {
-			return nil
+		// A cancelled parent is a graceful shutdown (rollout/scale-down): report
+		// no error. Otherwise the loop is only ending because a server failed and
+		// cancelled loopCtx with an explicit cause, so surface that cause.
+		if ctx.Err() == nil {
+			return context.Cause(loopCtx)
 		}
-		return cause
+		return nil
 	}
 
 	// Supervision loop: (re)build and start the manager, backing off on each

--- a/pkg/shim/supervisor/supervisor.go
+++ b/pkg/shim/supervisor/supervisor.go
@@ -1,0 +1,199 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+// Package supervisor runs a self-healing controller-manager for a shim while
+// keeping the shim's HTTP surface (REST API, liveness probe, metrics) alive and
+// decoupled from the manager's lifecycle.
+//
+// A shim such as the placement shim must keep serving even when its
+// controller-runtime manager loses connectivity to a (local or remote)
+// apiserver. In controller-runtime, the manager owns the informer cache and,
+// crucially, every long-lived HTTP server it hosts (healthz, metrics, webhook)
+// as Runnables — when the manager stops, those servers stop too, and
+// mgr.Start returns an error. Coupling the process to that means a connectivity
+// blip crashes the pod.
+//
+// The supervisor breaks that coupling:
+//
+//   - It binds the liveness/readiness probe, the REST API mux, and (optionally)
+//     the metrics endpoint ONCE, in the outer process, so they survive across
+//     manager restarts. The probe always reports healthy once the process is
+//     up, so pod liveness reflects the process, not the apiserver.
+//   - It runs a supervision loop that builds and starts a fresh manager (and
+//     its caches) via a caller-supplied BuildAndStart function, and restarts it
+//     with capped, jittered backoff whenever it returns. A looping manager is
+//     surfaced via the ManagerUp gauge (1 while a manager is running, 0
+//     otherwise) rather than by crashing the pod.
+//
+// The package is deliberately shim-agnostic so future shims can reuse it.
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sapcc/go-bits/httpext"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var log = ctrl.Log.WithName("shim-supervisor")
+
+// Options configures a supervisor run. The three HTTP servers are bound once
+// for the whole process lifetime; only BuildAndStart is invoked repeatedly.
+type Options struct {
+	// ProbeAddr is the address the liveness/readiness probe binds to (e.g.
+	// ":8081"). It always reports healthy (200) once the process is up,
+	// decoupling pod liveness from apiserver/cache state. Required.
+	ProbeAddr string
+	// APIAddr is the address the REST API binds to (e.g. ":8080"). Required.
+	APIAddr string
+	// MetricsAddr is the address the metrics endpoint binds to (e.g. ":2112").
+	// If empty or "0", no outer metrics server is started (the caller may leave
+	// metrics to the manager, or disable them). Served from MetricsGatherer so
+	// metrics stay scrapable across manager restarts.
+	MetricsAddr string
+	// MetricsGatherer is scraped by the outer metrics server. Typically the
+	// global controller-runtime metrics registry. Required when MetricsAddr is
+	// set to a real address; ignored otherwise.
+	MetricsGatherer prometheus.Gatherer
+	// Mux serves the REST API on APIAddr. Its routes must be registered before
+	// Run is called; the supervisor never mutates it. Required.
+	Mux *http.ServeMux
+	// ManagerUp is set to 1 while a manager is running and 0 between restarts.
+	// Optional; nil disables the gauge.
+	ManagerUp prometheus.Gauge
+	// Backoff controls the wait between manager restarts. The zero value uses
+	// DefaultBackoff. The backoff is reset after a manager has stayed up longer
+	// than HealthyResetAfter, so a brief blip does not inflate the delay before
+	// the next real outage.
+	Backoff wait.Backoff
+	// HealthyResetAfter is how long a manager must stay up before its backoff is
+	// reset. The zero value uses DefaultHealthyResetAfter.
+	HealthyResetAfter time.Duration
+	// BuildAndStart builds a fresh manager (and its caches/controllers) and runs
+	// it, blocking until it stops. It receives a child context that is cancelled
+	// when the outer context is cancelled. It should return the error from
+	// mgr.Start (or a build error) so the supervisor can back off and retry.
+	// Required.
+	BuildAndStart func(ctx context.Context) error
+}
+
+// DefaultBackoff is a capped exponential backoff with jitter used when
+// Options.Backoff is the zero value.
+var DefaultBackoff = wait.Backoff{
+	Duration: 1 * time.Second,
+	Factor:   2.0,
+	Jitter:   0.2,
+	Cap:      30 * time.Second,
+	Steps:    100,
+}
+
+// DefaultHealthyResetAfter is the default for Options.HealthyResetAfter.
+const DefaultHealthyResetAfter = 60 * time.Second
+
+// Run binds the outer HTTP servers once and then supervises the manager until
+// ctx is cancelled. It returns nil on graceful shutdown (ctx cancelled) and an
+// error only if the required options are missing.
+func Run(ctx context.Context, o Options) error {
+	if o.ProbeAddr == "" || o.APIAddr == "" || o.Mux == nil || o.BuildAndStart == nil {
+		return errors.New("supervisor: ProbeAddr, APIAddr, Mux and BuildAndStart are required")
+	}
+	backoff := o.Backoff
+	if backoff.Duration == 0 {
+		backoff = DefaultBackoff
+	}
+	healthyResetAfter := o.HealthyResetAfter
+	if healthyResetAfter == 0 {
+		healthyResetAfter = DefaultHealthyResetAfter
+	}
+
+	// Bind the liveness/readiness probe once. It always reports healthy so pod
+	// liveness reflects the process being up, not apiserver reachability.
+	probeMux := http.NewServeMux()
+	alwaysOK := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+	probeMux.HandleFunc("/healthz", alwaysOK)
+	probeMux.HandleFunc("/readyz", alwaysOK)
+	go func() {
+		log.Info("starting liveness probe server", "address", o.ProbeAddr)
+		if err := httpext.ListenAndServeContext(ctx, o.ProbeAddr, probeMux); err != nil {
+			log.Error(err, "probe server exited with error")
+		}
+	}()
+
+	// Bind the REST API once so it survives manager restarts.
+	go func() {
+		log.Info("starting api server", "address", o.APIAddr)
+		if err := httpext.ListenAndServeContext(ctx, o.APIAddr, o.Mux); err != nil {
+			log.Error(err, "api server exited with error")
+		}
+	}()
+
+	// Bind the metrics server once (if configured) so metrics — including
+	// ManagerUp — stay scrapable during a manager restart.
+	if o.MetricsAddr != "" && o.MetricsAddr != "0" && o.MetricsGatherer != nil {
+		metricsMux := http.NewServeMux()
+		metricsMux.Handle("/metrics", promhttp.HandlerFor(
+			o.MetricsGatherer, promhttp.HandlerOpts{},
+		))
+		go func() {
+			log.Info("starting metrics server", "address", o.MetricsAddr)
+			if err := httpext.ListenAndServeContext(ctx, o.MetricsAddr, metricsMux); err != nil {
+				log.Error(err, "metrics server exited with error")
+			}
+		}()
+	}
+
+	// Supervision loop: (re)build and start the manager, backing off on each
+	// return, until the outer context is cancelled.
+	for {
+		// Observe cancellation before doing any work so we never rebuild a
+		// manager during shutdown.
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		runManagerCycle(ctx, &o, healthyResetAfter, &backoff)
+
+		delay := backoff.Step()
+		log.Info("manager stopped, backing off before restart", "delay", delay.String())
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(delay):
+		}
+	}
+}
+
+// runManagerCycle runs a single manager lifecycle: it sets the ManagerUp gauge,
+// runs BuildAndStart to completion, and clears the gauge on return. If the
+// manager stayed up longer than healthyResetAfter, the backoff is reset so the
+// next outage starts from the initial delay.
+func runManagerCycle(ctx context.Context, o *Options, healthyResetAfter time.Duration, backoff *wait.Backoff) {
+	if o.ManagerUp != nil {
+		o.ManagerUp.Set(1)
+		defer o.ManagerUp.Set(0)
+	}
+	start := time.Now()
+	log.Info("starting manager")
+	if err := o.BuildAndStart(ctx); err != nil {
+		log.Error(err, "manager exited with error; will restart")
+	} else {
+		log.Info("manager exited")
+	}
+	if time.Since(start) >= healthyResetAfter {
+		reset := o.Backoff
+		if reset.Duration == 0 {
+			reset = DefaultBackoff
+		}
+		*backoff = reset
+	}
+}

--- a/pkg/shim/supervisor/supervisor_test.go
+++ b/pkg/shim/supervisor/supervisor_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -43,16 +41,6 @@ func runAsync(t *testing.T, ctx context.Context, o Options) {
 			t.Errorf("Run returned error: %v", err)
 		}
 	}()
-}
-
-// gaugeValue reads the current value of a gauge.
-func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
-	t.Helper()
-	m := &dto.Metric{}
-	if err := g.Write(m); err != nil {
-		t.Fatalf("failed to write gauge: %v", err)
-	}
-	return m.GetGauge().GetValue()
 }
 
 // getStatus issues a GET against the given address+path and returns the status
@@ -145,42 +133,27 @@ func TestAPIServedFromMux(t *testing.T) {
 	}
 }
 
-// TestManagerUpGaugeTransitions verifies the gauge is 1 while a manager runs
-// and 0 after it returns.
-func TestManagerUpGaugeTransitions(t *testing.T) {
+// TestManagerRestartsOnFailure verifies a failing BuildAndStart is retried
+// (the supervisor keeps the process alive and rebuilds the manager) rather than
+// returning. The manager_up metric is owned by the caller (it needs to observe
+// cache sync), so the supervisor is only responsible for the restart behavior.
+func TestManagerRestartsOnFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	gauge := prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_manager_up"})
-	running := make(chan struct{})
-	release := make(chan struct{})
 	var cycles atomic.Int32
 
 	o := baseOptions(t)
-	o.ManagerUp = gauge
 	// Fast backoff so we do not slow the test down.
 	o.Backoff = wait.Backoff{Duration: time.Millisecond, Factor: 1.0, Steps: 100}
 	o.BuildAndStart = func(context.Context) error {
-		if cycles.Add(1) == 1 {
-			close(running)
-			<-release // hold the first manager "up" until the test releases it
-		}
+		cycles.Add(1)
 		return errors.New("boom")
 	}
 	runAsync(t, ctx, o)
 
-	<-running
-	// Give the deferred Set(1) a moment (it runs before BuildAndStart is called).
-	waitFor(t, func() bool { return gaugeValue(t, gauge) == 1 }, "gauge to reach 1 while manager up")
-
-	close(release)
-	// After the manager returns the gauge should drop to 0 at least momentarily;
-	// since it restarts quickly it may flip back to 1, so just assert we saw a
-	// restart happen (cycles advanced) and the gauge is a valid 0/1 value.
-	waitFor(t, func() bool { return cycles.Load() >= 2 }, "manager to restart after failure")
-	if v := gaugeValue(t, gauge); v != 0 && v != 1 {
-		t.Errorf("gauge value = %v, want 0 or 1", v)
-	}
+	// A failing manager must be rebuilt repeatedly, not cause Run to return.
+	waitFor(t, func() bool { return cycles.Load() >= 3 }, "manager to be rebuilt after repeated failures")
 }
 
 // TestContextCancelStopsLoop verifies cancelling the context stops the loop and

--- a/pkg/shim/supervisor/supervisor_test.go
+++ b/pkg/shim/supervisor/supervisor_test.go
@@ -220,14 +220,95 @@ func TestContextCancelStopsLoop(t *testing.T) {
 	}
 }
 
+// TestRunRequiresMetricsGathererWhenMetricsAddrSet verifies Run fails fast when
+// a metrics bind address is configured without a gatherer, rather than silently
+// serving no metrics.
+func TestRunRequiresMetricsGathererWhenMetricsAddrSet(t *testing.T) {
+	o := baseOptions(t)
+	o.MetricsAddr = freeAddr(t)
+	o.BuildAndStart = func(context.Context) error { return nil }
+	if err := Run(context.Background(), o); err == nil {
+		t.Fatal("expected error when MetricsAddr is set without MetricsGatherer, got nil")
+	}
+}
+
+// TestOuterServerBindFailureIsFatal verifies that if an outer server cannot bind
+// its port, Run returns an error instead of leaving the process "healthy" while
+// serving nothing.
+func TestOuterServerBindFailureIsFatal(t *testing.T) {
+	// Occupy a port so the API server cannot bind to it.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve port: %v", err)
+	}
+	defer func() {
+		if err := l.Close(); err != nil {
+			t.Errorf("failed to close listener: %v", err)
+		}
+	}()
+	occupied := l.Addr().String()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	o := baseOptions(t)
+	o.APIAddr = occupied
+	o.BuildAndStart = func(ctx context.Context) error { <-ctx.Done(); return nil }
+
+	done := make(chan error, 1)
+	go func() { done <- Run(ctx, o) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected Run to return an error on bind failure, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after outer server bind failure")
+	}
+}
+
 // TestBackoffProgressionAndReset verifies the delay grows across failures and
-// resets after the manager stays up past the healthy threshold.
+// that runManagerCycle resets the backoff after the manager stays up past the
+// healthy threshold.
 func TestBackoffProgressionAndReset(t *testing.T) {
+	// Progression: successive Step() calls grow.
 	b := wait.Backoff{Duration: 10 * time.Millisecond, Factor: 2.0, Steps: 100}
 	first := b.Step()
 	second := b.Step()
 	if second <= first {
 		t.Errorf("expected backoff to grow: first=%v second=%v", first, second)
+	}
+
+	// Reset: after a manager stays up longer than healthyResetAfter,
+	// runManagerCycle resets the working backoff to the configured Options.Backoff
+	// so a later outage starts from the initial delay again.
+	initial := wait.Backoff{Duration: 10 * time.Millisecond, Factor: 2.0, Steps: 100}
+	o := &Options{Backoff: initial}
+	working := initial
+	working.Step() // advance it so a no-op reset would be observable
+	working.Step()
+	const healthyResetAfter = 20 * time.Millisecond
+	o.BuildAndStart = func(context.Context) error {
+		time.Sleep(2 * healthyResetAfter) // stay "up" past the threshold
+		return nil
+	}
+	runManagerCycle(context.Background(), o, healthyResetAfter, &working)
+	// After a healthy cycle, the working backoff should equal a fresh initial
+	// backoff: its first Step() must match the first Step() of the initial.
+	wantFirst := initial
+	if got, want := working.Step(), wantFirst.Step(); got != want {
+		t.Errorf("backoff not reset after healthy cycle: first step=%v, want %v", got, want)
+	}
+
+	// And a cycle that returns quickly (before the threshold) must NOT reset.
+	working2 := initial
+	working2.Step()
+	advanced := working2 // snapshot of the advanced state
+	o.BuildAndStart = func(context.Context) error { return errors.New("boom") }
+	runManagerCycle(context.Background(), o, time.Hour, &working2)
+	if got, want := working2.Step(), advanced.Step(); got != want {
+		t.Errorf("backoff reset after a short cycle: first step=%v, want %v", got, want)
 	}
 }
 

--- a/pkg/shim/supervisor/supervisor_test.go
+++ b/pkg/shim/supervisor/supervisor_test.go
@@ -1,0 +1,244 @@
+// Copyright SAP SE
+// SPDX-License-Identifier: Apache-2.0
+
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// freeAddr returns a loopback address with a currently-free port. There is an
+// inherent (small) race between closing the listener and the supervisor
+// re-binding, but it is good enough for tests and avoids hardcoding ports.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve a free port: %v", err)
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatalf("failed to close reservation listener: %v", err)
+	}
+	return addr
+}
+
+// runAsync runs the supervisor in a goroutine, failing the test if it returns
+// an unexpected error.
+func runAsync(t *testing.T, ctx context.Context, o Options) {
+	t.Helper()
+	go func() {
+		if err := Run(ctx, o); err != nil {
+			t.Errorf("Run returned error: %v", err)
+		}
+	}()
+}
+
+// gaugeValue reads the current value of a gauge.
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	m := &dto.Metric{}
+	if err := g.Write(m); err != nil {
+		t.Fatalf("failed to write gauge: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}
+
+// getStatus issues a GET against the given address+path and returns the status
+// code, retrying briefly to absorb the goroutine startup delay.
+func getStatus(t *testing.T, addr, path string) int {
+	t.Helper()
+	var lastErr error
+	for range 50 {
+		resp, err := http.Get("http://" + addr + path) //nolint:noctx // test helper
+		if err != nil {
+			lastErr = err
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			t.Fatalf("failed to drain response body: %v", err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("failed to close response body: %v", err)
+		}
+		return resp.StatusCode
+	}
+	t.Fatalf("failed to reach %s%s: %v", addr, path, lastErr)
+	return 0
+}
+
+func baseOptions(t *testing.T) Options {
+	return Options{
+		ProbeAddr: freeAddr(t),
+		APIAddr:   freeAddr(t),
+		Mux:       http.NewServeMux(),
+	}
+}
+
+// TestRunRequiredOptions verifies Run rejects incomplete options without
+// starting anything.
+func TestRunRequiredOptions(t *testing.T) {
+	cases := map[string]Options{
+		"missing probe": {APIAddr: ":1", Mux: http.NewServeMux(), BuildAndStart: func(context.Context) error { return nil }},
+		"missing api":   {ProbeAddr: ":1", Mux: http.NewServeMux(), BuildAndStart: func(context.Context) error { return nil }},
+		"missing mux":   {ProbeAddr: ":1", APIAddr: ":2", BuildAndStart: func(context.Context) error { return nil }},
+		"missing build": {ProbeAddr: ":1", APIAddr: ":2", Mux: http.NewServeMux()},
+	}
+	for name, o := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := Run(context.Background(), o); err == nil {
+				t.Fatal("expected error for incomplete options, got nil")
+			}
+		})
+	}
+}
+
+// TestProbeAlwaysOK verifies the liveness/readiness probe reports healthy even
+// when the manager never starts successfully (BuildAndStart always errors).
+func TestProbeAlwaysOK(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	o := baseOptions(t)
+	o.BuildAndStart = func(ctx context.Context) error {
+		// Never come up; block until cancelled so the loop keeps "failing".
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	runAsync(t, ctx, o)
+
+	if code := getStatus(t, o.ProbeAddr, "/healthz"); code != http.StatusOK {
+		t.Errorf("/healthz = %d, want 200", code)
+	}
+	if code := getStatus(t, o.ProbeAddr, "/readyz"); code != http.StatusOK {
+		t.Errorf("/readyz = %d, want 200", code)
+	}
+}
+
+// TestAPIServedFromMux verifies routes registered on the mux are served by the
+// outer API server, independent of the manager.
+func TestAPIServedFromMux(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	o := baseOptions(t)
+	o.Mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	o.BuildAndStart = func(ctx context.Context) error { <-ctx.Done(); return nil }
+	runAsync(t, ctx, o)
+
+	if code := getStatus(t, o.APIAddr, "/ping"); code != http.StatusTeapot {
+		t.Errorf("/ping = %d, want 418", code)
+	}
+}
+
+// TestManagerUpGaugeTransitions verifies the gauge is 1 while a manager runs
+// and 0 after it returns.
+func TestManagerUpGaugeTransitions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	gauge := prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_manager_up"})
+	running := make(chan struct{})
+	release := make(chan struct{})
+	var cycles atomic.Int32
+
+	o := baseOptions(t)
+	o.ManagerUp = gauge
+	// Fast backoff so we do not slow the test down.
+	o.Backoff = wait.Backoff{Duration: time.Millisecond, Factor: 1.0, Steps: 100}
+	o.BuildAndStart = func(context.Context) error {
+		if cycles.Add(1) == 1 {
+			close(running)
+			<-release // hold the first manager "up" until the test releases it
+		}
+		return errors.New("boom")
+	}
+	runAsync(t, ctx, o)
+
+	<-running
+	// Give the deferred Set(1) a moment (it runs before BuildAndStart is called).
+	waitFor(t, func() bool { return gaugeValue(t, gauge) == 1 }, "gauge to reach 1 while manager up")
+
+	close(release)
+	// After the manager returns the gauge should drop to 0 at least momentarily;
+	// since it restarts quickly it may flip back to 1, so just assert we saw a
+	// restart happen (cycles advanced) and the gauge is a valid 0/1 value.
+	waitFor(t, func() bool { return cycles.Load() >= 2 }, "manager to restart after failure")
+	if v := gaugeValue(t, gauge); v != 0 && v != 1 {
+		t.Errorf("gauge value = %v, want 0 or 1", v)
+	}
+}
+
+// TestContextCancelStopsLoop verifies cancelling the context stops the loop and
+// prevents any further manager rebuild.
+func TestContextCancelStopsLoop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var cycles atomic.Int32
+	done := make(chan error, 1)
+
+	o := baseOptions(t)
+	o.Backoff = wait.Backoff{Duration: 10 * time.Millisecond, Factor: 1.0, Steps: 100}
+	o.BuildAndStart = func(context.Context) error {
+		cycles.Add(1)
+		return nil // return immediately so the loop spins on backoff
+	}
+	go func() { done <- Run(ctx, o) }()
+
+	// Let a couple of cycles happen, then cancel.
+	waitFor(t, func() bool { return cycles.Load() >= 1 }, "at least one manager cycle")
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error on cancel: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+
+	// No further rebuilds after Run returned.
+	before := cycles.Load()
+	time.Sleep(50 * time.Millisecond)
+	if after := cycles.Load(); after != before {
+		t.Errorf("manager rebuilt after loop exit: before=%d after=%d", before, after)
+	}
+}
+
+// TestBackoffProgressionAndReset verifies the delay grows across failures and
+// resets after the manager stays up past the healthy threshold.
+func TestBackoffProgressionAndReset(t *testing.T) {
+	b := wait.Backoff{Duration: 10 * time.Millisecond, Factor: 2.0, Steps: 100}
+	first := b.Step()
+	second := b.Step()
+	if second <= first {
+		t.Errorf("expected backoff to grow: first=%v second=%v", first, second)
+	}
+}
+
+// waitFor polls cond up to ~2s, failing the test if it never becomes true.
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	for range 200 {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}


### PR DESCRIPTION
The placement shim was a standard controller-manager where the manager owned the informer cache and every long-lived HTTP server (healthz, REST API, metrics) as Runnables. A lost connection to a local or remote apiserver made mgr.Start return an error and crashed the pod, even though passthrough mode forwards to upstream Placement over its own http.Client and never touches the cache. The commit decouples the manager from pod liveness.

It adds pkg/shim/supervisor: a reusable Run(ctx, Options) helper that binds the liveness probe (always 200), REST API, and metrics endpoint once in the durable outer process, then supervises the manager, rebuilding it (cache + controllers) with capped jittered backoff on failure. A looping manager is surfaced via a `cortex_placement_shim_manager_up` gauge, never by crashing the pod.

We also split the placement shim's setup into Init (once-only: config, auth, metrics, HTTP client) and SetupControllerWithManager (per-cycle: indexes + watch), removing the dead coupled-mode Start/SetupWithManager, and providing the option for the supervisor to restart and re-setup the shim.

Since not all shims may need this, we make it optional inside the cmd/shim/main.go: add a --self-heal flag (default true); --self-heal=false keeps the classic coupled behavior where a manager failure exits the process. Reject --metrics-secure with --self-heal since the outer metrics server cannot apply the authn/authz filter.

Finally, to surface a looping manager, we add a warning-level CortexPlacementShimManagerLooping alert.